### PR TITLE
Add hostname services for NodeSets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to this project will be documented in this file.
 - Added `NVIDIA/dcgm-exporter` integration to Slurm helm chart.
 - Added conditions to slurmd pods to reflect Slurm node state
 - Added helm chart `kubeVersion` requirements.
+- Added cluster-wide hostname services for NodeSets to enable direct pod-to-pod communication using predictable hostnames
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,13 @@ The operator supports NodeSet scale to zero, scaling the resource down to zero
 replicas. Hence, any Horizontal Pod Autoscaler (HPA) that also support scale to
 zero can be best paired with NodeSets.
 
+NodeSets support optional hostname services, which create a cluster-wide headless
+Kubernetes service for all worker pods in the same Slurm cluster. This enables 
+hostname-based resolution between login pods and worker pods, enabling direct 
+pod-to-pod communication using predictable hostnames (e.g., `cpu-1-0`, `gpu-2-1`). 
+The hostname service uses a multi-owner pattern and is automatically managed during 
+scaling operations.
+
 ### LoginSets
 
 A set of homogeneous login nodes (submit node, jump host) for Slurm, which

--- a/internal/builder/common.go
+++ b/internal/builder/common.go
@@ -14,6 +14,7 @@ import (
 	clientutils "github.com/SlinkyProject/slurm-client/pkg/utils"
 
 	slinkyv1alpha1 "github.com/SlinkyProject/slurm-operator/api/v1alpha1"
+	"github.com/SlinkyProject/slurm-operator/internal/builder/labels"
 )
 
 const (
@@ -209,4 +210,12 @@ func mergeEnvVar(envVarList1, envVarList2 []corev1.EnvVar, sep string) []corev1.
 		envVarList = append(envVarList, envVar)
 	}
 	return envVarList
+}
+
+// slurmClusterWorkerServiceName returns the service name for all worker nodes in a Slurm cluster
+// Format: "slurm-workers-{controller-name}"
+func slurmClusterWorkerServiceName(controllerName string) string {
+	// Derive service name dynamically from component constants
+	componentPlural := labels.WorkerComp + "s"
+	return fmt.Sprintf("slurm-%s-%s", componentPlural, controllerName)
 }

--- a/internal/builder/labels/labels.go
+++ b/internal/builder/labels/labels.go
@@ -11,11 +11,12 @@ import (
 
 // Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels
 const (
-	appLabel       = "app.kubernetes.io/name"
-	instanceLabel  = "app.kubernetes.io/instance"
-	componentLabel = "app.kubernetes.io/component"
-	partOfLabel    = "app.kubernetes.io/part-of"
-	managedbyLabel = "app.kubernetes.io/managed-by"
+	appLabel        = "app.kubernetes.io/name"
+	instanceLabel   = "app.kubernetes.io/instance"
+	componentLabel  = "app.kubernetes.io/component"
+	partOfLabel     = "app.kubernetes.io/part-of"
+	managedbyLabel  = "app.kubernetes.io/managed-by"
+	controllerLabel = "slinky.slurm.net/controller"
 )
 
 type Builder struct {
@@ -50,6 +51,11 @@ func (b *Builder) WithPartOf(instance string) *Builder {
 
 func (b *Builder) WithManagedBy(component string) *Builder {
 	b.labels[managedbyLabel] = component
+	return b
+}
+
+func (b *Builder) WithController(controller string) *Builder {
+	b.labels[controllerLabel] = controller
 	return b
 }
 
@@ -120,7 +126,8 @@ func (b *Builder) WithWorkerSelectorLabels(obj *slinkyv1alpha1.NodeSet) *Builder
 func (b *Builder) WithWorkerLabels(obj *slinkyv1alpha1.NodeSet) *Builder {
 	return b.
 		WithWorkerSelectorLabels(obj).
-		WithComponent(WorkerComp)
+		WithComponent(WorkerComp).
+		WithController(obj.Spec.ControllerRef.Name)
 }
 
 func (b *Builder) WithLoginSelectorLabels(obj *slinkyv1alpha1.LoginSet) *Builder {

--- a/internal/builder/labels/labels_test.go
+++ b/internal/builder/labels/labels_test.go
@@ -76,6 +76,16 @@ func TestNewBuilder(t *testing.T) {
 			},
 		},
 		{
+			name: "WithController",
+			args: args{
+				builder: NewBuilder().
+					WithController("slurm"),
+			},
+			want: map[string]string{
+				controllerLabel: "slurm",
+			},
+		},
+		{
 			name: "WithLabels",
 			args: args{
 				builder: NewBuilder().

--- a/internal/builder/login_app_test.go
+++ b/internal/builder/login_app_test.go
@@ -94,6 +94,15 @@ func TestBuilder_BuildLogin(t *testing.T) {
 			case got.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort != LoginPort:
 				t.Errorf("Template.Spec.Containers[0].Ports[0].ContainerPort = %v , want = %v",
 					got.Spec.Template.Spec.Containers[0].Ports[0].Name, LoginPort)
+
+			case got.Spec.Template.Spec.Subdomain == "":
+				t.Errorf("Template.Spec.Subdomain = %v , want = non-empty", got.Spec.Template.Spec.Subdomain)
+
+			case got.Spec.Template.Spec.DNSConfig == nil:
+				t.Errorf("Template.Spec.DNSConfig = %v , want = non-nil", got.Spec.Template.Spec.DNSConfig)
+
+			case len(got.Spec.Template.Spec.DNSConfig.Searches) == 0:
+				t.Errorf("len(Template.Spec.DNSConfig.Searches) = %v , want = > 0", len(got.Spec.Template.Spec.DNSConfig.Searches))
 			}
 		})
 	}

--- a/internal/builder/nodeset_hostname_service.go
+++ b/internal/builder/nodeset_hostname_service.go
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: Copyright (C) SchedMD LLC.
+// SPDX-License-Identifier: Apache-2.0
+
+package builder
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	slinkyv1alpha1 "github.com/SlinkyProject/slurm-operator/api/v1alpha1"
+	"github.com/SlinkyProject/slurm-operator/internal/builder/labels"
+	"github.com/SlinkyProject/slurm-operator/internal/utils/structutils"
+)
+
+// BuildClusterWideWorkerService creates a single headless service for ALL worker NodeSets in the same Slurm cluster
+// The service name is derived from the Slurm cluster name to support hybrid deployments
+func (b *Builder) BuildClusterWideWorkerService(nodeset *slinkyv1alpha1.NodeSet) (*corev1.Service, error) {
+	// Service name based on Slurm cluster (ControllerRef.Name)
+	serviceName := slurmClusterWorkerServiceName(nodeset.Spec.ControllerRef.Name)
+
+	opts := ServiceOpts{
+		Key: types.NamespacedName{
+			Name:      serviceName,
+			Namespace: nodeset.Namespace,
+		},
+		Metadata:    slinkyv1alpha1.Metadata{},
+		ServiceSpec: corev1.ServiceSpec{},
+		Selector: labels.NewBuilder().
+			WithApp(labels.WorkerApp).
+			WithController(nodeset.Spec.ControllerRef.Name).
+			Build(),
+		Headless: true,
+	}
+
+	// Add labels
+	opts.Metadata.Labels = structutils.MergeMaps(opts.Metadata.Labels,
+		labels.NewBuilder().WithWorkerLabels(nodeset).Build())
+
+	// Add slurmd port
+	port := corev1.ServicePort{
+		Name:       labels.WorkerApp,
+		Protocol:   corev1.ProtocolTCP,
+		Port:       SlurmdPort,
+		TargetPort: intstr.FromString(labels.WorkerApp),
+	}
+	opts.Ports = append(opts.Ports, port)
+
+	// Build service with NodeSet
+	return b.BuildService(opts, nodeset)
+}

--- a/internal/builder/nodeset_hostname_service_test.go
+++ b/internal/builder/nodeset_hostname_service_test.go
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: Copyright (C) SchedMD LLC.
+// SPDX-License-Identifier: Apache-2.0
+
+package builder
+
+import (
+	"testing"
+
+	slinkyv1alpha1 "github.com/SlinkyProject/slurm-operator/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestBuilder_BuildClusterWideWorkerService(t *testing.T) {
+	type fields struct {
+		client client.Client
+	}
+	type args struct {
+		nodeset *slinkyv1alpha1.NodeSet
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "default",
+			fields: fields{
+				client: fake.NewFakeClient(),
+			},
+			args: args{
+				nodeset: &slinkyv1alpha1.NodeSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gpu-1",
+						Namespace: "slinky",
+					},
+					Spec: slinkyv1alpha1.NodeSetSpec{
+						ControllerRef: slinkyv1alpha1.ObjectReference{
+							Name: "slurm",
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := New(tt.fields.client)
+			got, err := b.BuildClusterWideWorkerService(tt.args.nodeset)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Builder.BuildClusterWideWorkerService() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			switch {
+			case err != nil:
+				return
+
+			case got.Name != slurmClusterWorkerServiceName(tt.args.nodeset.Spec.ControllerRef.Name):
+				t.Errorf("Service.Name = %v, want %v", got.Name, slurmClusterWorkerServiceName(tt.args.nodeset.Spec.ControllerRef.Name))
+
+			case got.Spec.ClusterIP != corev1.ClusterIPNone:
+				t.Errorf("Service.Spec.ClusterIP = %v, want headless service", got.Spec.ClusterIP)
+
+			case len(got.Spec.Ports) != 1 || got.Spec.Ports[0].Port != SlurmdPort:
+				t.Errorf("Service.Spec.Ports = %v, want single port %d", got.Spec.Ports, SlurmdPort)
+			}
+		})
+	}
+}

--- a/internal/builder/worker_app_test.go
+++ b/internal/builder/worker_app_test.go
@@ -42,6 +42,9 @@ func TestBuilder_BuildWorkerPodTemplate(t *testing.T) {
 						Name: "slurm-foo",
 					},
 					Spec: slinkyv1alpha1.NodeSetSpec{
+						ControllerRef: slinkyv1alpha1.ObjectReference{
+							Name: "slurm",
+						},
 						ExtraConf: strings.Join([]string{
 							"features=bar",
 							"weight=5",
@@ -89,6 +92,15 @@ func TestBuilder_BuildWorkerPodTemplate(t *testing.T) {
 			case got.Spec.Containers[0].Ports[0].ContainerPort != SlurmdPort:
 				t.Errorf("Containers[0].Ports[0].ContainerPort = %v , want = %v",
 					got.Spec.Containers[0].Ports[0].Name, SlurmdPort)
+
+			case got.Spec.Subdomain == "":
+				t.Errorf("Subdomain = %v , want = non-empty", got.Spec.Subdomain)
+
+			case got.Spec.DNSConfig == nil:
+				t.Errorf("DNSConfig = %v , want = non-nil", got.Spec.DNSConfig)
+
+			case len(got.Spec.DNSConfig.Searches) == 0:
+				t.Errorf("len(DNSConfig.Searches) = %v , want = > 0", len(got.Spec.DNSConfig.Searches))
 			}
 		})
 	}

--- a/internal/controller/nodeset/nodeset_controller.go
+++ b/internal/controller/nodeset/nodeset_controller.go
@@ -88,6 +88,7 @@ type NodeSetReconciler struct {
 //+kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=pods/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
 //+kubebuilder:rbac:groups=apps,resources=controllerrevisions,verbs=get;list;watch;create;update;patch;delete
@@ -145,6 +146,7 @@ func (r *NodeSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Named(ControllerName).
 		For(&slinkyv1alpha1.NodeSet{}).
 		Owns(&corev1.Pod{}).
+		Owns(&corev1.Service{}).
 		Watches(&corev1.Pod{}, podEventHandler).
 		WatchesRawSource(source.Channel(r.EventCh, podEventHandler)).
 		Watches(&slinkyv1alpha1.Controller{}, &controllerEventHandler{

--- a/internal/controller/nodeset/nodeset_sync_test.go
+++ b/internal/controller/nodeset/nodeset_sync_test.go
@@ -37,6 +37,7 @@ import (
 	slurmtypes "github.com/SlinkyProject/slurm-client/pkg/types"
 
 	slinkyv1alpha1 "github.com/SlinkyProject/slurm-operator/api/v1alpha1"
+	"github.com/SlinkyProject/slurm-operator/internal/builder"
 	"github.com/SlinkyProject/slurm-operator/internal/builder/labels"
 	"github.com/SlinkyProject/slurm-operator/internal/clientmap"
 	"github.com/SlinkyProject/slurm-operator/internal/controller/nodeset/podcontrol"
@@ -59,6 +60,7 @@ func newNodeSetController(client client.Client, clientMap *clientmap.ClientMap) 
 		slurmControl:   slurmcontrol.NewSlurmControl(clientMap),
 		expectations:   kubecontroller.NewUIDTrackingControllerExpectations(kubecontroller.NewControllerExpectations()),
 	}
+	r.builder = builder.New(r.Client)
 	return r
 }
 
@@ -1877,6 +1879,48 @@ func Test_findUpdatedPods(t *testing.T) {
 			}
 			if diff := cmp.Diff(tt.wantOldPods, gotOldPodsOrdered); diff != "" {
 				t.Errorf("gotOldPods (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestNodeSetReconciler_syncClusterWideHostnameService(t *testing.T) {
+	utilruntime.Must(slinkyv1alpha1.AddToScheme(clientgoscheme.Scheme))
+	controller := &slinkyv1alpha1.Controller{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "slurm",
+		},
+	}
+	type fields struct {
+		Client client.Client
+	}
+	type args struct {
+		ctx     context.Context
+		nodeset *slinkyv1alpha1.NodeSet
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "success",
+			fields: fields{
+				Client: fake.NewFakeClient(),
+			},
+			args: args{
+				ctx:     context.TODO(),
+				nodeset: newNodeSet("gpu-1", controller.Name, 2),
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newNodeSetController(tt.fields.Client, nil)
+			if err := r.syncClusterWideHostnameService(tt.args.ctx, tt.args.nodeset); (err != nil) != tt.wantErr {
+				t.Errorf("NodeSetReconciler.syncClusterWideHostnameService() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}


### PR DESCRIPTION
<!--
Feature requests, code contributions, and bug reports are welcome!
Github/Gitlab submitted issues and PRs/MRs are handled on a best effort basis.
The SchedMD official issue tracker is at <https://support.schedmd.com/>.
-->

## Summary (updated after discussion with Skyler)

This PR adds hostname services support for LoginSets and Nodesets, enabling login pods to resolve worker pod hostnames using the same cluster-wide headless service pattern as NodeSets. This allows direct pod-to-pod communication from login pods to worker pods using predictable hostnames (e.g., `cpu-1-0`, `gpu-2-1`). This is needed for specific workloads which accessing slurm nodes with their hostnames.

## Breaking Changes

NA

## Testing Notes

- Verified hostname services are created when hostnameServices: true
- Confirmed pods can resolve each other using service names (e.g., getent hosts cpu-3-0)


**Verification Steps:**
Deploy operator with hostname services enabled:
   ```bash
   # Set in values.yaml
   nodesets:
     enableHostnameServices: true
   ```

Verify LoginSet has hostname services enabled:
   ```bash
   kubectl get loginset slurm-login-slinky -o yaml | grep hostnameServices
   # Should show: hostnameServices: true
   ```

Verify NodeSets have hostname services enabled:

   ```bash
   kubectl get nodesets -n slinky -o yaml | grep -A 3 -B 3 "hostnameServices"
   # Should show: hostnameServices: true
   ```

Test hostname resolution from login pod and worker pod:
   ```bash
    kubectl exec -n slinky slurm-login-slinky-558b659966-4sp84 -- getent hosts cpu-1-1
    10.0.129.73     cpu-1-1.slurm-workers-slurm.slinky.svc.cluster.local

    kubectl exec -n slinky slurm-worker-cpu-6-0 -c slurmd -- getent hosts cpu-1-1
    10.0.129.73     cpu-1-1.slurm-workers-slurm.slinky.svc.cluster.local

   ```

```
$ go test ./internal/builder -v -run TestBuilder_BuildNodeSetHostnameService
=== RUN   TestBuilder_BuildNodeSetHostnameService
=== RUN   TestBuilder_BuildNodeSetHostnameService/default
--- PASS: TestBuilder_BuildNodeSetHostnameService (0.03s)
    --- PASS: TestBuilder_BuildNodeSetHostnameService/default (0.03s)
PASS
```

## Additional Context

Use-Cases:

- Login pods connecting directly to specific worker nodes
- Inter-worker communication for distributed workloads
- Debugging and administrative access to specific worker pods
- Applications requiring stable, predictable hostnames 