### PR TITLE
add method to remove .s from nodeName

### DIFF
--- a/internal/controller/nodeset/nodeset_update.go
+++ b/internal/controller/nodeset/nodeset_update.go
@@ -368,7 +368,7 @@ func (nsc *defaultNodeSetControl) syncSlurm(
 		_ = slurmtypes.NodeInfoParse(node.Comment, &nodeInfo)
 		noPodInfo := nodeInfo.Equal(slurmtypes.NodeInfo{})
 		if kubeNodes.Has(node.Name) || !hasCommunicationFailure || noPodInfo {
-			slurmNodes.Insert(node.Name)
+			slurmNodes.Insert(getSafeNodeName(node.Name))
 			continue
 		}
 		logger.Info("Deleting Slurm Node without a corresponding Pod", "Node", node.Name, "Pod", node.Comment)

--- a/internal/controller/nodeset/nodeset_utils.go
+++ b/internal/controller/nodeset/nodeset_utils.go
@@ -639,7 +639,7 @@ func findUpdatedPodsOnNode(
 	return newPod, oldPod, true
 }
 
-// Ensure we don't use FQDN for nodeName as setting it as the hostName is not supported yet
+// Ensure we don't use FQDN for nodeName as setting it as the hostName is not supported yet.
 func getSafeNodeName(nodeName string) string {
-	return strings.Split(nodeName, ".")[0]
+	return strings.ReplaceAll(nodeName, ".", "-")
 }

--- a/internal/controller/nodeset/nodeset_utils.go
+++ b/internal/controller/nodeset/nodeset_utils.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"regexp"
 	"sort"
+	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -373,7 +374,7 @@ func newNodeSetPod(set *slinkyv1alpha1.NodeSet, nodeName, hash string) *corev1.P
 
 	// Set pod hostname to match the targeted node name to let user
 	// better correlate the Slurm node with the Kubernetes node.
-	pod.Spec.Hostname = nodeName
+	pod.Spec.Hostname = getSafeNodeName(nodeName)
 
 	setPodRevision(pod, hash)
 	updateIdentity(set, pod)
@@ -636,4 +637,9 @@ func findUpdatedPodsOnNode(
 		}
 	}
 	return newPod, oldPod, true
+}
+
+// Ensure we don't use FQDN for nodeName as setting it as the hostName is not supported yet
+func getSafeNodeName(nodeName string) string {
+	return strings.Split(nodeName, ".")[0]
 }

--- a/internal/controller/nodeset/nodeset_utils_test.go
+++ b/internal/controller/nodeset/nodeset_utils_test.go
@@ -1506,29 +1506,26 @@ func Test_getSafeNodeName(t *testing.T) {
 	tests := []struct {
 		name string
 		args args
-		want bool
 	}{
 		{
-			name: "Non-FQDN Node Name",
+			name: "Non-FQDN nodeName",
 			args: args{
 				nodeName:          "node1",
 				correctedNodeName: "node1",
 			},
-			want: true,
 		},
 		{
-			name: "FQDN NodeName",
+			name: "FQDN nodeName escaped",
 			args: args{
 				nodeName:          "node1.us-west-2.compute.internal",
-				correctedNodeName: "node1",
+				correctedNodeName: "node1-us-west-2-compute-internal",
 			},
-			want: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := getSafeNodeName(tt.args.nodeName); got != tt.args.correctedNodeName {
-				t.Errorf("safeNodeName() = %v, want %v", got, tt.want)
+				t.Errorf("safeNodeName() = %v, wanted %v", got, tt.args.correctedNodeName)
 			}
 		})
 	}

--- a/internal/controller/nodeset/nodeset_utils_test.go
+++ b/internal/controller/nodeset/nodeset_utils_test.go
@@ -1497,3 +1497,39 @@ func Test_findUpdatedPodsOnNode(t *testing.T) {
 		})
 	}
 }
+
+func Test_getSafeNodeName(t *testing.T) {
+	type args struct {
+		nodeName          string
+		correctedNodeName string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "Non-FQDN Node Name",
+			args: args{
+				nodeName:          "node1",
+				correctedNodeName: "node1",
+			},
+			want: true,
+		},
+		{
+			name: "FQDN NodeName",
+			args: args{
+				nodeName:          "node1.us-west-2.compute.internal",
+				correctedNodeName: "node1",
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getSafeNodeName(tt.args.nodeName); got != tt.args.correctedNodeName {
+				t.Errorf("safeNodeName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
At the moment, it's not possible to set the pod.spec.hostName to a name with `.`s. This is a problem if the node name has a `.` in it, which is allowed. This PR addresses that by taking the first part of the node name before the `.` and setting that as the pod.spec.hostName