### PR TITLE
Add per-nodeset authcred image override support

### DIFF
--- a/helm/slurm/templates/compute/compute-nodeset.yaml
+++ b/helm/slurm/templates/compute/compute-nodeset.yaml
@@ -8,6 +8,16 @@ SPDX-License-Identifier: Apache-2.0
 {{- $repository := $nodeset.image.repository | default (include "slurm.compute.image.repository" $) }}
 {{- $tag := $nodeset.image.tag | default (include "slurm.compute.image.tag" $) }}
 {{- $imageRef := printf "%s:%s" $repository $tag }}
+{{- $authcredRepository := "" }}
+{{- $authcredTag := "" }}
+{{- if $nodeset.authcred }}
+{{- $authcredRepository = $nodeset.authcred.image.repository | default (include "slurm.authcred.image.repository" $) }}
+{{- $authcredTag = $nodeset.authcred.image.tag | default (include "slurm.authcred.image.tag" $) }}
+{{- else }}
+{{- $authcredRepository = include "slurm.authcred.image.repository" $ }}
+{{- $authcredTag = include "slurm.authcred.image.tag" $ }}
+{{- end }}
+{{- $authcredImageRef := printf "%s:%s" $authcredRepository $authcredTag }}
 {{- $name := printf "%s-%s" (include "slurm.compute.name" $) $nodeset.name }}
 ---
 apiVersion: slinky.slurm.net/v1alpha1

--- a/helm/slurm/values.yaml
+++ b/helm/slurm/values.yaml
@@ -34,7 +34,8 @@ namespaceOverride: ""
 # -- (list)
 # Set the secrets for image pull.
 # Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-imagePullSecrets: []
+imagePullSecrets:
+  []
   # - name: regcred
 
 #
@@ -74,7 +75,8 @@ slurm:
   # Extra slurmdbd configuration lines to append to `slurmdbd.conf`.
   # WARNING: Values can override existing ones.
   # Ref: https://slurm.schedmd.com/slurmdbd.conf.html
-  extraSlurmdbdConf: {}
+  extraSlurmdbdConf:
+    {}
     # CommitDelay: 1
     ### LOGGING ###
     # DebugLevel: debug2
@@ -92,7 +94,8 @@ slurm:
   # Extra slurm configuration lines to append to `slurm.conf`, represetned as a string or a map.
   # WARNING: Values can override existing ones.
   # Ref: https://slurm.schedmd.com/slurm.conf.html
-  extraSlurmConf: {}
+  extraSlurmConf:
+    {}
     # MinJobAge: 2
     # MaxNodeCount: 1024
     ### LOGGING ###
@@ -145,7 +148,8 @@ slurm:
   # Ref: https://slurm.schedmd.com/slurm.conf.html#OPT_Prolog
   # Ref: https://slurm.schedmd.com/prolog_epilog.html
   # Ref: https://en.wikipedia.org/wiki/Shebang_(Unix)
-  prologScripts: {}
+  prologScripts:
+    {}
     # 00-empty.sh: |
     #   #!/usr/bin/env bash
     #   set -euo pipefail
@@ -158,7 +162,8 @@ slurm:
   # Ref: https://slurm.schedmd.com/slurm.conf.html#OPT_Epilog
   # Ref: https://slurm.schedmd.com/prolog_epilog.html
   # Ref: https://en.wikipedia.org/wiki/Shebang_(Unix)
-  epilogScripts: {}
+  epilogScripts:
+    {}
     # 00-empty.sh: |
     #   #!/usr/bin/env bash
     #   set -euo pipefail
@@ -185,7 +190,8 @@ authcred:
   # -- (object)
   # Set container resource requests and limits for Kubernetes Pod scheduling.
   # Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container
-  resources: {}
+  resources:
+    {}
     # requests:
     #   cpu: 1
     #   memory: 1Gi
@@ -215,7 +221,8 @@ controller:
   # -- (object)
   # The controller service configuration.
   # Ref: https://kubernetes.io/docs/concepts/services-networking/service/
-  service: {}
+  service:
+    {}
     # type: LoadBalancer
     # externalIPs: []
     # externalName: my.slurmctld.example.com
@@ -253,7 +260,8 @@ controller:
   # -- (object)
   # Set container resource requests and limits for Kubernetes Pod scheduling.
   # Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container
-  resources: {}
+  resources:
+    {}
     # requests:
     #   cpu: 1
     #   memory: 1Gi
@@ -297,7 +305,8 @@ controller:
     #
     # -- (object)
     # Selector to match an existing `PersistentVolume`.
-    selector: {}
+    selector:
+      {}
       # matchLabels:
       #   app: foo
 
@@ -347,7 +356,8 @@ login:
   #
   # -- (list)
   # The `/root/.ssh/authorized_keys` file to write, represented as a list.
-  rootSshAuthorizedKeys: []
+  rootSshAuthorizedKeys:
+    []
     # - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx user@example.com
   #
   # -- (map)
@@ -396,7 +406,8 @@ login:
     # -- (map)
     # The `/etc/sssd/sssd.conf` [pam] section, represented as a map.
     # Ref: https://man.archlinux.org/man/sssd.conf.5#PAM_configuration_options
-    pam: {}
+    pam:
+      {}
       # debug_level: 9
   #
   # -- (object)
@@ -411,7 +422,8 @@ login:
   # --(list)
   # List of volume mounts.
   # Ref: https://kubernetes.io/docs/concepts/storage/volumes/
-  extraVolumeMounts: []
+  extraVolumeMounts:
+    []
     # - name: nfs-home
     #   mountPath: /home
     # - name: nfs-data
@@ -420,7 +432,8 @@ login:
   # --(list)
   # Define list of pod volumes.
   # Ref: https://kubernetes.io/docs/concepts/storage/volumes/
-  extraVolumes: []
+  extraVolumes:
+    []
     # - name: nfs-home
     #   nfs:
     #     server: nfs-server.example.com
@@ -453,7 +466,8 @@ login:
   # -- (object)
   # Set container resource requests and limits for Kubernetes Pod scheduling.
   # Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container
-  resources: {}
+  resources:
+    {}
     # requests:
     #   cpu: 1
     #   memory: 1Gi
@@ -484,9 +498,9 @@ compute:
   # -- (list)
   # Slurm NodeSets by object list.
   nodesets:
-      #
-      # -- (string)
-      # Name of NodeSet. Must be unique.
+    #
+    # -- (string)
+    # Name of NodeSet. Must be unique.
     - name: debug
       #
       # -- (bool)
@@ -526,7 +540,8 @@ compute:
       # -- (object)
       # Set affinity for Kubernetes Pod scheduling.
       # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
-      affinity: {}
+      affinity:
+        {}
         # podAntiAffinity:
         #   preferredDuringSchedulingIgnoredDuringExecution:
         #     - weight: 100
@@ -550,7 +565,8 @@ compute:
       # -- (object)
       # Set container resource requests and limits for Kubernetes Pod scheduling.
       # Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container
-      resources: {}
+      resources:
+        {}
         # limits:
         #   cpu: 1
         #   memory: 1Gi
@@ -603,7 +619,8 @@ compute:
       # List of PVCs to be created from template and mounted on each NodeSet pod.
       # PVCs are given a unique identity relative to each NodeSet pod.
       # Ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#volume-claim-templates
-      volumeClaimTemplates: []
+      volumeClaimTemplates:
+        []
         # - metadata:
         #     name: scratch
         #   spec:
@@ -618,7 +635,8 @@ compute:
       # --(list)
       # List of volume mounts.
       # Ref: https://kubernetes.io/docs/concepts/storage/volumes/
-      extraVolumeMounts: []
+      extraVolumeMounts:
+        []
         # - name: nfs-home
         #   mountPath: /home
         # - name: nfs-data
@@ -627,7 +645,8 @@ compute:
       # --(list)
       # Define list of pod volumes.
       # Ref: https://kubernetes.io/docs/concepts/storage/volumes/
-      extraVolumes: []
+      extraVolumes:
+        []
         # - name: nfs-home
         #   nfs:
         #     server: nfs-server.example.com
@@ -655,17 +674,53 @@ compute:
       # Extra Slurm node configuration appended into the --conf arguments.
       # WARNING: Values can override existing ones.
       # Ref: https://slurm.schedmd.com/slurm.conf.html#lbAE
-      nodeConfig: {}
+      nodeConfig:
+        {}
         # Features: []
         # Gres: []
         # Weight: 1
+    #
+    # Example of a second NodeSet with custom authcred configuration:
+    # - name: gpu
+    #   enabled: true
+    #   replicas: 2
+    #   imagePullPolicy: IfNotPresent
+    #   image:
+    #     repository: ghcr.io/slinkyproject/slurmd
+    #     tag: 24.11-ubuntu24.04
+    #   authcred:
+    #     imagePullPolicy: Always
+    #     image:
+    #       repository: ghcr.io/slinkyproject/sackd
+    #       tag: 24.11-ubuntu24.04-custom
+    #     resources:
+    #       requests:
+    #         cpu: 100m
+    #         memory: 128Mi
+    #       limits:
+    #         cpu: 200m
+    #         memory: 256Mi
+    #   nodeSelector:
+    #     kubernetes.io/os: linux
+    #     nvidia.com/gpu.present: "true"
+    #   resources:
+    #     limits:
+    #       cpu: 4
+    #       memory: 8Gi
+    #       nvidia.com/gpu: 1
+    #   useResourceLimits: true
+    #   nodeConfig:
+    #     Features:
+    #       - gpu
+    #     Gres:
+    #       - gpu:1
   #
   # -- (list)
   # Slurm Partitions by object list.
   partitions:
-      #
-      # -- (string)
-      # Name of Partition. Must be unique.
+    #
+    # -- (string)
+    # Name of Partition. Must be unique.
     - name: all
       #
       # -- (bool)
@@ -751,7 +806,8 @@ accounting:
   # -- (object)
   # Set affinity for Kubernetes Pod scheduling.
   # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
-  affinity: {}
+  affinity:
+    {}
     # podAffinity:
     #   requiredDuringSchedulingIgnoredDuringExecution:
     #     - topologyKey: kubernetes.io/hostname
@@ -770,7 +826,8 @@ accounting:
   # -- (object)
   # Set container resource requests and limits for Kubernetes Pod scheduling.
   # Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container
-  resources: {}
+  resources:
+    {}
     # requests:
     #   cpu: 1
     #   memory: 1Gi
@@ -897,7 +954,8 @@ restapi:
   # -- (object)
   # The restapi service configuration.
   # Ref: https://kubernetes.io/docs/concepts/services-networking/service/
-  service: {}
+  service:
+    {}
     # type: LoadBalancer
     # externalIPs: []
     # externalName: my.slurmrestd.example.com
@@ -925,7 +983,8 @@ restapi:
   # -- (object)
   # Set affinity for Kubernetes Pod scheduling.
   # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
-  affinity: {}
+  affinity:
+    {}
     # podAffinity:
     #   requiredDuringSchedulingIgnoredDuringExecution:
     #     - topologyKey: kubernetes.io/hostname
@@ -945,7 +1004,8 @@ restapi:
   # -- (object)
   # Set container resource requests and limits for Kubernetes Pod scheduling.
   # Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container
-  resources: {}
+  resources:
+    {}
     # requests:
     #   cpu: 1
     #   memory: 1Gi
@@ -961,7 +1021,8 @@ slurm-exporter:
   exporter:
     enabled: true
     secretName: "slurm-token-exporter"
-    affinity: {}
+    affinity:
+      {}
       # podAffinity:
       #   requiredDuringSchedulingIgnoredDuringExecution:
       #     - topologyKey: kubernetes.io/hostname


### PR DESCRIPTION
Adds support for configuring authcred (sackd) settings at the individual NodeSet level, allowing different nodesets to use different authcred images or resource configurations.

### Example Usage
```yaml
nodesets:
  - name: gpu
    authcred:
      imagePullPolicy: Always
      image:
        repository: ghcr.io/slinkyproject/sackd
        tag: 24.11-ubuntu24.04-custom
```


- Enables different authcred configurations per nodeset type (e.g., GPU vs CPU nodes)
- Maintains backward compatibility with existing global authcred configuration
- Provides flexibility for heterogeneous cluster deployments
