### PR TITLE
Include imagePullSecrets in login deployment

### DIFF
--- a/helm/slurm/templates/login/login-deployment.yaml
+++ b/helm/slurm/templates/login/login-deployment.yaml
@@ -28,6 +28,7 @@ spec:
       enableServiceLinks: false
       dnsConfig:
         {{- include "slurm.dnsConfig" . | nindent 8 }}
+        {{- include "slurm.imagePullSecrets" . | nindent 6 }}
       initContainers:
         - name: init
           image: {{ include "slurm.authcred.imageRef" . }}


### PR DESCRIPTION
In v0.3.1, the login Deployment template is missing imagePullSecrets, so `slurm.imagePullSecrets` isn’t applied.

Tested with `helm template` and `helm install` on a k8s.