### PR TITLE
Add NVIDIA DCGM GPU-to-job mapping integration

### DIFF
--- a/helm/slurm/README.md
+++ b/helm/slurm/README.md
@@ -115,4 +115,8 @@ Helm Chart for Slurm HPC Workload Manager
 | slurm-exporter.exporter.secretName | string | `"slurm-token-exporter"` |  |
 | slurm-exporter.exporter.tolerations | list | `[]` |  |
 | slurmKeyRef | secretKeyRef | `{}` | Slurm shared authentication key. If empty, one will be generated and used. Ref: https://slurm.schedmd.com/authentication.html#slurm |
+| vendor.nvidia.dcgm.autoDetect | bool | `true` | Auto-detect NVIDIA GPU nodesets based on nvidia.com/gpu resource limits |
+| vendor.nvidia.dcgm.enabled | bool | `false` | Enable DCGM GPU-to-job mapping integration |
+| vendor.nvidia.dcgm.jobMappingDir | string | `"/var/lib/dcgm-exporter/job-mapping"` | Directory path where GPU-to-job mapping files will be stored |
+| vendor.nvidia.dcgm.scriptPriority | string | `"90"` | Script execution priority (lower numbers run first) |
 

--- a/helm/slurm/README.md
+++ b/helm/slurm/README.md
@@ -115,7 +115,6 @@ Helm Chart for Slurm HPC Workload Manager
 | slurm-exporter.exporter.secretName | string | `"slurm-token-exporter"` |  |
 | slurm-exporter.exporter.tolerations | list | `[]` |  |
 | slurmKeyRef | secretKeyRef | `{}` | Slurm shared authentication key. If empty, one will be generated and used. Ref: https://slurm.schedmd.com/authentication.html#slurm |
-| vendor.nvidia.dcgm.autoDetect | bool | `true` | Auto-detect NVIDIA GPU nodesets based on nvidia.com/gpu resource limits |
 | vendor.nvidia.dcgm.enabled | bool | `false` | Enable DCGM GPU-to-job mapping integration |
 | vendor.nvidia.dcgm.jobMappingDir | string | `"/var/lib/dcgm-exporter/job-mapping"` | Directory path where GPU-to-job mapping files will be stored |
 | vendor.nvidia.dcgm.scriptPriority | string | `"90"` | Script execution priority (lower numbers run first) |

--- a/helm/slurm/_vendor/nvidia/dcgm/README.md
+++ b/helm/slurm/_vendor/nvidia/dcgm/README.md
@@ -12,7 +12,6 @@ vendor:
     dcgm:
       enabled: true
       jobMappingDir: "/var/lib/dcgm-exporter/job-mapping"
-      autoDetect: true
       scriptPriority: "90"
 ```
 

--- a/helm/slurm/_vendor/nvidia/dcgm/README.md
+++ b/helm/slurm/_vendor/nvidia/dcgm/README.md
@@ -1,0 +1,36 @@
+# NVIDIA DCGM Integration for Slurm
+
+This integration provides GPU-to-job mapping for NVIDIA DCGM Exporter, enabling GPU metrics to be labeled with Slurm job IDs.
+
+## Configuration
+
+Add to your `values.yaml`:
+
+```yaml
+vendor:
+  nvidia:
+    dcgm:
+      enabled: true
+      jobMappingDir: "/var/lib/dcgm-exporter/job-mapping"
+      autoDetect: true
+      scriptPriority: "90"
+```
+
+## How It Works
+
+1. **Auto-detects** nodesets with `nvidia.com/gpu` resource limits
+2. **Adds prolog/epilog scripts** that create/cleanup GPU job mapping files
+3. **Mounts volume** at `/var/lib/dcgm-exporter/job-mapping` for DCGM exporter access
+
+## Testing
+
+Submit a GPU job and verify mapping files:
+
+```bash
+# Submit job
+sbatch --gres=gpu:2 --wrap="nvidia-smi; sleep 60"
+
+# Check mapping files (inside slurmd pod)
+ls /var/lib/dcgm-exporter/job-mapping/
+# Should show files like: 0, 1 (containing job ID)
+```

--- a/helm/slurm/_vendor/nvidia/dcgm/example-values.yaml
+++ b/helm/slurm/_vendor/nvidia/dcgm/example-values.yaml
@@ -1,0 +1,27 @@
+# Example configuration for DCGM GPU-to-job mapping integration
+
+# Enable DCGM integration
+vendor:
+  nvidia:
+    dcgm:
+      enabled: true
+      jobMappingDir: "/var/lib/dcgm-exporter/job-mapping"
+      autoDetect: true
+      scriptPriority: "90"
+
+# Example GPU nodeset that will be auto-detected
+nodesets:
+  gpu-nodes:
+    enabled: true
+    replicas: 1
+    image:
+      repository: ghcr.io/slinkyproject/slurmd
+      tag: 25.05-ubuntu24.04
+    resources:
+      limits:
+        nvidia.com/gpu: 2 # This triggers DCGM auto-detection
+        memory: 16Gi
+    logfile:
+      image:
+        repository: docker.io/library/alpine
+        tag: latest

--- a/helm/slurm/_vendor/nvidia/dcgm/example-values.yaml
+++ b/helm/slurm/_vendor/nvidia/dcgm/example-values.yaml
@@ -6,10 +6,9 @@ vendor:
     dcgm:
       enabled: true
       jobMappingDir: "/var/lib/dcgm-exporter/job-mapping"
-      autoDetect: true
       scriptPriority: "90"
 
-# Example GPU nodeset that will be auto-detected
+# Example GPU nodeset that will be automatically detected
 nodesets:
   gpu-nodes:
     enabled: true
@@ -19,7 +18,7 @@ nodesets:
       tag: 25.05-ubuntu24.04
     resources:
       limits:
-        nvidia.com/gpu: 2 # This triggers DCGM auto-detection
+        nvidia.com/gpu: 2 # This triggers automatic DCGM integration
         memory: 16Gi
     logfile:
       image:

--- a/helm/slurm/_vendor/nvidia/dcgm/scripts/90-epilog-dcgm.sh
+++ b/helm/slurm/_vendor/nvidia/dcgm/scripts/90-epilog-dcgm.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (C) SchedMD LLC.
+# SPDX-FileCopyrightText: Copyright (C) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# DCGM GPU-to-Job Mapping Epilog Script
+# 
+# This script runs when jobs complete on GPU nodes and cleans up job mapping files
+# to prevent stale job mappings in the DCGM exporter.
+
+function log_msg() {
+  echo "[$(date)] [$$] $*" >&2
+}
+
+function set_globals() {
+  declare -g METRICS_DIR="__JOB_MAPPING_DIR__"
+}
+
+function clean_gpu_job_files() {
+  if [[ -z ${CUDA_VISIBLE_DEVICES:-} ]]; then
+    log_msg "no gres cuda devices requested by user"
+    return
+  fi
+
+  mapfile -t -d ',' cuda_devs<<<"${CUDA_VISIBLE_DEVICES:-}"
+  cuda_devs[-1]="${cuda_devs[-1]%$'\n'}"
+
+  for gpu_id in "${cuda_devs[@]}"; do
+    log_msg "removing ${METRICS_DIR:-}/${gpu_id:-99}"
+    rm -f "${METRICS_DIR:-}/${gpu_id:-99}" || log_msg "unable to remove file ${METRICS_DIR:-}/${gpu_id:-99}"
+  done
+}
+
+set -o nounset -o errexit -o pipefail -o errtrace
+set_globals
+clean_gpu_job_files

--- a/helm/slurm/_vendor/nvidia/dcgm/scripts/90-prolog-dcgm.sh
+++ b/helm/slurm/_vendor/nvidia/dcgm/scripts/90-prolog-dcgm.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (C) SchedMD LLC.
+# SPDX-FileCopyrightText: Copyright (C) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# DCGM GPU-to-Job Mapping Prolog Script
+# 
+# This script runs when jobs start on GPU nodes and creates job mapping files
+# for the DCGM exporter to correlate GPU metrics with Slurm job IDs.
+
+function log_msg() {
+  echo "[$(date)] [$$] $*" >&2
+}
+
+function set_globals() {
+  declare -g METRICS_DIR="__JOB_MAPPING_DIR__"
+}
+
+function make_gpu_job_files() {
+  if [[ -z ${CUDA_VISIBLE_DEVICES:-} ]]; then
+    log_msg "no gres cuda devices requested by user"
+    return
+  fi
+
+  if [[ ! -d "${METRICS_DIR:-}" ]]; then
+    mkdir -p "${METRICS_DIR:-}" || (log_msg "unable to create the data dir ${METRICS_DIR:-missing}"; return)
+  fi
+
+  mapfile -t -d ',' cuda_devs<<<"${CUDA_VISIBLE_DEVICES:-}"
+  cuda_devs[-1]="${cuda_devs[-1]%$'\n'}"
+
+  for gpu_id in "${cuda_devs[@]}"; do
+    log_msg "writing ${METRICS_DIR:-}/${gpu_id:-99}"
+    printf "%s" "${SLURM_JOB_ID:-0}" > "${METRICS_DIR:-}/${gpu_id:-99}" || log_msg "unable to write job file"
+  done
+}
+
+set -o nounset -o errexit -o pipefail -o errtrace
+set_globals
+make_gpu_job_files

--- a/helm/slurm/templates/_helpers/dcgm.tpl
+++ b/helm/slurm/templates/_helpers/dcgm.tpl
@@ -8,7 +8,7 @@ SPDX-License-Identifier: Apache-2.0
 Check if DCGM integration is enabled
 */}}
 {{- define "slurm.dcgm.enabled" -}}
-{{- and .Values.vendor.nvidia.dcgm.enabled .Values.vendor.nvidia.dcgm.autoDetect -}}
+{{- .Values.vendor.nvidia.dcgm.enabled -}}
 {{- end }}
 
 {{/*

--- a/helm/slurm/templates/_helpers/dcgm.tpl
+++ b/helm/slurm/templates/_helpers/dcgm.tpl
@@ -1,0 +1,50 @@
+{{- /*
+SPDX-FileCopyrightText: Copyright (C) SchedMD LLC.
+SPDX-FileCopyrightText: Copyright (C) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
+
+{{/*
+Check if DCGM integration is enabled
+*/}}
+{{- define "slurm.dcgm.enabled" -}}
+{{- and .Values.vendor.nvidia.dcgm.enabled .Values.vendor.nvidia.dcgm.autoDetect -}}
+{{- end }}
+
+{{/*
+Get the DCGM job mapping directory
+*/}}
+{{- define "slurm.dcgm.jobMappingDir" -}}
+{{- .Values.vendor.nvidia.dcgm.jobMappingDir | default "/var/lib/dcgm-exporter/job-mapping" -}}
+{{- end }}
+
+{{/*
+Check if a nodeset has GPU resources allocated
+*/}}
+{{- define "slurm.dcgm.nodesetHasGPU" -}}
+{{- $hasGPU := false -}}
+{{- with .resources -}}
+  {{- with .limits -}}
+    {{- if index . "nvidia.com/gpu" -}}
+      {{- $hasGPU = true -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- print $hasGPU -}}
+{{- end }}
+
+{{/*
+Generate DCGM prolog script content
+*/}}
+{{- define "slurm.dcgm.prologScript" -}}
+{{- $jobMappingDir := include "slurm.dcgm.jobMappingDir" . -}}
+{{- .Files.Get "_vendor/nvidia/dcgm/scripts/90-prolog-dcgm.sh" | replace "__JOB_MAPPING_DIR__" $jobMappingDir -}}
+{{- end }}
+
+{{/*
+Generate DCGM epilog script content
+*/}}
+{{- define "slurm.dcgm.epilogScript" -}}
+{{- $jobMappingDir := include "slurm.dcgm.jobMappingDir" . -}}
+{{- .Files.Get "_vendor/nvidia/dcgm/scripts/90-epilog-dcgm.sh" | replace "__JOB_MAPPING_DIR__" $jobMappingDir -}}
+{{- end }}

--- a/helm/slurm/templates/controller/controller-cr.yaml
+++ b/helm/slurm/templates/controller/controller-cr.yaml
@@ -41,14 +41,21 @@ spec:
   configFiles:
     {{- toYaml . | nindent 4 }}
   {{- end }}{{- /* with .Values.configFiles */}}
-  {{- with .Values.prologScripts }}
+  {{- $prologScripts := .Values.prologScripts | default dict }}
+  {{- $epilogScripts := .Values.epilogScripts | default dict }}
+  {{- if (include "slurm.dcgm.enabled" .) }}
+    {{- $scriptPriority := .Values.vendor.nvidia.dcgm.scriptPriority | default "90" }}
+    {{- $prologScripts = merge $prologScripts (dict (printf "%s-prolog-dcgm.sh" $scriptPriority) (include "slurm.dcgm.prologScript" .)) }}
+    {{- $epilogScripts = merge $epilogScripts (dict (printf "%s-epilog-dcgm.sh" $scriptPriority) (include "slurm.dcgm.epilogScript" .)) }}
+  {{- end }}
+  {{- with $prologScripts }}
   prologScripts:
     {{- toYaml . | nindent 4 }}
-  {{- end }}{{- /* with .Values.prologScripts */}}
-  {{- with .Values.epilogScripts }}
+  {{- end }}{{- /* with $prologScripts */}}
+  {{- with $epilogScripts }}
   epilogScripts:
     {{- toYaml . | nindent 4 }}
-  {{- end }}{{- /* with .Values.epilogScripts */}}
+  {{- end }}{{- /* with $epilogScripts */}}
   template:
     metadata:
       labels:

--- a/helm/slurm/templates/nodeset/nodeset-cr.yaml
+++ b/helm/slurm/templates/nodeset/nodeset-cr.yaml
@@ -58,10 +58,15 @@ spec:
       resources:
         {{- toYaml . | nindent 8 }}
       {{- end }}{{- /* with $nodeset.resources */}}
-      {{- with $nodeset.volumeMounts }}
+      {{- $volumeMounts := $nodeset.volumeMounts | default list }}
+      {{- if and (include "slurm.dcgm.enabled" $) (include "slurm.dcgm.nodesetHasGPU" $nodeset | eq "true") }}
+        {{- $dcgmVolumeMount := dict "name" "dcgm-job-mapping" "mountPath" (include "slurm.dcgm.jobMappingDir" $) }}
+        {{- $volumeMounts = append $volumeMounts $dcgmVolumeMount }}
+      {{- end }}
+      {{- with $volumeMounts }}
       volumeMounts:
         {{- toYaml . | nindent 8 }}
-      {{- end }}{{- /* with $nodeset.volumeMounts */}}
+      {{- end }}{{- /* with $volumeMounts */}}
     logfile:
       image: {{ include "format-image" $nodeset.logfile.image }}
       imagePullPolicy: {{ $.Values.imagePullPolicy }}
@@ -82,10 +87,15 @@ spec:
       {{- toYaml . | nindent 6 }}
     {{- end }}{{- /* with $nodeset.tolerations */}}
     priorityClassName: {{ $.Values.priorityClassName }}
-    {{- with $nodeset.volumes }}
+    {{- $volumes := $nodeset.volumes | default list }}
+    {{- if and (include "slurm.dcgm.enabled" $) (include "slurm.dcgm.nodesetHasGPU" $nodeset | eq "true") }}
+      {{- $dcgmVolume := dict "name" "dcgm-job-mapping" "hostPath" (dict "path" (include "slurm.dcgm.jobMappingDir" $) "type" "DirectoryOrCreate") }}
+      {{- $volumes = append $volumes $dcgmVolume }}
+    {{- end }}
+    {{- with $volumes }}
     volumes:
       {{- toYaml . | nindent 6 }}
-    {{- end }}{{- /* with $nodeset.volumes */}}
+    {{- end }}{{- /* with $volumes */}}
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:

--- a/helm/slurm/values.yaml
+++ b/helm/slurm/values.yaml
@@ -12,8 +12,7 @@ namespaceOverride: null
 
 # -- Set the secrets for image pull.
 # Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-imagePullSecrets:
-  []
+imagePullSecrets: []
   # - name: regcred
 
 # -- Set the image pull policy.
@@ -27,16 +26,14 @@ priorityClassName: null
 # -- (secretKeyRef) Slurm shared authentication key.
 # If empty, one will be generated and used.
 # Ref: https://slurm.schedmd.com/authentication.html#slurm
-slurmKeyRef:
-  {}
+slurmKeyRef: {}
   # name: slurm-auth-slurm
   # key: slurm.key
 
 # -- (secretKeyRef) Slurm cluster JWT HS256 authentication key.
 # If empty, one will be generated and used.
 # Ref: https://slurm.schedmd.com/authentication.html#jwt
-jwtHs256KeyRef:
-  {}
+jwtHs256KeyRef: {}
   # name: slurm-auth-jwths256
   # key: jwt_hs256.key
 
@@ -47,8 +44,7 @@ clusterName: null
 
 # -- (map[string]string) Extra Slurm config files to be mounted.
 # Ref: https://slurm.schedmd.com/man_index.html#configuration_files
-configFiles:
-  {}
+configFiles: {}
   # Ref: https://slurm.schedmd.com/cgroup.conf.html
   # cgroup.conf: |
   #   CgroupPlugin=autodetect
@@ -80,8 +76,7 @@ configFiles:
 # Ref: https://slurm.schedmd.com/slurm.conf.html#OPT_Prolog
 # Ref: https://slurm.schedmd.com/prolog_epilog.html
 # Ref: https://en.wikipedia.org/wiki/Shebang_(Unix)
-prologScripts:
-  {}
+prologScripts: {}
   # 00-empty.sh: |
   #   #!/usr/bin/env bash
   #   set -euo pipefail
@@ -93,8 +88,7 @@ prologScripts:
 # Ref: https://slurm.schedmd.com/slurm.conf.html#OPT_Epilog
 # Ref: https://slurm.schedmd.com/prolog_epilog.html
 # Ref: https://en.wikipedia.org/wiki/Shebang_(Unix)
-epilogScripts:
-  {}
+epilogScripts: {}
   # 00-empty.sh: |
   #   #!/usr/bin/env bash
   #   set -euo pipefail
@@ -109,8 +103,7 @@ authcred:
     tag: 25.05-ubuntu24.04
   # -- The container resource limits and requests.
   # Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container
-  resources:
-    {}
+  resources: {}
     # limits:
     #   cpu: 1
     #   memory: 1Gi
@@ -124,8 +117,7 @@ controller:
     tag: 25.05-ubuntu24.04
   # -- Arguments passed to the image.
   # Ref: https://slurm.schedmd.com/slurmctld.html#SECTION_OPTIONS
-  args:
-    []
+  args: []
     # - -vvv
   # -- Extra Slurm configuration lines appended to `slurm.conf`.
   # Ref: https://slurm.schedmd.com/slurm.conf.html
@@ -133,8 +125,7 @@ controller:
   # -- (map[string]string \| map[string][]string) Extra Slurm configuration lines appended to `slurm.conf`.
   # If `extraConf` is not empty, it takes precedence.
   # Ref: https://slurm.schedmd.com/slurmdbd.conf.html
-  extraConfMap:
-    {}
+  extraConfMap: {}
     # DebugFlags: []
     # MinJobAge: 2
     # SchedulerParameters: []
@@ -170,11 +161,10 @@ controller:
       tag: 25.05-ubuntu24.04
     # -- The container resource limits and requests.
     # Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container
-    resources:
-      {}
+    resources: {}
       # limits:
-      # cpu: 500m
-      # memory: 100Mi
+        # cpu: 500m
+        # memory: 100Mi
   # LogFile sidecar configurations.
   logfile:
     # -- The image to use, `${repository}:${tag}`.
@@ -184,15 +174,13 @@ controller:
       tag: latest
     # -- The container resource limits and requests.
     # Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container
-    resources:
-      {}
+    resources: {}
       # limits:
       #   cpu: 500m
       #   memory: 100Mi
   # -- The container resource limits and requests.
   # Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container
-  resources:
-    {}
+  resources: {}
     # limits:
     #   cpu: 1
     #   memory: 1Gi
@@ -205,15 +193,13 @@ controller:
   affinity: {}
   # -- Tolerations for pod assignment.
   # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-  tolerations:
-    []
+  tolerations: []
     # - key: key1
     #   operator: Exists
     #   effect: NoSchedule
   # -- The service configuration.
   # Ref: https://kubernetes.io/docs/concepts/services-networking/service/
-  service:
-    {}
+  service: {}
     # type: LoadBalancer
     # port: 6817
     # loadBalancerIP: ""
@@ -229,21 +215,18 @@ restapi:
     tag: 25.05-ubuntu24.04
   # -- Environment passed to the image.
   # Ref: https://slurm.schedmd.com/slurmrestd.html#SECTION_ENVIRONMENT-VARIABLES
-  env:
-    []
+  env: []
     # - name: SLURMRESTD_YAML
     #   value: pretty
   # -- Arguments passed to the image.
   # Ref: https://slurm.schedmd.com/slurmrestd.html#SECTION_OPTIONS
-  args:
-    []
+  args: []
     # - -vvv
   # -- Number of replicas to deploy.
   replicas: 1
   # -- The container resource limits and requests.
   # Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container
-  resources:
-    {}
+  resources: {}
     # limits:
     #   cpu: 1
     #   memory: 1Gi
@@ -256,15 +239,13 @@ restapi:
   affinity: {}
   # -- Tolerations for pod assignment.
   # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-  tolerations:
-    []
+  tolerations: []
     # - key: key1
     #   operator: Exists
     #   effect: NoSchedule
   # -- The service configuration.
   # Ref: https://kubernetes.io/docs/concepts/services-networking/service/
-  service:
-    {}
+  service: {}
     # type: ClusterIP
     # port: 6820
     # loadBalancerIP: ""
@@ -295,8 +276,7 @@ accounting:
     tag: 25.05-ubuntu24.04
   # -- Arguments passed to the image.
   # Ref: https://slurm.schedmd.com/slurmdbd.html#SECTION_OPTIONS
-  args:
-    []
+  args: []
     # - -vvv
   # -- Extra Slurm configuration lines appended to `slurmdbd.conf`.
   # Ref: https://slurm.schedmd.com/slurm.conf.html
@@ -304,8 +284,7 @@ accounting:
   # -- (map[string]string \| map[string][]string) Extra Slurm configuration lines appended to `slurmdbd.conf`.
   # If `extraConf` is not empty, it takes precedence.
   # Ref: https://slurm.schedmd.com/slurmdbd.conf.html
-  extraConfMap:
-    {}
+  extraConfMap: {}
     # CommitDelay: 1
     # DebugLevel: debug2
     # DebugFlags: []
@@ -344,15 +323,13 @@ accounting:
       tag: 25.05-ubuntu24.04
     # -- The container resource limits and requests.
     # Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container
-    resources:
-      {}
+    resources: {}
       # limits:
       #   cpu: 500m
       #   memory: 100Mi
   # -- The container resource limits and requests.
   # Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container
-  resources:
-    {}
+  resources: {}
     # limits:
     #   cpu: 1
     #   memory: 1Gi
@@ -365,15 +342,13 @@ accounting:
   affinity: {}
   # -- Tolerations for pod assignment.
   # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-  tolerations:
-    []
+  tolerations: []
     # - key: key1
     #   operator: Exists
     #   effect: NoSchedule
   # -- The service configuration.
   # Ref: https://kubernetes.io/docs/concepts/services-networking/service/
-  service:
-    {}
+  service: {}
     # type: LoadBalancer
     # loadBalancerIP: ""
     # externalIPs: []
@@ -393,8 +368,7 @@ loginsets:
       repository: ghcr.io/slinkyproject/login
       tag: 25.05-ubuntu24.04
     # -- Environment passed to the image.
-    env:
-      {}
+    env: {}
       # - name: SACKD_OPTIONS
       #   value: -vvv
     # -- SSH public keys to write into `/root/.ssh/authorized_keys`.
@@ -432,8 +406,7 @@ loginsets:
       #     - SYS_CHROOT
     # -- The container resource limits and requests.
     # Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container
-    resources:
-      {}
+    resources: {}
       # limits:
       #   cpu: 1
       #   memory: 1Gi
@@ -446,8 +419,7 @@ loginsets:
     affinity: {}
     # -- Tolerations for pod assignment.
     # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-    tolerations:
-      []
+    tolerations: []
       # - key: key1
       #   operator: Exists
       #   effect: NoSchedule
@@ -461,16 +433,14 @@ loginsets:
       # externalName: ""
     # -- List of volumes to use.
     # Ref: https://kubernetes.io/docs/concepts/storage/volumes/
-    volumes:
-      []
+    volumes: []
       # - name: nfs-home
       #   nfs:
       #     server: nfs-server.example.com
       #     path: /exports/home
     # -- List of volume mounts to use.
     # Ref: https://kubernetes.io/docs/concepts/storage/volumes/
-    volumeMounts:
-      []
+    volumeMounts: []
       # - name: nfs-home
       #   mountPath: /home
 
@@ -489,8 +459,7 @@ nodesets:
       tag: 25.05-ubuntu24.04
     # -- Arguments passed to the image.
     # Ref: https://slurm.schedmd.com/slurmd.html#SECTION_OPTIONS
-    args:
-      []
+    args: []
       # - -vvv
     # -- Extra configuration added to the `--conf` argument.
     # Ref: https://slurm.schedmd.com/slurm.conf.html#SECTION_NODE-CONFIGURATION
@@ -498,8 +467,7 @@ nodesets:
     # -- (map[string]string \| map[string][]string) Extra configuration added to the `--conf` argument.
     # If `extraConf` is not empty, it takes precedence.
     # Ref: https://slurm.schedmd.com/slurm.conf.html#SECTION_NODE-CONFIGURATION
-    extraConfMap:
-      {}
+    extraConfMap: {}
       # Features: []
       # Gres: []
       # Weight: 1
@@ -513,8 +481,7 @@ nodesets:
       # -- (map[string]string \| map[string][]string) The Slurm partition configuration options added to the partition line.
       # If `config` is not empty, it takes precedence.
       # Ref: https://slurm.schedmd.com/slurm.conf.html#SECTION_PARTITION-CONFIGURATION
-      configMap:
-        {}
+      configMap: {}
         # State: UP
         # MaxTime: UNLIMITED
     # LogFile sidecar configurations.
@@ -526,15 +493,13 @@ nodesets:
         tag: latest
       # -- The container resource limits and requests.
       # Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container
-      resources:
-        {}
+      resources: {}
         # limits:
         #   cpu: 500m
         #   memory: 100Mi
     # -- The container resource limits and requests.
     # Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container
-    resources:
-      {}
+    resources: {}
       # limits:
       #   cpu: 1
       #   memory: 1Gi
@@ -549,23 +514,20 @@ nodesets:
     affinity: {}
     # -- Tolerations for pod assignment.
     # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-    tolerations:
-      []
+    tolerations: []
       # - key: nvidia.com/gpu
       #   value: Exists
       #   effect: NoSchedule
     # -- List of volumes to use.
     # Ref: https://kubernetes.io/docs/concepts/storage/volumes/
-    volumes:
-      []
+    volumes: []
       # - name: nfs-home
       #   nfs:
       #     server: nfs-server.example.com
       #     path: /exports/home
     # -- List of volume mounts to use.
     # Ref: https://kubernetes.io/docs/concepts/storage/volumes/
-    volumeMounts:
-      []
+    volumeMounts: []
       # - name: nfs-home
       #   mountPath: /home
 

--- a/helm/slurm/values.yaml
+++ b/helm/slurm/values.yaml
@@ -12,7 +12,8 @@ namespaceOverride: null
 
 # -- Set the secrets for image pull.
 # Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-imagePullSecrets: []
+imagePullSecrets:
+  []
   # - name: regcred
 
 # -- Set the image pull policy.
@@ -26,14 +27,16 @@ priorityClassName: null
 # -- (secretKeyRef) Slurm shared authentication key.
 # If empty, one will be generated and used.
 # Ref: https://slurm.schedmd.com/authentication.html#slurm
-slurmKeyRef: {}
+slurmKeyRef:
+  {}
   # name: slurm-auth-slurm
   # key: slurm.key
 
 # -- (secretKeyRef) Slurm cluster JWT HS256 authentication key.
 # If empty, one will be generated and used.
 # Ref: https://slurm.schedmd.com/authentication.html#jwt
-jwtHs256KeyRef: {}
+jwtHs256KeyRef:
+  {}
   # name: slurm-auth-jwths256
   # key: jwt_hs256.key
 
@@ -44,7 +47,8 @@ clusterName: null
 
 # -- (map[string]string) Extra Slurm config files to be mounted.
 # Ref: https://slurm.schedmd.com/man_index.html#configuration_files
-configFiles: {}
+configFiles:
+  {}
   # Ref: https://slurm.schedmd.com/cgroup.conf.html
   # cgroup.conf: |
   #   CgroupPlugin=autodetect
@@ -76,7 +80,8 @@ configFiles: {}
 # Ref: https://slurm.schedmd.com/slurm.conf.html#OPT_Prolog
 # Ref: https://slurm.schedmd.com/prolog_epilog.html
 # Ref: https://en.wikipedia.org/wiki/Shebang_(Unix)
-prologScripts: {}
+prologScripts:
+  {}
   # 00-empty.sh: |
   #   #!/usr/bin/env bash
   #   set -euo pipefail
@@ -88,7 +93,8 @@ prologScripts: {}
 # Ref: https://slurm.schedmd.com/slurm.conf.html#OPT_Epilog
 # Ref: https://slurm.schedmd.com/prolog_epilog.html
 # Ref: https://en.wikipedia.org/wiki/Shebang_(Unix)
-epilogScripts: {}
+epilogScripts:
+  {}
   # 00-empty.sh: |
   #   #!/usr/bin/env bash
   #   set -euo pipefail
@@ -103,7 +109,8 @@ authcred:
     tag: 25.05-ubuntu24.04
   # -- The container resource limits and requests.
   # Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container
-  resources: {}
+  resources:
+    {}
     # limits:
     #   cpu: 1
     #   memory: 1Gi
@@ -117,7 +124,8 @@ controller:
     tag: 25.05-ubuntu24.04
   # -- Arguments passed to the image.
   # Ref: https://slurm.schedmd.com/slurmctld.html#SECTION_OPTIONS
-  args: []
+  args:
+    []
     # - -vvv
   # -- Extra Slurm configuration lines appended to `slurm.conf`.
   # Ref: https://slurm.schedmd.com/slurm.conf.html
@@ -125,7 +133,8 @@ controller:
   # -- (map[string]string \| map[string][]string) Extra Slurm configuration lines appended to `slurm.conf`.
   # If `extraConf` is not empty, it takes precedence.
   # Ref: https://slurm.schedmd.com/slurmdbd.conf.html
-  extraConfMap: {}
+  extraConfMap:
+    {}
     # DebugFlags: []
     # MinJobAge: 2
     # SchedulerParameters: []
@@ -161,10 +170,11 @@ controller:
       tag: 25.05-ubuntu24.04
     # -- The container resource limits and requests.
     # Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container
-    resources: {}
+    resources:
+      {}
       # limits:
-        # cpu: 500m
-        # memory: 100Mi
+      # cpu: 500m
+      # memory: 100Mi
   # LogFile sidecar configurations.
   logfile:
     # -- The image to use, `${repository}:${tag}`.
@@ -174,13 +184,15 @@ controller:
       tag: latest
     # -- The container resource limits and requests.
     # Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container
-    resources: {}
+    resources:
+      {}
       # limits:
       #   cpu: 500m
       #   memory: 100Mi
   # -- The container resource limits and requests.
   # Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container
-  resources: {}
+  resources:
+    {}
     # limits:
     #   cpu: 1
     #   memory: 1Gi
@@ -193,13 +205,15 @@ controller:
   affinity: {}
   # -- Tolerations for pod assignment.
   # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-  tolerations: []
+  tolerations:
+    []
     # - key: key1
     #   operator: Exists
     #   effect: NoSchedule
   # -- The service configuration.
   # Ref: https://kubernetes.io/docs/concepts/services-networking/service/
-  service: {}
+  service:
+    {}
     # type: LoadBalancer
     # port: 6817
     # loadBalancerIP: ""
@@ -215,18 +229,21 @@ restapi:
     tag: 25.05-ubuntu24.04
   # -- Environment passed to the image.
   # Ref: https://slurm.schedmd.com/slurmrestd.html#SECTION_ENVIRONMENT-VARIABLES
-  env: []
+  env:
+    []
     # - name: SLURMRESTD_YAML
     #   value: pretty
   # -- Arguments passed to the image.
   # Ref: https://slurm.schedmd.com/slurmrestd.html#SECTION_OPTIONS
-  args: []
+  args:
+    []
     # - -vvv
   # -- Number of replicas to deploy.
   replicas: 1
   # -- The container resource limits and requests.
   # Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container
-  resources: {}
+  resources:
+    {}
     # limits:
     #   cpu: 1
     #   memory: 1Gi
@@ -239,13 +256,15 @@ restapi:
   affinity: {}
   # -- Tolerations for pod assignment.
   # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-  tolerations: []
+  tolerations:
+    []
     # - key: key1
     #   operator: Exists
     #   effect: NoSchedule
   # -- The service configuration.
   # Ref: https://kubernetes.io/docs/concepts/services-networking/service/
-  service: {}
+  service:
+    {}
     # type: ClusterIP
     # port: 6820
     # loadBalancerIP: ""
@@ -276,7 +295,8 @@ accounting:
     tag: 25.05-ubuntu24.04
   # -- Arguments passed to the image.
   # Ref: https://slurm.schedmd.com/slurmdbd.html#SECTION_OPTIONS
-  args: []
+  args:
+    []
     # - -vvv
   # -- Extra Slurm configuration lines appended to `slurmdbd.conf`.
   # Ref: https://slurm.schedmd.com/slurm.conf.html
@@ -284,7 +304,8 @@ accounting:
   # -- (map[string]string \| map[string][]string) Extra Slurm configuration lines appended to `slurmdbd.conf`.
   # If `extraConf` is not empty, it takes precedence.
   # Ref: https://slurm.schedmd.com/slurmdbd.conf.html
-  extraConfMap: {}
+  extraConfMap:
+    {}
     # CommitDelay: 1
     # DebugLevel: debug2
     # DebugFlags: []
@@ -323,13 +344,15 @@ accounting:
       tag: 25.05-ubuntu24.04
     # -- The container resource limits and requests.
     # Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container
-    resources: {}
+    resources:
+      {}
       # limits:
       #   cpu: 500m
       #   memory: 100Mi
   # -- The container resource limits and requests.
   # Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container
-  resources: {}
+  resources:
+    {}
     # limits:
     #   cpu: 1
     #   memory: 1Gi
@@ -342,13 +365,15 @@ accounting:
   affinity: {}
   # -- Tolerations for pod assignment.
   # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-  tolerations: []
+  tolerations:
+    []
     # - key: key1
     #   operator: Exists
     #   effect: NoSchedule
   # -- The service configuration.
   # Ref: https://kubernetes.io/docs/concepts/services-networking/service/
-  service: {}
+  service:
+    {}
     # type: LoadBalancer
     # loadBalancerIP: ""
     # externalIPs: []
@@ -368,7 +393,8 @@ loginsets:
       repository: ghcr.io/slinkyproject/login
       tag: 25.05-ubuntu24.04
     # -- Environment passed to the image.
-    env: {}
+    env:
+      {}
       # - name: SACKD_OPTIONS
       #   value: -vvv
     # -- SSH public keys to write into `/root/.ssh/authorized_keys`.
@@ -406,7 +432,8 @@ loginsets:
       #     - SYS_CHROOT
     # -- The container resource limits and requests.
     # Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container
-    resources: {}
+    resources:
+      {}
       # limits:
       #   cpu: 1
       #   memory: 1Gi
@@ -419,7 +446,8 @@ loginsets:
     affinity: {}
     # -- Tolerations for pod assignment.
     # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-    tolerations: []
+    tolerations:
+      []
       # - key: key1
       #   operator: Exists
       #   effect: NoSchedule
@@ -433,14 +461,16 @@ loginsets:
       # externalName: ""
     # -- List of volumes to use.
     # Ref: https://kubernetes.io/docs/concepts/storage/volumes/
-    volumes: []
+    volumes:
+      []
       # - name: nfs-home
       #   nfs:
       #     server: nfs-server.example.com
       #     path: /exports/home
     # -- List of volume mounts to use.
     # Ref: https://kubernetes.io/docs/concepts/storage/volumes/
-    volumeMounts: []
+    volumeMounts:
+      []
       # - name: nfs-home
       #   mountPath: /home
 
@@ -459,7 +489,8 @@ nodesets:
       tag: 25.05-ubuntu24.04
     # -- Arguments passed to the image.
     # Ref: https://slurm.schedmd.com/slurmd.html#SECTION_OPTIONS
-    args: []
+    args:
+      []
       # - -vvv
     # -- Extra configuration added to the `--conf` argument.
     # Ref: https://slurm.schedmd.com/slurm.conf.html#SECTION_NODE-CONFIGURATION
@@ -467,7 +498,8 @@ nodesets:
     # -- (map[string]string \| map[string][]string) Extra configuration added to the `--conf` argument.
     # If `extraConf` is not empty, it takes precedence.
     # Ref: https://slurm.schedmd.com/slurm.conf.html#SECTION_NODE-CONFIGURATION
-    extraConfMap: {}
+    extraConfMap:
+      {}
       # Features: []
       # Gres: []
       # Weight: 1
@@ -481,7 +513,8 @@ nodesets:
       # -- (map[string]string \| map[string][]string) The Slurm partition configuration options added to the partition line.
       # If `config` is not empty, it takes precedence.
       # Ref: https://slurm.schedmd.com/slurm.conf.html#SECTION_PARTITION-CONFIGURATION
-      configMap: {}
+      configMap:
+        {}
         # State: UP
         # MaxTime: UNLIMITED
     # LogFile sidecar configurations.
@@ -493,13 +526,15 @@ nodesets:
         tag: latest
       # -- The container resource limits and requests.
       # Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container
-      resources: {}
+      resources:
+        {}
         # limits:
         #   cpu: 500m
         #   memory: 100Mi
     # -- The container resource limits and requests.
     # Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container
-    resources: {}
+    resources:
+      {}
       # limits:
       #   cpu: 1
       #   memory: 1Gi
@@ -514,20 +549,23 @@ nodesets:
     affinity: {}
     # -- Tolerations for pod assignment.
     # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-    tolerations: []
+    tolerations:
+      []
       # - key: nvidia.com/gpu
       #   value: Exists
       #   effect: NoSchedule
     # -- List of volumes to use.
     # Ref: https://kubernetes.io/docs/concepts/storage/volumes/
-    volumes: []
+    volumes:
+      []
       # - name: nfs-home
       #   nfs:
       #     server: nfs-server.example.com
       #     path: /exports/home
     # -- List of volume mounts to use.
     # Ref: https://kubernetes.io/docs/concepts/storage/volumes/
-    volumeMounts: []
+    volumeMounts:
+      []
       # - name: nfs-home
       #   mountPath: /home
 
@@ -551,3 +589,19 @@ partitions:
       State: UP
       Default: "YES"
       MaxTime: UNLIMITED
+
+# Vendor specific integration and configurations.
+vendor:
+  # NVIDIA
+  nvidia:
+    # DCGM integration for GPU metrics with job labeling
+    # Ref: https://github.com/NVIDIA/dcgm-exporter
+    dcgm:
+      # -- Enable DCGM GPU-to-job mapping integration
+      enabled: false
+      # -- Directory path where GPU-to-job mapping files will be stored
+      jobMappingDir: "/var/lib/dcgm-exporter/job-mapping"
+      # -- Auto-detect NVIDIA GPU nodesets based on nvidia.com/gpu resource limits
+      autoDetect: true
+      # -- Script execution priority (lower numbers run first)
+      scriptPriority: "90"

--- a/helm/slurm/values.yaml
+++ b/helm/slurm/values.yaml
@@ -563,7 +563,5 @@ vendor:
       enabled: false
       # -- Directory path where GPU-to-job mapping files will be stored
       jobMappingDir: "/var/lib/dcgm-exporter/job-mapping"
-      # -- Auto-detect NVIDIA GPU nodesets based on nvidia.com/gpu resource limits
-      autoDetect: true
       # -- Script execution priority (lower numbers run first)
       scriptPriority: "90"


### PR DESCRIPTION
## Summary

This PR implements [NVIDIA DCGM GPU-to-job mapping](https://github.com/NVIDIA/dcgm-exporter?tab=readme-ov-file#enabling-hpc-job-mapping-on-dcgm-exporter) integration for the Slurm Helm chart, enabling GPU metrics to be labeled with Slurm job IDs for enhanced observability.

## Breaking Changes

N/A. This is an optional feature that is disabled by default.

## Testing Notes

### Verification Steps

1. **Enable DCGM integration** in values.yaml
2. **Deploy GPU nodesets** with `nvidia.com/gpu` resource limits
3. **Submit GPU job**: `sbatch --gres=gpu:1 --wrap="nvidia-smi; sleep 60"`
4. **Verify mapping files**: Check `/var/lib/dcgm-exporter/job-mapping/` in slurmd pods

### Test Evidence

**Environment**: NVIDIA H100 80GB HBM3, Slurm 25.05.0

**GPU Job Execution**:
```bash
$ kubectl exec slurm-dcgm-controller-0 -n slinky -c slurmctld -- sbatch --gres=gpu:1 --wrap="echo 'Testing DCGM'; nvidia-smi -L"
Submitted batch job 7

$ kubectl exec slurm-dcgm-controller-0 -n slinky -c slurmctld -- squeue
JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)
    7       all     wrap    slurm  R       0:10      1 gpu-test-0
```

**Job Mapping Files**:
```bash
$ kubectl exec slurm-dcgm-compute-gpu-test-0 -n slinky -c slurmd -- ls -la /var/lib/dcgm-exporter/job-mapping/
total 4
drwxr-xr-x 2 root root 23 Aug 18 15:19 .
drwxr-xr-x 3 root root 33 Aug 18 15:14 ..
-rw-r--r-- 1 root root  1 Aug 18 15:19 0

$ kubectl exec slurm-dcgm-compute-gpu-test-0 -n slinky -c slurmd -- cat /var/lib/dcgm-exporter/job-mapping/0
7
```

## Additional Context

This implementation follows the proposed vendor integration pattern (discussed in https://support.schedmd.com/ ticket) and provides a foundation for additional NVIDIA GPU integrations in the future.
