### PR TITLE
Minor chart fixes

### DIFF
--- a/helm/slurm/templates/cluster/token-job-rbac.yaml
+++ b/helm/slurm/templates/cluster/token-job-rbac.yaml
@@ -22,9 +22,11 @@ rules:
   - ""
   resources:
   - secrets
+  - secrets/finalizers
   verbs:
   - create
   - get
+  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/helm/slurm/templates/controller/controller-statefulset.yaml
+++ b/helm/slurm/templates/controller/controller-statefulset.yaml
@@ -68,6 +68,9 @@ spec:
         - name: wait
           image: {{ include "slurm.controller.imageRef" . }}
           securityContext:
+            capabilities:
+              add:
+                - NET_RAW
             {{- include "slurm.securityContext" . | nindent 12 }}
           env:
             - name: HOST

--- a/helm/slurm/templates/restapi/restapi-deployment.yaml
+++ b/helm/slurm/templates/restapi/restapi-deployment.yaml
@@ -70,6 +70,8 @@ spec:
           env:
             - name: SLURM_JWT
               value: daemon
+            - name: SLURMRESTD_SECURITY
+              value: disable_unshare_files,disable_unshare_sysv
           args:
             - "0.0.0.0:{{- include "slurm.restapi.port" . }}"
           ports:


### PR DESCRIPTION
The first commit is just about being more explicit with requirements:
* NET_RAW is required for using ping 
* Finalizers RBAC is required when setting OwnerReferences if the Kubernetes cluster has the [OwnerReferencesPermissionEnforcement](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement) admission controller plugin enabled

Second commit disables unshare in slurmrestd which does not work on unprivileged containers