### PR TITLE
Remove automatic DaemonSet tolerations from NodeSet pods

### DIFF
--- a/internal/controller/nodeset/utils/utils.go
+++ b/internal/controller/nodeset/utils/utils.go
@@ -13,7 +13,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8scontroller "k8s.io/kubernetes/pkg/controller"
-	daemonutil "k8s.io/kubernetes/pkg/controller/daemon/util"
 
 	slinkyv1alpha1 "github.com/SlinkyProject/slurm-operator/api/v1alpha1"
 	"github.com/SlinkyProject/slurm-operator/internal/builder"
@@ -48,9 +47,6 @@ func NewNodeSetPod(
 	// WARNING: Do not use the spec.NodeName otherwise the Pod scheduler will
 	// be avoided and priorityClass will not be honored.
 	pod.Spec.NodeName = ""
-
-	// Adopt DaemonSet pod tolerations.
-	daemonutil.AddOrUpdateDaemonPodTolerations(&pod.Spec)
 
 	return pod
 }


### PR DESCRIPTION
## Summary

Removes automatic DaemonSet tolerations from NodeSet pods to prevent them from scheduling on cordoned nodes during maintenance.

**Problem**: NodeSet pods currently inherit DaemonSet tolerations (including `node.kubernetes.io/unschedulable`), allowing them to bypass Kubernetes node cordoning. This defeats the purpose of cordoning nodes for maintenance and can lead to workloads running on unstable nodes.

**Root Cause**: The `daemonutil.AddOrUpdateDaemonPodTolerations()` call was retained from the original StatefulSet+DaemonSet implementation.

**Solution**: Remove the automatic DaemonSet tolerations. Users who need specific tolerations can configure them explicitly via the NodeSet spec's `tolerations` field.

## Breaking Changes

N/A

The change only removes _automatic_ tolerations that were overriding user intent and standard Kubernetes scheduling behavior.

## Testing Notes

**Tested:**
- All existing tests pass
- NodeSet pod creation works correctly
- User-specified tolerations are preserved
