### PR TITLE
Add missing volume mount merging

### DIFF
--- a/internal/builder/compute_app.go
+++ b/internal/builder/compute_app.go
@@ -164,6 +164,7 @@ func slurmdContainer(nodeset *slinkyv1alpha1.NodeSet, controller *slinkyv1alpha1
 			{Name: slurmLogFileVolume, MountPath: slurmLogFileDir},
 		},
 	}
+	out.VolumeMounts = append(out.VolumeMounts, template.Container.VolumeMounts...)
 	return out
 }
 

--- a/internal/builder/login_app.go
+++ b/internal/builder/login_app.go
@@ -293,6 +293,7 @@ func loginContainer(container slinkyv1alpha1.Container, controller *slinkyv1alph
 			{Name: sssdConfVolume, MountPath: sssdConfFilePath, SubPath: sssdConfFile, ReadOnly: true},
 		},
 	}
+	out.VolumeMounts = append(out.VolumeMounts, container.VolumeMounts...)
 	return out
 }
 


### PR DESCRIPTION
<!--
Feature requests, code contributions, and bug reports are welcome!
Github/Gitlab submitted issues and PRs/MRs are handled on a best effort basis.
The SchedMD official issue tracker is at <https://support.schedmd.com/>.
-->

## Summary

This PR fixes a critical bug where volume mounts defined in NodeSet and LoginSet Custom Resource specifications were not being applied to compute and login pods, despite being correctly configured in Helm values and visible in the Custom Resource specs.

Root Cause: The `slurmdContainer()` and `loginContainer()` functions are missing the critical line that merges template-specified volume mounts with the hardcoded system volume mounts.

## Breaking Changes

N/A

## Testing Notes

Before Fix:

- Define volume mounts in NodeSet or LoginSet Custom Resource specifications
- Observe that volume mounts appear in the CR spec but are missing from actual pod containers
- kubectl describe pod <compute-pod> shows only hardcoded system volume mounts

After Fix:

- Define volume mounts in NodeSet or LoginSet Custom Resource specifications
- Verify that volume mounts appear in both the CR spec AND actual pod containers
- `kubectl describe pod <compute-pod>` shows both system and user-defined volume mounts
