### PR TITLE
 DRA ResourceClaims Support for Slurm Operator

### DIFF
--- a/api/v1alpha1/base_types.go
+++ b/api/v1alpha1/base_types.go
@@ -111,6 +111,21 @@ type PodTemplate struct {
 	// +listType=map
 	// +listMapKey=name
 	Volumes []corev1.Volume `json:"volumes,omitempty" patchStrategy:"merge,retainKeys" patchMergeKey:"name"`
+
+	// ResourceClaims defines which ResourceClaims must be allocated
+	// and reserved before the Pod is allowed to start. The resources
+	// will be made available to those containers which consume them
+	// by name.
+	//
+	// This is an alpha field and requires enabling the
+	// DynamicResourceAllocation feature gate.
+	//
+	// This field is immutable.
+	//
+	// +optional
+	// +listType=map
+	// +listMapKey=name
+	ResourceClaims []corev1.PodResourceClaim `json:"resourceClaims,omitempty"`
 }
 
 // Metadata defines the metadata to added to resources.

--- a/config/crd/bases/slinky.slurm.net_accountings.yaml
+++ b/config/crd/bases/slinky.slurm.net_accountings.yaml
@@ -2145,6 +2145,64 @@ spec:
                       If not specified, the pod priority will be default or zero if there is no
                       default.
                     type: string
+                  resourceClaims:
+                    description: |-
+                      ResourceClaims defines which ResourceClaims must be allocated
+                      and reserved before the Pod is allowed to start. The resources
+                      will be made available to those containers which consume them
+                      by name.
+
+                      This is an alpha field and requires enabling the
+                      DynamicResourceAllocation feature gate.
+
+                      This field is immutable.
+                    items:
+                      description: |-
+                        PodResourceClaim references exactly one ResourceClaim, either directly
+                        or by naming a ResourceClaimTemplate which is then turned into a ResourceClaim
+                        for the pod.
+
+                        It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
+                        Containers that need access to the ResourceClaim reference it with this name.
+                      properties:
+                        name:
+                          description: |-
+                            Name uniquely identifies this resource claim inside the pod.
+                            This must be a DNS_LABEL.
+                          type: string
+                        resourceClaimName:
+                          description: |-
+                            ResourceClaimName is the name of a ResourceClaim object in the same
+                            namespace as this pod.
+
+                            Exactly one of ResourceClaimName and ResourceClaimTemplateName must
+                            be set.
+                          type: string
+                        resourceClaimTemplateName:
+                          description: |-
+                            ResourceClaimTemplateName is the name of a ResourceClaimTemplate
+                            object in the same namespace as this pod.
+
+                            The template will be used to create a new ResourceClaim, which will
+                            be bound to this pod. When this pod is deleted, the ResourceClaim
+                            will also be deleted. The pod name and resource name, along with a
+                            generated component, will be used to form a unique name for the
+                            ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
+
+                            This field is immutable and no changes will be made to the
+                            corresponding ResourceClaim by the control plane after creating the
+                            ResourceClaim.
+
+                            Exactly one of ResourceClaimName and ResourceClaimTemplateName must
+                            be set.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
                   tolerations:
                     description: |-
                       If specified, the pod's tolerations.

--- a/config/crd/bases/slinky.slurm.net_controllers.yaml
+++ b/config/crd/bases/slinky.slurm.net_controllers.yaml
@@ -2413,6 +2413,64 @@ spec:
                             type: object
                         type: object
                     type: object
+                  resourceClaims:
+                    description: |-
+                      ResourceClaims defines which ResourceClaims must be allocated
+                      and reserved before the Pod is allowed to start. The resources
+                      will be made available to those containers which consume them
+                      by name.
+
+                      This is an alpha field and requires enabling the
+                      DynamicResourceAllocation feature gate.
+
+                      This field is immutable.
+                    items:
+                      description: |-
+                        PodResourceClaim references exactly one ResourceClaim, either directly
+                        or by naming a ResourceClaimTemplate which is then turned into a ResourceClaim
+                        for the pod.
+
+                        It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
+                        Containers that need access to the ResourceClaim reference it with this name.
+                      properties:
+                        name:
+                          description: |-
+                            Name uniquely identifies this resource claim inside the pod.
+                            This must be a DNS_LABEL.
+                          type: string
+                        resourceClaimName:
+                          description: |-
+                            ResourceClaimName is the name of a ResourceClaim object in the same
+                            namespace as this pod.
+
+                            Exactly one of ResourceClaimName and ResourceClaimTemplateName must
+                            be set.
+                          type: string
+                        resourceClaimTemplateName:
+                          description: |-
+                            ResourceClaimTemplateName is the name of a ResourceClaimTemplate
+                            object in the same namespace as this pod.
+
+                            The template will be used to create a new ResourceClaim, which will
+                            be bound to this pod. When this pod is deleted, the ResourceClaim
+                            will also be deleted. The pod name and resource name, along with a
+                            generated component, will be used to form a unique name for the
+                            ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
+
+                            This field is immutable and no changes will be made to the
+                            corresponding ResourceClaim by the control plane after creating the
+                            ResourceClaim.
+
+                            Exactly one of ResourceClaimName and ResourceClaimTemplateName must
+                            be set.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
                   tolerations:
                     description: |-
                       If specified, the pod's tolerations.

--- a/config/crd/bases/slinky.slurm.net_loginsets.yaml
+++ b/config/crd/bases/slinky.slurm.net_loginsets.yaml
@@ -2006,6 +2006,64 @@ spec:
                       If not specified, the pod priority will be default or zero if there is no
                       default.
                     type: string
+                  resourceClaims:
+                    description: |-
+                      ResourceClaims defines which ResourceClaims must be allocated
+                      and reserved before the Pod is allowed to start. The resources
+                      will be made available to those containers which consume them
+                      by name.
+
+                      This is an alpha field and requires enabling the
+                      DynamicResourceAllocation feature gate.
+
+                      This field is immutable.
+                    items:
+                      description: |-
+                        PodResourceClaim references exactly one ResourceClaim, either directly
+                        or by naming a ResourceClaimTemplate which is then turned into a ResourceClaim
+                        for the pod.
+
+                        It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
+                        Containers that need access to the ResourceClaim reference it with this name.
+                      properties:
+                        name:
+                          description: |-
+                            Name uniquely identifies this resource claim inside the pod.
+                            This must be a DNS_LABEL.
+                          type: string
+                        resourceClaimName:
+                          description: |-
+                            ResourceClaimName is the name of a ResourceClaim object in the same
+                            namespace as this pod.
+
+                            Exactly one of ResourceClaimName and ResourceClaimTemplateName must
+                            be set.
+                          type: string
+                        resourceClaimTemplateName:
+                          description: |-
+                            ResourceClaimTemplateName is the name of a ResourceClaimTemplate
+                            object in the same namespace as this pod.
+
+                            The template will be used to create a new ResourceClaim, which will
+                            be bound to this pod. When this pod is deleted, the ResourceClaim
+                            will also be deleted. The pod name and resource name, along with a
+                            generated component, will be used to form a unique name for the
+                            ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
+
+                            This field is immutable and no changes will be made to the
+                            corresponding ResourceClaim by the control plane after creating the
+                            ResourceClaim.
+
+                            Exactly one of ResourceClaimName and ResourceClaimTemplateName must
+                            be set.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
                   tolerations:
                     description: |-
                       If specified, the pod's tolerations.

--- a/config/crd/bases/slinky.slurm.net_nodesets.yaml
+++ b/config/crd/bases/slinky.slurm.net_nodesets.yaml
@@ -1794,6 +1794,64 @@ spec:
                       If not specified, the pod priority will be default or zero if there is no
                       default.
                     type: string
+                  resourceClaims:
+                    description: |-
+                      ResourceClaims defines which ResourceClaims must be allocated
+                      and reserved before the Pod is allowed to start. The resources
+                      will be made available to those containers which consume them
+                      by name.
+
+                      This is an alpha field and requires enabling the
+                      DynamicResourceAllocation feature gate.
+
+                      This field is immutable.
+                    items:
+                      description: |-
+                        PodResourceClaim references exactly one ResourceClaim, either directly
+                        or by naming a ResourceClaimTemplate which is then turned into a ResourceClaim
+                        for the pod.
+
+                        It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
+                        Containers that need access to the ResourceClaim reference it with this name.
+                      properties:
+                        name:
+                          description: |-
+                            Name uniquely identifies this resource claim inside the pod.
+                            This must be a DNS_LABEL.
+                          type: string
+                        resourceClaimName:
+                          description: |-
+                            ResourceClaimName is the name of a ResourceClaim object in the same
+                            namespace as this pod.
+
+                            Exactly one of ResourceClaimName and ResourceClaimTemplateName must
+                            be set.
+                          type: string
+                        resourceClaimTemplateName:
+                          description: |-
+                            ResourceClaimTemplateName is the name of a ResourceClaimTemplate
+                            object in the same namespace as this pod.
+
+                            The template will be used to create a new ResourceClaim, which will
+                            be bound to this pod. When this pod is deleted, the ResourceClaim
+                            will also be deleted. The pod name and resource name, along with a
+                            generated component, will be used to form a unique name for the
+                            ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
+
+                            This field is immutable and no changes will be made to the
+                            corresponding ResourceClaim by the control plane after creating the
+                            ResourceClaim.
+
+                            Exactly one of ResourceClaimName and ResourceClaimTemplateName must
+                            be set.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
                   tolerations:
                     description: |-
                       If specified, the pod's tolerations.

--- a/config/crd/bases/slinky.slurm.net_restapis.yaml
+++ b/config/crd/bases/slinky.slurm.net_restapis.yaml
@@ -1967,6 +1967,64 @@ spec:
                       If not specified, the pod priority will be default or zero if there is no
                       default.
                     type: string
+                  resourceClaims:
+                    description: |-
+                      ResourceClaims defines which ResourceClaims must be allocated
+                      and reserved before the Pod is allowed to start. The resources
+                      will be made available to those containers which consume them
+                      by name.
+
+                      This is an alpha field and requires enabling the
+                      DynamicResourceAllocation feature gate.
+
+                      This field is immutable.
+                    items:
+                      description: |-
+                        PodResourceClaim references exactly one ResourceClaim, either directly
+                        or by naming a ResourceClaimTemplate which is then turned into a ResourceClaim
+                        for the pod.
+
+                        It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
+                        Containers that need access to the ResourceClaim reference it with this name.
+                      properties:
+                        name:
+                          description: |-
+                            Name uniquely identifies this resource claim inside the pod.
+                            This must be a DNS_LABEL.
+                          type: string
+                        resourceClaimName:
+                          description: |-
+                            ResourceClaimName is the name of a ResourceClaim object in the same
+                            namespace as this pod.
+
+                            Exactly one of ResourceClaimName and ResourceClaimTemplateName must
+                            be set.
+                          type: string
+                        resourceClaimTemplateName:
+                          description: |-
+                            ResourceClaimTemplateName is the name of a ResourceClaimTemplate
+                            object in the same namespace as this pod.
+
+                            The template will be used to create a new ResourceClaim, which will
+                            be bound to this pod. When this pod is deleted, the ResourceClaim
+                            will also be deleted. The pod name and resource name, along with a
+                            generated component, will be used to form a unique name for the
+                            ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
+
+                            This field is immutable and no changes will be made to the
+                            corresponding ResourceClaim by the control plane after creating the
+                            ResourceClaim.
+
+                            Exactly one of ResourceClaimName and ResourceClaimTemplateName must
+                            be set.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
                   tolerations:
                     description: |-
                       If specified, the pod's tolerations.

--- a/helm/slurm-operator/crds/slinky.slurm.net_accountings.yaml
+++ b/helm/slurm-operator/crds/slinky.slurm.net_accountings.yaml
@@ -2145,6 +2145,64 @@ spec:
                       If not specified, the pod priority will be default or zero if there is no
                       default.
                     type: string
+                  resourceClaims:
+                    description: |-
+                      ResourceClaims defines which ResourceClaims must be allocated
+                      and reserved before the Pod is allowed to start. The resources
+                      will be made available to those containers which consume them
+                      by name.
+
+                      This is an alpha field and requires enabling the
+                      DynamicResourceAllocation feature gate.
+
+                      This field is immutable.
+                    items:
+                      description: |-
+                        PodResourceClaim references exactly one ResourceClaim, either directly
+                        or by naming a ResourceClaimTemplate which is then turned into a ResourceClaim
+                        for the pod.
+
+                        It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
+                        Containers that need access to the ResourceClaim reference it with this name.
+                      properties:
+                        name:
+                          description: |-
+                            Name uniquely identifies this resource claim inside the pod.
+                            This must be a DNS_LABEL.
+                          type: string
+                        resourceClaimName:
+                          description: |-
+                            ResourceClaimName is the name of a ResourceClaim object in the same
+                            namespace as this pod.
+
+                            Exactly one of ResourceClaimName and ResourceClaimTemplateName must
+                            be set.
+                          type: string
+                        resourceClaimTemplateName:
+                          description: |-
+                            ResourceClaimTemplateName is the name of a ResourceClaimTemplate
+                            object in the same namespace as this pod.
+
+                            The template will be used to create a new ResourceClaim, which will
+                            be bound to this pod. When this pod is deleted, the ResourceClaim
+                            will also be deleted. The pod name and resource name, along with a
+                            generated component, will be used to form a unique name for the
+                            ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
+
+                            This field is immutable and no changes will be made to the
+                            corresponding ResourceClaim by the control plane after creating the
+                            ResourceClaim.
+
+                            Exactly one of ResourceClaimName and ResourceClaimTemplateName must
+                            be set.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
                   tolerations:
                     description: |-
                       If specified, the pod's tolerations.

--- a/helm/slurm-operator/crds/slinky.slurm.net_controllers.yaml
+++ b/helm/slurm-operator/crds/slinky.slurm.net_controllers.yaml
@@ -2413,6 +2413,64 @@ spec:
                             type: object
                         type: object
                     type: object
+                  resourceClaims:
+                    description: |-
+                      ResourceClaims defines which ResourceClaims must be allocated
+                      and reserved before the Pod is allowed to start. The resources
+                      will be made available to those containers which consume them
+                      by name.
+
+                      This is an alpha field and requires enabling the
+                      DynamicResourceAllocation feature gate.
+
+                      This field is immutable.
+                    items:
+                      description: |-
+                        PodResourceClaim references exactly one ResourceClaim, either directly
+                        or by naming a ResourceClaimTemplate which is then turned into a ResourceClaim
+                        for the pod.
+
+                        It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
+                        Containers that need access to the ResourceClaim reference it with this name.
+                      properties:
+                        name:
+                          description: |-
+                            Name uniquely identifies this resource claim inside the pod.
+                            This must be a DNS_LABEL.
+                          type: string
+                        resourceClaimName:
+                          description: |-
+                            ResourceClaimName is the name of a ResourceClaim object in the same
+                            namespace as this pod.
+
+                            Exactly one of ResourceClaimName and ResourceClaimTemplateName must
+                            be set.
+                          type: string
+                        resourceClaimTemplateName:
+                          description: |-
+                            ResourceClaimTemplateName is the name of a ResourceClaimTemplate
+                            object in the same namespace as this pod.
+
+                            The template will be used to create a new ResourceClaim, which will
+                            be bound to this pod. When this pod is deleted, the ResourceClaim
+                            will also be deleted. The pod name and resource name, along with a
+                            generated component, will be used to form a unique name for the
+                            ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
+
+                            This field is immutable and no changes will be made to the
+                            corresponding ResourceClaim by the control plane after creating the
+                            ResourceClaim.
+
+                            Exactly one of ResourceClaimName and ResourceClaimTemplateName must
+                            be set.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
                   tolerations:
                     description: |-
                       If specified, the pod's tolerations.

--- a/helm/slurm-operator/crds/slinky.slurm.net_loginsets.yaml
+++ b/helm/slurm-operator/crds/slinky.slurm.net_loginsets.yaml
@@ -2006,6 +2006,64 @@ spec:
                       If not specified, the pod priority will be default or zero if there is no
                       default.
                     type: string
+                  resourceClaims:
+                    description: |-
+                      ResourceClaims defines which ResourceClaims must be allocated
+                      and reserved before the Pod is allowed to start. The resources
+                      will be made available to those containers which consume them
+                      by name.
+
+                      This is an alpha field and requires enabling the
+                      DynamicResourceAllocation feature gate.
+
+                      This field is immutable.
+                    items:
+                      description: |-
+                        PodResourceClaim references exactly one ResourceClaim, either directly
+                        or by naming a ResourceClaimTemplate which is then turned into a ResourceClaim
+                        for the pod.
+
+                        It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
+                        Containers that need access to the ResourceClaim reference it with this name.
+                      properties:
+                        name:
+                          description: |-
+                            Name uniquely identifies this resource claim inside the pod.
+                            This must be a DNS_LABEL.
+                          type: string
+                        resourceClaimName:
+                          description: |-
+                            ResourceClaimName is the name of a ResourceClaim object in the same
+                            namespace as this pod.
+
+                            Exactly one of ResourceClaimName and ResourceClaimTemplateName must
+                            be set.
+                          type: string
+                        resourceClaimTemplateName:
+                          description: |-
+                            ResourceClaimTemplateName is the name of a ResourceClaimTemplate
+                            object in the same namespace as this pod.
+
+                            The template will be used to create a new ResourceClaim, which will
+                            be bound to this pod. When this pod is deleted, the ResourceClaim
+                            will also be deleted. The pod name and resource name, along with a
+                            generated component, will be used to form a unique name for the
+                            ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
+
+                            This field is immutable and no changes will be made to the
+                            corresponding ResourceClaim by the control plane after creating the
+                            ResourceClaim.
+
+                            Exactly one of ResourceClaimName and ResourceClaimTemplateName must
+                            be set.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
                   tolerations:
                     description: |-
                       If specified, the pod's tolerations.

--- a/helm/slurm-operator/crds/slinky.slurm.net_nodesets.yaml
+++ b/helm/slurm-operator/crds/slinky.slurm.net_nodesets.yaml
@@ -1794,6 +1794,64 @@ spec:
                       If not specified, the pod priority will be default or zero if there is no
                       default.
                     type: string
+                  resourceClaims:
+                    description: |-
+                      ResourceClaims defines which ResourceClaims must be allocated
+                      and reserved before the Pod is allowed to start. The resources
+                      will be made available to those containers which consume them
+                      by name.
+
+                      This is an alpha field and requires enabling the
+                      DynamicResourceAllocation feature gate.
+
+                      This field is immutable.
+                    items:
+                      description: |-
+                        PodResourceClaim references exactly one ResourceClaim, either directly
+                        or by naming a ResourceClaimTemplate which is then turned into a ResourceClaim
+                        for the pod.
+
+                        It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
+                        Containers that need access to the ResourceClaim reference it with this name.
+                      properties:
+                        name:
+                          description: |-
+                            Name uniquely identifies this resource claim inside the pod.
+                            This must be a DNS_LABEL.
+                          type: string
+                        resourceClaimName:
+                          description: |-
+                            ResourceClaimName is the name of a ResourceClaim object in the same
+                            namespace as this pod.
+
+                            Exactly one of ResourceClaimName and ResourceClaimTemplateName must
+                            be set.
+                          type: string
+                        resourceClaimTemplateName:
+                          description: |-
+                            ResourceClaimTemplateName is the name of a ResourceClaimTemplate
+                            object in the same namespace as this pod.
+
+                            The template will be used to create a new ResourceClaim, which will
+                            be bound to this pod. When this pod is deleted, the ResourceClaim
+                            will also be deleted. The pod name and resource name, along with a
+                            generated component, will be used to form a unique name for the
+                            ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
+
+                            This field is immutable and no changes will be made to the
+                            corresponding ResourceClaim by the control plane after creating the
+                            ResourceClaim.
+
+                            Exactly one of ResourceClaimName and ResourceClaimTemplateName must
+                            be set.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
                   tolerations:
                     description: |-
                       If specified, the pod's tolerations.

--- a/helm/slurm-operator/crds/slinky.slurm.net_restapis.yaml
+++ b/helm/slurm-operator/crds/slinky.slurm.net_restapis.yaml
@@ -1967,6 +1967,64 @@ spec:
                       If not specified, the pod priority will be default or zero if there is no
                       default.
                     type: string
+                  resourceClaims:
+                    description: |-
+                      ResourceClaims defines which ResourceClaims must be allocated
+                      and reserved before the Pod is allowed to start. The resources
+                      will be made available to those containers which consume them
+                      by name.
+
+                      This is an alpha field and requires enabling the
+                      DynamicResourceAllocation feature gate.
+
+                      This field is immutable.
+                    items:
+                      description: |-
+                        PodResourceClaim references exactly one ResourceClaim, either directly
+                        or by naming a ResourceClaimTemplate which is then turned into a ResourceClaim
+                        for the pod.
+
+                        It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
+                        Containers that need access to the ResourceClaim reference it with this name.
+                      properties:
+                        name:
+                          description: |-
+                            Name uniquely identifies this resource claim inside the pod.
+                            This must be a DNS_LABEL.
+                          type: string
+                        resourceClaimName:
+                          description: |-
+                            ResourceClaimName is the name of a ResourceClaim object in the same
+                            namespace as this pod.
+
+                            Exactly one of ResourceClaimName and ResourceClaimTemplateName must
+                            be set.
+                          type: string
+                        resourceClaimTemplateName:
+                          description: |-
+                            ResourceClaimTemplateName is the name of a ResourceClaimTemplate
+                            object in the same namespace as this pod.
+
+                            The template will be used to create a new ResourceClaim, which will
+                            be bound to this pod. When this pod is deleted, the ResourceClaim
+                            will also be deleted. The pod name and resource name, along with a
+                            generated component, will be used to form a unique name for the
+                            ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
+
+                            This field is immutable and no changes will be made to the
+                            corresponding ResourceClaim by the control plane after creating the
+                            ResourceClaim.
+
+                            Exactly one of ResourceClaimName and ResourceClaimTemplateName must
+                            be set.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
                   tolerations:
                     description: |-
                       If specified, the pod's tolerations.

--- a/helm/slurm/templates/accounting/accounting-cr.yaml
+++ b/helm/slurm/templates/accounting/accounting-cr.yaml
@@ -69,6 +69,10 @@ spec:
       {{- toYaml . | nindent 6 }}
     {{- end }}{{- /* with .Values.accounting.tolerations */}}
     priorityClassName: {{ .Values.priorityClassName }}
+    {{- with .Values.accounting.resourceClaims }}
+    resourceClaims:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}{{- /* with .Values.accounting.resourceClaims */}}
   {{- with .Values.accounting.storageConfig }}
   storageConfig:
     {{- toYaml . | nindent 4 }}

--- a/helm/slurm/templates/controller/controller-cr.yaml
+++ b/helm/slurm/templates/controller/controller-cr.yaml
@@ -95,6 +95,10 @@ spec:
       {{- toYaml . | nindent 6 }}
     {{- end }}{{- /* with .Values.controller.tolerations */}}
     priorityClassName: {{ .Values.priorityClassName }}
+    {{- with .Values.controller.resourceClaims }}
+    resourceClaims:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}{{- /* with .Values.controller.resourceClaims */}}
   {{- with .Values.controller.persistence }}
   persistence:
     {{- toYaml . | nindent 4 }}

--- a/helm/slurm/templates/loginset/loginset-cr.yaml
+++ b/helm/slurm/templates/loginset/loginset-cr.yaml
@@ -72,6 +72,10 @@ spec:
       {{- toYaml . | nindent 6 }}
     {{- end }}{{- /* with $loginset.tolerations */}}
     priorityClassName: {{ $.Values.priorityClassName }}
+    {{- with $loginset.resourceClaims }}
+    resourceClaims:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}{{- /* with $loginset.resourceClaims */}}
     {{- with $loginset.volumes }}
     volumes:
       {{- toYaml . | nindent 6 }}

--- a/helm/slurm/templates/nodeset/nodeset-cr.yaml
+++ b/helm/slurm/templates/nodeset/nodeset-cr.yaml
@@ -82,6 +82,10 @@ spec:
       {{- toYaml . | nindent 6 }}
     {{- end }}{{- /* with $nodeset.tolerations */}}
     priorityClassName: {{ $.Values.priorityClassName }}
+    {{- with $nodeset.resourceClaims }}
+    resourceClaims:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}{{- /* with $nodeset.resourceClaims */}}
     {{- with $nodeset.volumes }}
     volumes:
       {{- toYaml . | nindent 6 }}

--- a/helm/slurm/templates/restapi/restapi-cr.yaml
+++ b/helm/slurm/templates/restapi/restapi-cr.yaml
@@ -57,3 +57,7 @@ spec:
       {{- toYaml . | nindent 6 }}
     {{- end }}{{- /* with .Values.restapi.tolerations */}}
     priorityClassName: {{ .Values.priorityClassName }}
+    {{- with .Values.restapi.resourceClaims }}
+    resourceClaims:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}{{- /* with .Values.restapi.resourceClaims */}}

--- a/helm/slurm/values.yaml
+++ b/helm/slurm/values.yaml
@@ -12,7 +12,8 @@ namespaceOverride: null
 
 # -- Set the secrets for image pull.
 # Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-imagePullSecrets: []
+imagePullSecrets:
+  []
   # - name: regcred
 
 # -- Set the image pull policy.
@@ -26,14 +27,16 @@ priorityClassName: null
 # -- (secretKeyRef) Slurm shared authentication key.
 # If empty, one will be generated and used.
 # Ref: https://slurm.schedmd.com/authentication.html#slurm
-slurmKeyRef: {}
+slurmKeyRef:
+  {}
   # name: slurm-auth-slurm
   # key: slurm.key
 
 # -- (secretKeyRef) Slurm cluster JWT HS256 authentication key.
 # If empty, one will be generated and used.
 # Ref: https://slurm.schedmd.com/authentication.html#jwt
-jwtHs256KeyRef: {}
+jwtHs256KeyRef:
+  {}
   # name: slurm-auth-jwths256
   # key: jwt_hs256.key
 
@@ -44,7 +47,8 @@ clusterName: null
 
 # -- (map[string]string) Extra Slurm config files to be mounted.
 # Ref: https://slurm.schedmd.com/man_index.html#configuration_files
-configFiles: {}
+configFiles:
+  {}
   # Ref: https://slurm.schedmd.com/cgroup.conf.html
   # cgroup.conf: |
   #   CgroupPlugin=autodetect
@@ -76,7 +80,8 @@ configFiles: {}
 # Ref: https://slurm.schedmd.com/slurm.conf.html#OPT_Prolog
 # Ref: https://slurm.schedmd.com/prolog_epilog.html
 # Ref: https://en.wikipedia.org/wiki/Shebang_(Unix)
-prologScripts: {}
+prologScripts:
+  {}
   # 00-empty.sh: |
   #   #!/usr/bin/env bash
   #   set -euo pipefail
@@ -88,7 +93,8 @@ prologScripts: {}
 # Ref: https://slurm.schedmd.com/slurm.conf.html#OPT_Epilog
 # Ref: https://slurm.schedmd.com/prolog_epilog.html
 # Ref: https://en.wikipedia.org/wiki/Shebang_(Unix)
-epilogScripts: {}
+epilogScripts:
+  {}
   # 00-empty.sh: |
   #   #!/usr/bin/env bash
   #   set -euo pipefail
@@ -103,7 +109,8 @@ authcred:
     tag: 25.05-ubuntu24.04
   # -- The container resource limits and requests.
   # Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container
-  resources: {}
+  resources:
+    {}
     # limits:
     #   cpu: 1
     #   memory: 1Gi
@@ -117,7 +124,8 @@ controller:
     tag: 25.05-ubuntu24.04
   # -- Arguments passed to the image.
   # Ref: https://slurm.schedmd.com/slurmctld.html#SECTION_OPTIONS
-  args: []
+  args:
+    []
     # - -vvv
   # -- Extra Slurm configuration lines appended to `slurm.conf`.
   # Ref: https://slurm.schedmd.com/slurm.conf.html
@@ -125,7 +133,8 @@ controller:
   # -- (map[string]string \| map[string][]string) Extra Slurm configuration lines appended to `slurm.conf`.
   # If `extraConf` is not empty, it takes precedence.
   # Ref: https://slurm.schedmd.com/slurmdbd.conf.html
-  extraConfMap: {}
+  extraConfMap:
+    {}
     # DebugFlags: []
     # MinJobAge: 2
     # SchedulerParameters: []
@@ -161,10 +170,11 @@ controller:
       tag: 25.05-ubuntu24.04
     # -- The container resource limits and requests.
     # Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container
-    resources: {}
+    resources:
+      {}
       # limits:
-        # cpu: 500m
-        # memory: 100Mi
+      # cpu: 500m
+      # memory: 100Mi
   # LogFile sidecar configurations.
   logfile:
     # -- The image to use, `${repository}:${tag}`.
@@ -174,13 +184,15 @@ controller:
       tag: latest
     # -- The container resource limits and requests.
     # Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container
-    resources: {}
+    resources:
+      {}
       # limits:
       #   cpu: 500m
       #   memory: 100Mi
   # -- The container resource limits and requests.
   # Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container
-  resources: {}
+  resources:
+    {}
     # limits:
     #   cpu: 1
     #   memory: 1Gi
@@ -193,13 +205,15 @@ controller:
   affinity: {}
   # -- Tolerations for pod assignment.
   # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-  tolerations: []
+  tolerations:
+    []
     # - key: key1
     #   operator: Exists
     #   effect: NoSchedule
   # -- The service configuration.
   # Ref: https://kubernetes.io/docs/concepts/services-networking/service/
-  service: {}
+  service:
+    {}
     # type: LoadBalancer
     # port: 6817
     # loadBalancerIP: ""
@@ -215,18 +229,21 @@ restapi:
     tag: 25.05-ubuntu24.04
   # -- Environment passed to the image.
   # Ref: https://slurm.schedmd.com/slurmrestd.html#SECTION_ENVIRONMENT-VARIABLES
-  env: []
+  env:
+    []
     # - name: SLURMRESTD_YAML
     #   value: pretty
   # -- Arguments passed to the image.
   # Ref: https://slurm.schedmd.com/slurmrestd.html#SECTION_OPTIONS
-  args: []
+  args:
+    []
     # - -vvv
   # -- Number of replicas to deploy.
   replicas: 1
   # -- The container resource limits and requests.
   # Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container
-  resources: {}
+  resources:
+    {}
     # limits:
     #   cpu: 1
     #   memory: 1Gi
@@ -239,13 +256,15 @@ restapi:
   affinity: {}
   # -- Tolerations for pod assignment.
   # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-  tolerations: []
+  tolerations:
+    []
     # - key: key1
     #   operator: Exists
     #   effect: NoSchedule
   # -- The service configuration.
   # Ref: https://kubernetes.io/docs/concepts/services-networking/service/
-  service: {}
+  service:
+    {}
     # type: ClusterIP
     # port: 6820
     # loadBalancerIP: ""
@@ -276,7 +295,8 @@ accounting:
     tag: 25.05-ubuntu24.04
   # -- Arguments passed to the image.
   # Ref: https://slurm.schedmd.com/slurmdbd.html#SECTION_OPTIONS
-  args: []
+  args:
+    []
     # - -vvv
   # -- Extra Slurm configuration lines appended to `slurmdbd.conf`.
   # Ref: https://slurm.schedmd.com/slurm.conf.html
@@ -284,7 +304,8 @@ accounting:
   # -- (map[string]string \| map[string][]string) Extra Slurm configuration lines appended to `slurmdbd.conf`.
   # If `extraConf` is not empty, it takes precedence.
   # Ref: https://slurm.schedmd.com/slurmdbd.conf.html
-  extraConfMap: {}
+  extraConfMap:
+    {}
     # CommitDelay: 1
     # DebugLevel: debug2
     # DebugFlags: []
@@ -323,13 +344,15 @@ accounting:
       tag: 25.05-ubuntu24.04
     # -- The container resource limits and requests.
     # Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container
-    resources: {}
+    resources:
+      {}
       # limits:
       #   cpu: 500m
       #   memory: 100Mi
   # -- The container resource limits and requests.
   # Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container
-  resources: {}
+  resources:
+    {}
     # limits:
     #   cpu: 1
     #   memory: 1Gi
@@ -342,13 +365,15 @@ accounting:
   affinity: {}
   # -- Tolerations for pod assignment.
   # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-  tolerations: []
+  tolerations:
+    []
     # - key: key1
     #   operator: Exists
     #   effect: NoSchedule
   # -- The service configuration.
   # Ref: https://kubernetes.io/docs/concepts/services-networking/service/
-  service: {}
+  service:
+    {}
     # type: LoadBalancer
     # loadBalancerIP: ""
     # externalIPs: []
@@ -368,7 +393,8 @@ loginsets:
       repository: ghcr.io/slinkyproject/login
       tag: 25.05-ubuntu24.04
     # -- Environment passed to the image.
-    env: {}
+    env:
+      {}
       # - name: SACKD_OPTIONS
       #   value: -vvv
     # -- SSH public keys to write into `/root/.ssh/authorized_keys`.
@@ -406,7 +432,8 @@ loginsets:
       #     - SYS_CHROOT
     # -- The container resource limits and requests.
     # Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container
-    resources: {}
+    resources:
+      {}
       # limits:
       #   cpu: 1
       #   memory: 1Gi
@@ -419,7 +446,8 @@ loginsets:
     affinity: {}
     # -- Tolerations for pod assignment.
     # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-    tolerations: []
+    tolerations:
+      []
       # - key: key1
       #   operator: Exists
       #   effect: NoSchedule
@@ -433,14 +461,16 @@ loginsets:
       # externalName: ""
     # -- List of volumes to use.
     # Ref: https://kubernetes.io/docs/concepts/storage/volumes/
-    volumes: []
+    volumes:
+      []
       # - name: nfs-home
       #   nfs:
       #     server: nfs-server.example.com
       #     path: /exports/home
     # -- List of volume mounts to use.
     # Ref: https://kubernetes.io/docs/concepts/storage/volumes/
-    volumeMounts: []
+    volumeMounts:
+      []
       # - name: nfs-home
       #   mountPath: /home
 
@@ -459,7 +489,8 @@ nodesets:
       tag: 25.05-ubuntu24.04
     # -- Arguments passed to the image.
     # Ref: https://slurm.schedmd.com/slurmd.html#SECTION_OPTIONS
-    args: []
+    args:
+      []
       # - -vvv
     # -- Extra configuration added to the `--conf` argument.
     # Ref: https://slurm.schedmd.com/slurm.conf.html#SECTION_NODE-CONFIGURATION
@@ -467,7 +498,8 @@ nodesets:
     # -- (map[string]string \| map[string][]string) Extra configuration added to the `--conf` argument.
     # If `extraConf` is not empty, it takes precedence.
     # Ref: https://slurm.schedmd.com/slurm.conf.html#SECTION_NODE-CONFIGURATION
-    extraConfMap: {}
+    extraConfMap:
+      {}
       # Features: []
       # Gres: []
       # Weight: 1
@@ -481,7 +513,8 @@ nodesets:
       # -- (map[string]string \| map[string][]string) The Slurm partition configuration options added to the partition line.
       # If `config` is not empty, it takes precedence.
       # Ref: https://slurm.schedmd.com/slurm.conf.html#SECTION_PARTITION-CONFIGURATION
-      configMap: {}
+      configMap:
+        {}
         # State: UP
         # MaxTime: UNLIMITED
     # LogFile sidecar configurations.
@@ -493,16 +526,22 @@ nodesets:
         tag: latest
       # -- The container resource limits and requests.
       # Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container
-      resources: {}
+      resources:
+        {}
         # limits:
         #   cpu: 500m
         #   memory: 100Mi
     # -- The container resource limits and requests.
     # Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container
-    resources: {}
+    resources:
+      {}
       # limits:
       #   cpu: 1
       #   memory: 1Gi
+      # DRA ResourceClaim references
+      # claims:
+      #   - name: "gpu-claim"
+      #     request: "gpu-request"
     # -- Enable propagation of container `resources.limits` into slurmd.
     useResourceLimits: true
     # -- (map[string]string) Node label selector for pod assignment.
@@ -514,22 +553,32 @@ nodesets:
     affinity: {}
     # -- Tolerations for pod assignment.
     # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-    tolerations: []
+    tolerations:
+      []
       # - key: nvidia.com/gpu
       #   value: Exists
       #   effect: NoSchedule
     # -- List of volumes to use.
     # Ref: https://kubernetes.io/docs/concepts/storage/volumes/
-    volumes: []
+    volumes:
+      []
       # - name: nfs-home
       #   nfs:
       #     server: nfs-server.example.com
       #     path: /exports/home
     # -- List of volume mounts to use.
     # Ref: https://kubernetes.io/docs/concepts/storage/volumes/
-    volumeMounts: []
+    volumeMounts:
+      []
       # - name: nfs-home
       #   mountPath: /home
+    # DRA ResourceClaims for dynamic resource allocation
+    # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/
+    resourceClaims:
+      []
+      # - name: "gpu-claim"
+      #   source:
+      #     resourceClaimTemplateName: "gpu-claim-template"
 
 # Slurm partition configurations.
 partitions:

--- a/internal/builder/accounting_app.go
+++ b/internal/builder/accounting_app.go
@@ -101,6 +101,7 @@ func (b *Builder) accountingPodTemplate(accounting *slinkyv1alpha1.Accounting) (
 			},
 			NodeSelector:      template.NodeSelector,
 			PriorityClassName: template.PriorityClassName,
+			ResourceClaims:    template.ResourceClaims,
 			Tolerations:       template.Tolerations,
 			Volumes:           utils.MergeList(accountingVolumes(accounting), template.Volumes),
 		},

--- a/internal/builder/compute_app.go
+++ b/internal/builder/compute_app.go
@@ -60,6 +60,7 @@ func (b *Builder) BuildComputePodTemplate(nodeset *slinkyv1alpha1.NodeSet, contr
 			},
 			NodeSelector:      template.NodeSelector,
 			PriorityClassName: template.PriorityClassName,
+			ResourceClaims:    template.ResourceClaims,
 			Tolerations:       template.Tolerations,
 			Volumes:           utils.MergeList(nodesetVolumes(controller), template.Volumes),
 		},

--- a/internal/builder/controller_app.go
+++ b/internal/builder/controller_app.go
@@ -132,6 +132,7 @@ func (b *Builder) controllerPodTemplate(controller *slinkyv1alpha1.Controller) (
 			ImagePullSecrets:  template.ImagePullSecrets,
 			NodeSelector:      template.NodeSelector,
 			PriorityClassName: template.PriorityClassName,
+			ResourceClaims:    template.ResourceClaims,
 			SecurityContext: &corev1.PodSecurityContext{
 				RunAsNonRoot: ptr.To(true),
 				RunAsUser:    ptr.To(slurmUserUid),

--- a/internal/builder/login_app.go
+++ b/internal/builder/login_app.go
@@ -143,6 +143,7 @@ func (b *Builder) loginPodTemplate(loginset *slinkyv1alpha1.LoginSet) (corev1.Po
 			ImagePullSecrets:  template.ImagePullSecrets,
 			NodeSelector:      template.NodeSelector,
 			PriorityClassName: template.PriorityClassName,
+			ResourceClaims:    template.ResourceClaims,
 			Tolerations:       template.Tolerations,
 			Volumes:           utils.MergeList(loginVolumes(loginset, controller), template.Volumes),
 		},

--- a/internal/builder/restapi_app.go
+++ b/internal/builder/restapi_app.go
@@ -99,6 +99,7 @@ func (b *Builder) restapiPodTemplate(restapi *slinkyv1alpha1.RestApi) (corev1.Po
 			ImagePullSecrets:  template.ImagePullSecrets,
 			NodeSelector:      template.NodeSelector,
 			PriorityClassName: template.PriorityClassName,
+			ResourceClaims:    template.ResourceClaims,
 			SecurityContext: &corev1.PodSecurityContext{
 				RunAsNonRoot: ptr.To(true),
 				RunAsUser:    ptr.To(slurmrestdUserUid),


### PR DESCRIPTION
## Summary

This PR adds Dynamic Resource Allocation (DRA) ResourceClaims support to the Slurm operator, enabling integration with Kubernetes dynamic resource allocation. This is critical for the NVIDIA k8s-dra-driver-gpu and advanced GPU resource management.

## Changes

- **API**: Added `ResourceClaims` field to `PodTemplate` struct in `api/v1alpha1/base_types.go`
- **Builders**: Updated all component builders to pass ResourceClaims to PodSpec
- **CRDs**: Auto-generated ResourceClaims schema for all Custom Resources
- **Helm**: Added ResourceClaims support to all CR templates and values.yaml examples

## Breaking Changes

N/A

## Testing Notes

Verified ResourceClaims functionality through comprehensive Helm template rendering. Tested all components generate correct ResourceClaims.

Kubernetes cluster with DynamicResourceAllocation feature gate enabled is needed for testing.

## Additional Context

- Added to all components (not just NodeSets) to maintain API consistency
and prevent misleading CRD schemas that would advertise but ignore ResourceClaims.

