### PR TITLE
feat: match Slurm resources with Kubernetes for CPU/Memory

### DIFF
--- a/helm/slurm/templates/_helpers.tpl
+++ b/helm/slurm/templates/_helpers.tpl
@@ -83,3 +83,86 @@ Define image tag
 {{- define "slurm.image.tag" -}}
 {{- printf "%s-ubuntu24.04" .Chart.AppVersion -}}
 {{- end }}
+
+
+{{- /* Helper function for power calculation */}}
+{{- define "pow" -}}
+    {{- $base := index . 0 -}}
+    {{- $exp := index . 1 -}}
+    {{- $result := 1 -}}
+    {{- range $i := until $exp -}}
+        {{- $result = mul $result $base -}}
+    {{- end -}}
+    {{- $result -}}
+{{- end -}}
+
+{{/*
+Convert Kubernetes storage request to Megabytes
+Supports all resource units that Kubernetes supports
+*/}}
+{{- define "slurm.convertToMB" -}}
+{{- $input := . -}}
+{{- $value := $input -}}
+{{- $multiplier := 1 -}}
+{{- $isBinary := false -}}
+
+{{- /* Handle bytes */}}
+{{- if eq (kindOf $input) "float64" }}
+    {{- $value = $input }}
+
+{{- /* Handle decimal suffixes */}}
+{{- else if hasSuffix "E" $input }}
+    {{- $value = trimSuffix "E" $input }}
+    {{- $multiplier = include "pow" (list 1000 6) }}
+{{- else if hasSuffix "P" $input }}
+    {{- $value = trimSuffix "P" $input }}
+    {{- $multiplier = include "pow" (list 1000 5) }}
+{{- else if hasSuffix "T" $input }}
+    {{- $value = trimSuffix "T" $input }}
+    {{- $multiplier = include "pow" (list 1000 4) }}
+{{- else if hasSuffix "G" $input }}
+    {{- $value = trimSuffix "G" $input }}
+    {{- $multiplier = include "pow" (list 1000 3) }}
+{{- else if hasSuffix "M" $input }}
+    {{- $value = trimSuffix "M" $input }}
+    {{- $multiplier = include "pow" (list 1000 2) }}
+{{- else if hasSuffix "k" $input }}
+    {{- $value = trimSuffix "k" $input }}
+    {{- $multiplier = include "pow" (list 1000 1) }}
+
+{{- /* Handle binary suffixes */}}
+{{- else if hasSuffix "Ei" $input }}
+    {{- $value = trimSuffix "Ei" $input }}
+    {{- $multiplier = include "pow" (list 1024 6) }}
+    {{- $isBinary = true }}
+{{- else if hasSuffix "Pi" $input }}
+    {{- $value = trimSuffix "Pi" $input }}
+    {{- $multiplier = include "pow" (list 1024 5) }}
+    {{- $isBinary = true }}
+{{- else if hasSuffix "Ti" $input }}
+    {{- $value = trimSuffix "Ti" $input }}
+    {{- $multiplier = include "pow" (list 1024 4) }}
+    {{- $isBinary = true }}
+{{- else if hasSuffix "Gi" $input }}
+    {{- $value = trimSuffix "Gi" $input }}
+    {{- $multiplier = include "pow" (list 1024 3) }}
+    {{- $isBinary = true }}
+{{- else if hasSuffix "Mi" $input }}
+    {{- $value = trimSuffix "Mi" $input }}
+    {{- $multiplier = include "pow" (list 1024 2) }}
+    {{- $isBinary = true }}
+{{- else if hasSuffix "Ki" $input }}
+    {{- $value = trimSuffix "Ki" $input }}
+    {{- $multiplier = include "pow" (list 1024 1) }}
+    {{- $isBinary = true }}
+{{- end -}}
+
+{{- /* Convert to numeric and calculate MB */}}
+{{- $numericValue := float64 $value }}
+{{- $bytes := mul $numericValue (int64 $multiplier) }}
+{{- if $isBinary }}
+    {{- div $bytes (mul 1024 1024) -}}
+{{- else }}
+    {{- div $bytes (mul 1000 1000) -}}
+{{- end -}}
+{{- end -}}

--- a/helm/slurm/templates/compute/compute-nodeset.yaml
+++ b/helm/slurm/templates/compute/compute-nodeset.yaml
@@ -134,6 +134,10 @@ spec:
               Gres={{- $nodeset.nodeGres }}
               {{- end }}
               Weight={{- default 1 $nodeset.nodeWeight }}
+              {{- if $nodeset.enableSlurmdResourceLimits }}
+              CPUs={{- $nodeset.resources.limits.cpu }}
+              RealMemory={{- include "slurm.convertToMB" $nodeset.resources.limits.memory }}
+              {{- end }}{{- /* if $nodeset.enableSlurmdResourceLimits */}}
           ports:
             - name: slurmd
               containerPort: {{ include "slurm.compute.port" $ }}

--- a/helm/slurm/values.yaml
+++ b/helm/slurm/values.yaml
@@ -550,6 +550,10 @@ compute:
           cpu: 1
           memory: 1Gi
       #
+      # -- (bool)
+      # Mirror the container resource limits to slurmd.
+      enableSlurmdResourceLimits: true
+      #
       # -- (map)
       # Selector which must match a node's labels for the pod to be scheduled on that node.
       nodeSelector:


### PR DESCRIPTION
Adds support for mirroring the Kubernetes container resource request to slurmd. 

Kubernetes accepts a [wide array of options for memory resource units ](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory) which I implemented except for "milibytes" with lowercase m.