### PR TITLE
Set non-zero TTL for token-create job

### DIFF
--- a/helm/slurm/templates/cluster/token-job.yaml
+++ b/helm/slurm/templates/cluster/token-job.yaml
@@ -11,7 +11,7 @@ metadata:
   labels:
     {{- include "slurm.token.labels" . | nindent 4 }}
 spec:
-  ttlSecondsAfterFinished: 0
+  ttlSecondsAfterFinished: 60
   template:
     metadata:
       annotations:


### PR DESCRIPTION
When job TTL is zero the `helm install --wait --wait-for-jobs` command fails because the job is cleaned up by Kubernetes before Helm has a chance to see the job in a completed state which leads to the following error:
```
Error: INSTALLATION FAILED: jobs.batch "test-cluster-token-create" not found
```
Setting a short but non-zero TTL fixes the issue.