### PR TITLE
Add configmap to compute nodeset

### DIFF
--- a/helm/slurm/templates/compute/compute-nodeset.yaml
+++ b/helm/slurm/templates/compute/compute-nodeset.yaml
@@ -170,6 +170,8 @@ spec:
           projected:
             defaultMode: 0600
             sources:
+              - configMap:
+                  name: {{ include "slurm.configMapName" $ }}
               - secret:
                   name: {{ include "slurm.auth.secretName" $ }}
         - name: slurm-spool


### PR DESCRIPTION
## Problem
GPU nodes were showing as `invalid` state due to missing `gres.conf` configuration file in compute pods. The issue was that the `slurm-config` projected volume in the compute nodeset template only included the secret but not the configmap containing configuration files.

## Root Cause
In `helm/slurm/templates/compute/compute-nodeset.yaml`, the `slurm-config` volume was missing the configmap source:

```yaml
# Before (broken)
sources:
  - secret:
      name: {{ include "slurm.auth.secretName" $ }}

# After (fixed)  
sources:
  - configMap:
      name: {{ include "slurm.configMapName" $ }}
  - secret:
      name: {{ include "slurm.auth.secretName" $ }}
```

# Before fix:
```
[2025-05-23T14:46:50.178] warning: Can not stat gres.conf file (/var/spool/slurmd/conf-cache/gres.conf), using slurm.conf data
[2025-05-23T14:46:50.178] warning: Ignoring file-less GPU gpu:(null)
```

# After fix:
```
[2025-05-26T09:09:56.993] gres/gpu: init: loaded
[2025-05-26T09:09:56.993] gpu/nvidia: _set_name_and_file: Name=gpu Type=nvidia File=/dev/nvidia0

```
## Solution
Added the configmap to the projected volume sources to match the pattern used in the controller template (`helm/slurm/templates/controller/controller-statefulset.yaml` lines 103-108).

## How it was tested?
- GPU nodes now properly detect GPUs with `AutoDetect=nvidia` in `gres.conf`
- `sinfo` shows GPU nodes as `idle` instead of `inval`
