### PR TITLE
chore: add slurm-operator dependencies

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -8,7 +8,6 @@
   - [Table of Contents](#table-of-contents)
   - [Overview](#overview)
   - [Install](#install)
-    - [Pre-Requisites](#pre-requisites)
     - [Slurm Operator](#slurm-operator)
     - [Slurm Cluster](#slurm-cluster)
     - [Testing](#testing)
@@ -22,22 +21,6 @@ Slurm clusters to Kubernetes.
 
 ## Install
 
-### Pre-Requisites
-
-Install the pre-requisite helm charts.
-
-```bash
-helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-helm repo add metrics-server https://kubernetes-sigs.github.io/metrics-server/
-helm repo add bitnami https://charts.bitnami.com/bitnami
-helm repo add jetstack https://charts.jetstack.io
-helm repo update
-helm install cert-manager jetstack/cert-manager \
-	--namespace cert-manager --create-namespace --set crds.enabled=true
-helm install prometheus prometheus-community/kube-prometheus-stack \
-	--namespace prometheus --create-namespace --set installCRDs=true
-```
-
 ### Slurm Operator
 
 Download values and install the slurm-operator from OCI package.
@@ -46,7 +29,7 @@ Download values and install the slurm-operator from OCI package.
 curl -L https://raw.githubusercontent.com/SlinkyProject/slurm-operator/refs/tags/v0.3.0/helm/slurm-operator/values.yaml \
   -o values-operator.yaml
 helm install slurm-operator oci://ghcr.io/slinkyproject/charts/slurm-operator \
-  --values=values-operator.yaml --version=0.3.0 --namespace=slinky --create-namespace
+  --values=values-operator.yaml --version=0.3.0 --namespace=slinky --create-namespace --set cert-manager.enabled=true --set kube-prometheus-stack.enabled=true
 ```
 
 Make sure the cluster deployed successfully with:

--- a/helm/slurm-operator/Chart.lock
+++ b/helm/slurm-operator/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: cert-manager
+  repository: https://charts.jetstack.io
+  version: v1.18.0
+- name: kube-prometheus-stack
+  repository: https://prometheus-community.github.io/helm-charts
+  version: 75.2.1
+digest: sha256:c9fbb8ef0eead706ede87af25d06f6e041f5dbc94e93035fe04528d6e92a4329
+generated: "2025-06-18T17:07:46.713057+09:00"

--- a/helm/slurm-operator/Chart.yaml
+++ b/helm/slurm-operator/Chart.yaml
@@ -5,3 +5,13 @@ description: Helm Chart for Slurm HPC Workload Manager Operator
 name: slurm-operator
 type: application
 version: 0.3.0
+
+dependencies:
+  - name: cert-manager
+    repository: https://charts.jetstack.io
+    version: ">1.15.0"
+    condition: cert-manager.enabled
+  - name: kube-prometheus-stack
+    repository: https://prometheus-community.github.io/helm-charts
+    version: ">=75.0.0"
+    condition: prometheus.enabled

--- a/helm/slurm-operator/values.yaml
+++ b/helm/slurm-operator/values.yaml
@@ -184,3 +184,34 @@ certManager:
   # -- (string)
   # Certificate renewal time. Should be before the expiration.
   renewBefore: 8760h0m0s # 1 year
+
+#
+# Cert-Manager Dependencies configuration.
+cert-manager:
+  #
+  # -- (bool)
+  # Enables cert-manager.
+  enabled: false
+  #
+  # crd configurations.
+  crds:
+    #
+    # -- (bool)
+    # This option decides if the CRDs should be installed
+    enabled: true
+  #
+  # -- (string)
+  # The namespace where cert-manager is installed.
+  namespace: cert-manager
+
+#
+# Prometheus Stack Dependencies configurations.
+kube-prometheus-stack:
+  #
+  # -- (bool)
+  # Enables kube-prometheus-stack.
+  enabled: false
+  #
+  # -- (string)
+  # The namespace where kube-prometheus-stack is installed.
+  namespaceOverride: "prometheus"


### PR DESCRIPTION
add slurm-operator dependencies to skip pre-requisites