### PR TITLE
Add pod hostname label for Slurm node mapping

### DIFF
--- a/api/v1alpha1/well_known.go
+++ b/api/v1alpha1/well_known.go
@@ -38,4 +38,8 @@ const (
 	// LabelNodeSetPodIndex indicates the pod's ordinal.
 	// NOTE: Set by the NodeSet controller.
 	LabelNodeSetPodIndex = NodeSetPrefix + "pod-index"
+
+	// LabelNodeSetPodHostname indicates the pod hostname (used as SLURM node name).
+	// NOTE: Set by the NodeSet controller.
+	LabelNodeSetPodHostname = NodeSetPrefix + "pod-hostname"
 )

--- a/internal/controller/nodeset/utils/utils.go
+++ b/internal/controller/nodeset/utils/utils.go
@@ -72,6 +72,7 @@ func UpdateIdentity(nodeset *slinkyv1alpha1.NodeSet, pod *corev1.Pod) {
 	}
 	pod.Labels[slinkyv1alpha1.LabelNodeSetPodName] = pod.Name
 	pod.Labels[slinkyv1alpha1.LabelNodeSetPodIndex] = strconv.Itoa(ordinal)
+	pod.Labels[slinkyv1alpha1.LabelNodeSetPodHostname] = GetNodeName(pod)
 }
 
 // UpdateStorage updates pod's Volumes to conform with the PersistentVolumeClaim of nodeset's templates. If pod has


### PR DESCRIPTION
## Summary

Adds a new label `nodeset.slinky.slurm.net/pod-hostname` to slurmd worker pods containing the pod's hostname, which corresponds to the Slurm node name.

This enables external tools like [topograph](https://github.com/NVIDIA/topograph/blob/main/pkg/engines/slinky/engine.go) to easily identify which Slurm node each Kubernetes pod represents by providing direct access to the hostname that Slurm uses as the node identifier.

## Breaking Changes

N/A

## Testing Notes

- All existing tests pass without modification
- Code compiles successfully with `go build ./...`
- The new label will contain the pod's hostname (e.g., `cpu-1-0`, `gpu-1-0`) which matches the SLURM node names visible in `sinfo` commands
