### PR TITLE
Add tolerations and affinity to jobs

### DIFF
--- a/helm/slurm/templates/cluster/token-job.yaml
+++ b/helm/slurm/templates/cluster/token-job.yaml
@@ -25,7 +25,15 @@ spec:
       serviceAccountName: {{ include "slurm.cluster.name" . }}
       dnsConfig:
         {{- include "slurm.dnsConfig" . | nindent 8 }}
+      {{- with .Values.controller.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}{{- /* with .Values.controller.affinity */}}
       {{- include "slurm.imagePullSecrets" . | nindent 6 }}
+      {{- with .Values.controller.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}{{- /* with .Values.controller.tolerations */}}
       initContainers:
         - name: init
           image: {{ include "slurm.authcred.imageRef" . }}

--- a/helm/slurm/templates/controller/reconfigure-job.yaml
+++ b/helm/slurm/templates/controller/reconfigure-job.yaml
@@ -25,7 +25,15 @@ spec:
       automountServiceAccountToken: false
       dnsConfig:
         {{- include "slurm.dnsConfig" . | nindent 8 }}
+      {{- with .Values.controller.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}{{- /* with .Values.controller.affinity */}}
       {{- include "slurm.imagePullSecrets" . | nindent 6 }}
+      {{- with .Values.controller.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}{{- /* with .Values.controller.tolerations */}}
       initContainers:
         - name: init
           image: {{ include "slurm.authcred.imageRef" . }}


### PR DESCRIPTION
The `slurm-token-create-*` and `slurm-reconfigure-*` jobs now support tolerations and node affinity. This resolves an issue where these jobs would remain in a pending state if the controller was scheduled on a tainted node.