### PR TITLE
image.PullPolicy does not match Values usage

### DIFF
--- a/helm/slurm-operator/templates/_helpers.tpl
+++ b/helm/slurm-operator/templates/_helpers.tpl
@@ -98,7 +98,7 @@ Determine operator image reference (repo:tag)
 Common imagePullPolicy
 */}}
 {{- define "slurm-operator.imagePullPolicy" -}}
-{{ .Values.image.PullPolicy | default "IfNotPresent" }}
+{{ .Values.imagePullPolicy | default "IfNotPresent" }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
Was image.PullPolicy, which does not match usage (imagePullPolicy) in values.yaml