### PR TITLE
version 0.2.0 images are not available publicly

### DIFF
--- a/helm/slurm-operator/Chart.yaml
+++ b/helm/slurm-operator/Chart.yaml
@@ -4,4 +4,4 @@ appVersion: "24.11"
 description: Helm Chart for Slurm HPC Workload Manager Operator
 name: slurm-operator
 type: application
-version: 0.2.0
+version: 0.1.0


### PR DESCRIPTION
The operator image version `0.2.0` is not available publically. Since issues cannot be opened on the repo I am presenting this PR so either chart can be put back to the working public version or the images can be made public.

```
> docker pull ghcr.io/slinkyproject/slurm-operator:0.2.0
Error response from daemon: manifest unknown
```

However, version `0.1.0` is available still:

```
> docker pull ghcr.io/slinkyproject/slurm-operator:0.1.0
0.1.0: Pulling from slinkyproject/slurm-operator...
```

All versions of the operator-webhook image are blocked.
Version: `0.1.0`
```
> docker pull ghcr.io/slinkyproject/slurm-operator-webhook:0.1.0
Error response from daemon: Head "https://ghcr.io/v2/slinkyproject/slurm-operator-webhook/manifests/0.1.0": denied
```
Version: `0.2.0`
```
> docker pull ghcr.io/slinkyproject/slurm-operator-webhook:0.2.0
Error response from daemon: Head "https://ghcr.io/v2/slinkyproject/slurm-operator-webhook/manifests/0.2.0": denied
```

These issues are present on normal kubenetes, openshift, and local kind clusters and makes deploying the operator not possible. 