### PR TITLE
Add NodeSet event handling to reconciler

### DIFF
--- a/internal/controller/controller/controller_controller.go
+++ b/internal/controller/controller/controller_controller.go
@@ -121,6 +121,10 @@ func (r *ControllerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&corev1.Secret{}, &secretEventHandler{
 			Reader: r.Client,
 		}).
+		Watches(&slinkyv1alpha1.NodeSet{}, &nodesetEventHandler{
+			Reader:      r.Client,
+			refResolver: r.refResolver,
+		}).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: maxConcurrentReconciles,
 		}).

--- a/internal/utils/refresolver/refresolver.go
+++ b/internal/utils/refresolver/refresolver.go
@@ -107,6 +107,22 @@ func (r *RefResolver) GetControllersForAccounting(ctx context.Context, accountin
 	return out, nil
 }
 
+func (r *RefResolver) GetControllersForNodeSet(ctx context.Context, nodeset *slinkyv1alpha1.NodeSet) (*slinkyv1alpha1.ControllerList, error) {
+	list := &slinkyv1alpha1.ControllerList{}
+	if err := r.client.List(ctx, list); err != nil {
+		return nil, err
+	}
+
+	out := &slinkyv1alpha1.ControllerList{}
+	for _, item := range list.Items {
+		if nodeset.Spec.ControllerRef.IsMatch(utils.NamespacedName(&item)) {
+			out.Items = append(out.Items, item)
+		}
+	}
+
+	return out, nil
+}
+
 func (r *RefResolver) GetSecretKeyRef(ctx context.Context, selector *slinkyv1alpha1.SecretKeySelector, namespace string) ([]byte, error) {
 	secret := &corev1.Secret{}
 	key := types.NamespacedName{


### PR DESCRIPTION
## Summary

I noticed that new NodeSets with `partition.enabled: true` are added via Helm upgrade, the Slurm controller does not automatically create the individual partitions. Nodes are correctly added to the global "all" partition, but individual NodeSet partitions remain missing until manual controller restart.

### Initial Setup

1. Deploy Slurm cluster with existing nodesets (gpu-1, gpu-2, cpu-1, cpu-2, cpu-3, debug)
2. Verify all partitions are working correctly

### Bug Reproduction

1. Add new nodeset `cpu-4` with `partition.enabled: true` to values file:

   ```yaml
   cpu-4:
     enabled: true
     partition:
       enabled: true
       configMap:
         State: UP
         ...
   ```

2. Deploy via Helm upgrade:

   ```bash
   helm upgrade slurm ./helm/slurm -f values.yaml -n slinky
   ```

3. Verify nodeset is created successfully:
   ```bash
   kubectl get nodesets -n slinky
   # Shows: slurm-compute-cpu-4   1   1   1   2m
   ```

### Expected vs Actual Behavior

**Expected:**

- New `cpu-4` partition should appear automatically

**Actual:**

```bash
# BEFORE restart - cpu-4 partition MISSING
PARTITION AVAIL  TIMELIMIT  NODES  STATE NODELIST
gpu-1        up 1-00:00:00      1   idle gpu-1-0
cpu-1        up 1-00:00:00      1   idle cpu-1-0
cpu-2        up 1-00:00:00      2   idle cpu-2-[0-1]
cpu-3        up 1-00:00:00      2   idle cpu-3-[0-1]
debug        up 1-00:00:00      1   idle debug-0
gpu-2        up 1-00:00:00      1   idle gpu-2-0
all*         up 1-00:00:00      9   idle cpu-1-0,cpu-2-[0-1],cpu-3-[0-1],cpu-4-0,debug-0,gpu-1-0,gpu-2-0
```

**Note**: The `cpu-4-0` node IS added to the "all" partition (9 nodes total), but the individual `cpu-4` partition is missing.

Manual restart of the controller resolves the issue:

```bash
kubectl delete pod slurm-controller-0 -n slinky
# Wait for restart, then check again
```

**After restart - cpu-4 partition is available:**

```bash
PARTITION AVAIL  TIMELIMIT  NODES  STATE NODELIST
gpu-2        up 1-00:00:00      1   idle gpu-2-0
cpu-4        up   12:00:00      1   idle cpu-4-0  # ← NOW APPEARS!
gpu-1        up 1-00:00:00      1   idle gpu-1-0
cpu-1        up 1-00:00:00      1   idle cpu-1-0
cpu-2        up 1-00:00:00      2   idle cpu-2-[0-1]
cpu-3        up 1-00:00:00      2   idle cpu-3-[0-1]
debug        up 1-00:00:00      1   idle debug-0
all*         up 1-00:00:00      9   idle cpu-1-0,cpu-2-[0-1],cpu-3-[0-1],cpu-4-0,debug-0,gpu-1-0,gpu-2-0
```

## Breaking Changes

None. This is a backward-compatible bug fix that only adds missing functionality.

## Testing Notes

**Reproduction Test**:
1. Deploy Slurm cluster with existing nodesets
2. Add a new nodeset with `partition.enabled: true` via Helm upgrade
3. Verify the individual partition appears automatically in `sinfo` output

**Verification Results**:

After fix: cpu-5 partition appears automatically (without controller restart)
```bash
PARTITION AVAIL  TIMELIMIT  NODES  STATE NODELIST
cpu-5        up    8:00:00      1   idle cpu-5-0  # ← added by controller without restart
all*         up 1-00:00:00     10   idle cpu-1-0,cpu-2-[0-1],cpu-3-[0-1],cpu-4-0,cpu-5-0,debug-0,gpu-1-0,gpu-2-0
```

