### PR TITLE
nodeset: do not undrain node automatically

### DIFF
--- a/internal/controller/nodeset/nodeset_control.go
+++ b/internal/controller/nodeset/nodeset_control.go
@@ -427,7 +427,7 @@ func (nsc *defaultNodeSetControl) processNodeSetPod(
 	}
 
 	stateMatch := true
-	if isNodeSetPodCordon(pods[i]) || nsc.podControl.isNodeSetPodDrain(ctx, set, pods[i]) {
+	if isNodeSetPodCordon(pods[i]) {
 		stateMatch = false
 	}
 

--- a/internal/controller/nodeset/nodeset_pod_control.go
+++ b/internal/controller/nodeset/nodeset_pod_control.go
@@ -196,35 +196,6 @@ func (spc *NodeSetPodControl) updateSlurmNode(
 		return err
 	}
 
-	if spc.isNodeSetPodDrain(ctx, set, pod) {
-		clusterName := types.NamespacedName{
-			Namespace: set.GetNamespace(),
-			Name:      set.Spec.ClusterName,
-		}
-		slurmClient := spc.slurmClusters.Get(clusterName)
-		if slurmClient != nil && !isNodeSetPodDelete(pod) {
-			objectKey := object.ObjectKey(pod.Spec.Hostname)
-			slurmNode := &slurmtypes.Node{}
-			if err := slurmClient.Get(ctx, objectKey, slurmNode); err != nil {
-				if err.Error() == http.StatusText(http.StatusNotFound) {
-					return nil
-				}
-				return err
-			}
-
-			logger.Info("Undrain Slurm Node", "slurmNode", slurmNode, "Pod", pod)
-			slurmNode.State.Insert(slurmtypes.NodeStateUNDRAIN)
-			if err := slurmClient.Update(ctx, slurmNode); err != nil {
-				if err.Error() == http.StatusText(http.StatusNotFound) {
-					return nil
-				}
-				return err
-			}
-
-			return nil
-		}
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
When a node is drained within slurm, the slurm-operator will automatically undrain it unless the pod is marked for deletion. This behavior makes it very difficult to use a slinky cluster without administrative control over the host kubernetes cluster. It is impossible to prevent jobs from running on a (potentially broken) node from within the cluster.

I'm sure that there is a better way to do this, so I am super open to feedback on how this can be done.