### PR TITLE
Implement K8s node state synchronization

### DIFF
--- a/api/v1alpha1/well_known.go
+++ b/api/v1alpha1/well_known.go
@@ -27,6 +27,14 @@ const (
 	// workload by. Pods an earlier daedline are preferred to be deleted before pods with a later deadline.
 	// NOTE: this is honored on a best-effort basis, and does not offer guarantees on pod deletion order.
 	AnnotationPodDeadline = NodeSetPrefix + "pod-deadline"
+
+	// AnnotationPodDrainState indicates the current drain state of a NodeSet Pod.
+	// Possible values: "draining", "drained", "undraining"
+	AnnotationPodDrainState = NodeSetPrefix + "pod-drain-state"
+
+	// AnnotationPodDrainReason indicates why a NodeSet Pod was drained.
+	// Possible values: "k8s-node-cordoned", "manual", "scale-in", "update"
+	AnnotationPodDrainReason = NodeSetPrefix + "pod-drain-reason"
 )
 
 // Well Known Labels

--- a/internal/controller/nodeset/nodeset_controller.go
+++ b/internal/controller/nodeset/nodeset_controller.go
@@ -142,12 +142,16 @@ func (r *NodeSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Reader:       mgr.GetCache(),
 		expectations: r.expectations,
 	}
+	nodeEventHandler := &nodeEventHandler{
+		Reader: mgr.GetCache(),
+	}
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(ControllerName).
 		For(&slinkyv1alpha1.NodeSet{}).
 		Owns(&corev1.Pod{}).
 		Owns(&corev1.Service{}).
 		Watches(&corev1.Pod{}, podEventHandler).
+		Watches(&corev1.Node{}, nodeEventHandler).
 		WatchesRawSource(source.Channel(r.EventCh, podEventHandler)).
 		Watches(&slinkyv1alpha1.Controller{}, &controllerEventHandler{
 			Reader:      r.Client,

--- a/internal/controller/nodeset/nodeset_node_eventhandler.go
+++ b/internal/controller/nodeset/nodeset_node_eventhandler.go
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: Copyright (C) SchedMD LLC.
+// SPDX-License-Identifier: Apache-2.0
+
+package nodeset
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	k8slabels "k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	nodesetutils "github.com/SlinkyProject/slurm-operator/internal/controller/nodeset/utils"
+)
+
+var _ handler.EventHandler = &nodeEventHandler{}
+
+type nodeEventHandler struct {
+	client.Reader
+}
+
+// Create implements handler.EventHandler
+func (h *nodeEventHandler) Create(
+	ctx context.Context,
+	evt event.CreateEvent,
+	q workqueue.TypedRateLimitingInterface[reconcile.Request],
+) {
+	// Intentionally blank
+}
+
+// Delete implements handler.EventHandler
+func (h *nodeEventHandler) Delete(
+	ctx context.Context,
+	evt event.DeleteEvent,
+	q workqueue.TypedRateLimitingInterface[reconcile.Request],
+) {
+	// Intentionally blank
+}
+
+// Generic implements handler.EventHandler
+func (h *nodeEventHandler) Generic(
+	ctx context.Context,
+	evt event.GenericEvent,
+	q workqueue.TypedRateLimitingInterface[reconcile.Request],
+) {
+	// Intentionally blank
+}
+
+// Update implements handler.EventHandler
+func (h *nodeEventHandler) Update(
+	ctx context.Context,
+	evt event.UpdateEvent,
+	q workqueue.TypedRateLimitingInterface[reconcile.Request],
+) {
+	oldNode, ok := evt.ObjectOld.(*corev1.Node)
+	if !ok {
+		return
+	}
+	newNode, ok := evt.ObjectNew.(*corev1.Node)
+	if !ok {
+		return
+	}
+
+	// Detect node cordoning/uncordoning
+	if oldNode.Spec.Unschedulable != newNode.Spec.Unschedulable {
+		h.updateNode(ctx, newNode, q)
+	}
+}
+
+func (h *nodeEventHandler) updateNode(
+	ctx context.Context,
+	node *corev1.Node,
+	q workqueue.TypedRateLimitingInterface[reconcile.Request],
+) {
+	logger := log.FromContext(ctx)
+
+	if node.Spec.Unschedulable {
+		logger.Info("Node cordoned - triggering workload coordination", "node", node.Name)
+	} else {
+		logger.Info("Node uncordoned - triggering workload coordination", "node", node.Name)
+	}
+	h.enqueueNodeSetsForNode(ctx, node, q)
+}
+
+// enqueueNodeSetsForNode finds all NodeSets with pods on this node and enqueues them for reconciliation
+func (h *nodeEventHandler) enqueueNodeSetsForNode(
+	ctx context.Context,
+	node *corev1.Node,
+	q workqueue.TypedRateLimitingInterface[reconcile.Request],
+) {
+	logger := log.FromContext(ctx)
+
+	// Find all pods on this node using existing repository pattern
+	podList := &corev1.PodList{}
+	opts := &client.ListOptions{
+		LabelSelector: k8slabels.Everything(),
+	}
+
+	if err := h.List(ctx, podList, opts); err != nil {
+		logger.Error(err, "Failed to list pods", "node", node.Name)
+		return
+	}
+
+	// Filter pods on this specific node and enqueue unique NodeSets for reconciliation
+	nodesetNames := make(map[string]bool)
+	podsOnNode := 0
+	for _, pod := range podList.Items {
+		if pod.Spec.NodeName != node.Name {
+			continue
+		}
+		podsOnNode++
+		if nodesetName := nodesetutils.GetParentName(&pod); nodesetName != "" {
+			if !nodesetNames[nodesetName] {
+				nodesetNames[nodesetName] = true
+				logger.V(1).Info("Enqueueing NodeSet for infrastructure coordination",
+					"nodeset", nodesetName, "node", node.Name, "pod", pod.Name)
+				q.Add(reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Name:      nodesetName,
+						Namespace: pod.Namespace,
+					},
+				})
+			}
+		}
+	}
+
+	if len(nodesetNames) > 0 {
+		logger.V(1).Info("Enqueued NodeSets for infrastructure coordination",
+			"node", node.Name, "nodesets", len(nodesetNames), "pods", podsOnNode)
+	}
+}

--- a/internal/controller/nodeset/nodeset_node_eventhandler_test.go
+++ b/internal/controller/nodeset/nodeset_node_eventhandler_test.go
@@ -1,0 +1,317 @@
+// SPDX-FileCopyrightText: Copyright (C) SchedMD LLC.
+// SPDX-License-Identifier: Apache-2.0
+
+package nodeset
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	slinkyv1alpha1 "github.com/SlinkyProject/slurm-operator/api/v1alpha1"
+)
+
+func Test_nodeEventHandler_Create(t *testing.T) {
+	utilruntime.Must(slinkyv1alpha1.AddToScheme(clientgoscheme.Scheme))
+	type fields struct {
+		Reader client.Reader
+	}
+	type args struct {
+		ctx context.Context
+		evt event.CreateEvent
+		q   workqueue.TypedRateLimitingInterface[reconcile.Request]
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   int
+	}{
+		{
+			name: "Empty",
+			fields: fields{
+				Reader: fake.NewFakeClient(),
+			},
+			args: args{
+				ctx: context.TODO(),
+				evt: event.CreateEvent{},
+				q:   newQueue(),
+			},
+			want: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &nodeEventHandler{
+				Reader: tt.fields.Reader,
+			}
+			h.Create(tt.args.ctx, tt.args.evt, tt.args.q)
+			if got := tt.args.q.Len(); got != tt.want {
+				t.Errorf("nodeEventHandler.Create() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_nodeEventHandler_Delete(t *testing.T) {
+	utilruntime.Must(slinkyv1alpha1.AddToScheme(clientgoscheme.Scheme))
+	type fields struct {
+		Reader client.Reader
+	}
+	type args struct {
+		ctx context.Context
+		evt event.DeleteEvent
+		q   workqueue.TypedRateLimitingInterface[reconcile.Request]
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   int
+	}{
+		{
+			name: "Empty",
+			fields: fields{
+				Reader: fake.NewFakeClient(),
+			},
+			args: args{
+				ctx: context.TODO(),
+				evt: event.DeleteEvent{},
+				q:   newQueue(),
+			},
+			want: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &nodeEventHandler{
+				Reader: tt.fields.Reader,
+			}
+			h.Delete(tt.args.ctx, tt.args.evt, tt.args.q)
+			if got := tt.args.q.Len(); got != tt.want {
+				t.Errorf("nodeEventHandler.Delete() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_nodeEventHandler_Generic(t *testing.T) {
+	utilruntime.Must(slinkyv1alpha1.AddToScheme(clientgoscheme.Scheme))
+	type fields struct {
+		Reader client.Reader
+	}
+	type args struct {
+		ctx context.Context
+		evt event.GenericEvent
+		q   workqueue.TypedRateLimitingInterface[reconcile.Request]
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   int
+	}{
+		{
+			name: "Empty",
+			fields: fields{
+				Reader: fake.NewFakeClient(),
+			},
+			args: args{
+				ctx: context.TODO(),
+				evt: event.GenericEvent{},
+				q:   newQueue(),
+			},
+			want: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &nodeEventHandler{
+				Reader: tt.fields.Reader,
+			}
+			h.Generic(tt.args.ctx, tt.args.evt, tt.args.q)
+			if got := tt.args.q.Len(); got != tt.want {
+				t.Errorf("nodeEventHandler.Generic() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_nodeEventHandler_Update(t *testing.T) {
+	utilruntime.Must(slinkyv1alpha1.AddToScheme(clientgoscheme.Scheme))
+	type fields struct {
+		Reader client.Reader
+	}
+	type args struct {
+		ctx context.Context
+		evt event.UpdateEvent
+		q   workqueue.TypedRateLimitingInterface[reconcile.Request]
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   int
+	}{
+		{
+			name: "Node cordoned - should enqueue NodeSet",
+			fields: fields{
+				Reader: fake.NewFakeClient(
+					&corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "slurm-worker-cpu-1-0",
+							Namespace: "slinky",
+							Labels:    map[string]string{
+							},
+						},
+						Spec: corev1.PodSpec{
+							NodeName: "test-node",
+						},
+					},
+				),
+			},
+			args: args{
+				ctx: context.TODO(),
+				evt: event.UpdateEvent{
+					ObjectOld: &corev1.Node{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-node",
+						},
+						Spec: corev1.NodeSpec{
+							Unschedulable: false,
+						},
+					},
+					ObjectNew: &corev1.Node{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-node",
+						},
+						Spec: corev1.NodeSpec{
+							Unschedulable: true, // Node was cordoned
+						},
+					},
+				},
+				q: newQueue(),
+			},
+			want: 1, // Should enqueue 1 NodeSet for reconciliation
+		},
+		{
+			name: "Node uncordoned - should enqueue NodeSet",
+			fields: fields{
+				Reader: fake.NewFakeClient(
+					&corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "slurm-worker-cpu-1-0",
+							Namespace: "slinky",
+							Labels:    map[string]string{
+							},
+						},
+						Spec: corev1.PodSpec{
+							NodeName: "test-node",
+						},
+					},
+				),
+			},
+			args: args{
+				ctx: context.TODO(),
+				evt: event.UpdateEvent{
+					ObjectOld: &corev1.Node{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-node",
+						},
+						Spec: corev1.NodeSpec{
+							Unschedulable: true,
+						},
+					},
+					ObjectNew: &corev1.Node{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-node",
+						},
+						Spec: corev1.NodeSpec{
+							Unschedulable: false, // Node was uncordoned
+						},
+					},
+				},
+				q: newQueue(),
+			},
+			want: 1, // Should enqueue 1 NodeSet for reconciliation
+		},
+		{
+			name: "No cordon change - should not enqueue",
+			fields: fields{
+				Reader: fake.NewFakeClient(),
+			},
+			args: args{
+				ctx: context.TODO(),
+				evt: event.UpdateEvent{
+					ObjectOld: &corev1.Node{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-node",
+						},
+						Spec: corev1.NodeSpec{
+							Unschedulable: false,
+						},
+					},
+					ObjectNew: &corev1.Node{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-node",
+						},
+						Spec: corev1.NodeSpec{
+							Unschedulable: false, // No change
+						},
+					},
+				},
+				q: newQueue(),
+			},
+			want: 0, // Should not enqueue anything
+		},
+		{
+			name: "No worker pods on node - should not enqueue",
+			fields: fields{
+				Reader: fake.NewFakeClient(), // No pods
+			},
+			args: args{
+				ctx: context.TODO(),
+				evt: event.UpdateEvent{
+					ObjectOld: &corev1.Node{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-node",
+						},
+						Spec: corev1.NodeSpec{
+							Unschedulable: false,
+						},
+					},
+					ObjectNew: &corev1.Node{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-node",
+						},
+						Spec: corev1.NodeSpec{
+							Unschedulable: true,
+						},
+					},
+				},
+				q: newQueue(),
+			},
+			want: 0, // Should not enqueue anything
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &nodeEventHandler{
+				Reader: tt.fields.Reader,
+			}
+			h.Update(tt.args.ctx, tt.args.evt, tt.args.q)
+			if got := tt.args.q.Len(); got != tt.want {
+				t.Errorf("nodeEventHandler.Update() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/controller/nodeset/nodeset_sync.go
+++ b/internal/controller/nodeset/nodeset_sync.go
@@ -286,6 +286,31 @@ func (r *NodeSetReconciler) syncSlurm(
 		slurmNodeName := nodesetutils.GetNodeName(pod)
 		deadline := nodeDeadlines.Peek(slurmNodeName)
 
+		// K8s node state synchronization check
+		node := &corev1.Node{}
+		if err := r.Get(ctx, types.NamespacedName{Name: pod.Spec.NodeName}, node); err == nil {
+			logger := log.FromContext(ctx)
+			podIsCordoned := podutils.IsPodCordon(pod)
+
+			// If K8s node is cordoned but pod isn't, use existing function
+			if node.Spec.Unschedulable && !podIsCordoned {
+				logger.Info("K8s node state synchronization: node cordoned externally, cordoning pod for workload protection",
+					"pod", klog.KObj(pod), "node", node.Name)
+				return r.makePodCordonAndDrain(ctx, nodeset, pod)
+			}
+			// If K8s node is uncordoned but pod is cordoned, use existing function
+			if !node.Spec.Unschedulable && podIsCordoned {
+				logger.Info("K8s node state synchronization: node uncordoned externally, uncordoning pod",
+					"pod", klog.KObj(pod), "node", node.Name)
+				return r.makePodUncordonAndUndrain(ctx, nodeset, pod)
+			}
+		} else {
+			// Node doesn't exist - log and continue processing
+			logger := log.FromContext(ctx)
+			logger.V(1).Info("K8s node state synchronization: node not found, skipping synchronization check",
+				"pod", klog.KObj(pod), "node", pod.Spec.NodeName, "error", err)
+		}
+
 		toUpdate := pod.DeepCopy()
 		if deadline.IsZero() {
 			delete(toUpdate.Annotations, slinkyv1alpha1.AnnotationPodDeadline)
@@ -300,6 +325,22 @@ func (r *NodeSetReconciler) syncSlurm(
 			reason := fmt.Sprintf("Pod (%s) is cordoned", klog.KObj(pod))
 			if err := r.slurmControl.MakeNodeDrain(ctx, nodeset, pod, reason); err != nil {
 				return err
+			}
+
+			// Update drain state annotation for cordoned pods
+			if isDrained, err := r.slurmControl.IsNodeDrained(ctx, nodeset, pod); err == nil {
+				toUpdate := pod.DeepCopy()
+				if toUpdate.Annotations == nil {
+					toUpdate.Annotations = make(map[string]string)
+				}
+				if isDrained {
+					toUpdate.Annotations[slinkyv1alpha1.AnnotationPodDrainState] = "drained"
+				} else {
+					toUpdate.Annotations[slinkyv1alpha1.AnnotationPodDrainState] = "draining"
+				}
+				if err := r.Patch(ctx, toUpdate, client.StrategicMergeFrom(pod)); err != nil {
+					return err
+				}
 			}
 		} else {
 			reason := fmt.Sprintf("Pod (%s) is uncordoned", klog.KObj(pod))
@@ -363,7 +404,8 @@ func (r *NodeSetReconciler) doPodScaleOut(
 
 	uncordonFn := func(i int) error {
 		pod := pods[i]
-		return r.makePodUncordonAndUndrain(ctx, nodeset, pod)
+
+		return r.handleUncordonWithSynchronization(ctx, nodeset, pod)
 	}
 	if _, err := utils.SlowStartBatch(len(pods), utils.SlowStartInitialBatchSize, uncordonFn); err != nil {
 		return err
@@ -465,7 +507,8 @@ func (r *NodeSetReconciler) doPodScaleIn(
 
 	uncordonFn := func(i int) error {
 		pod := podsToKeep[i]
-		return r.makePodUncordonAndUndrain(ctx, nodeset, pod)
+
+		return r.handleUncordonWithSynchronization(ctx, nodeset, pod)
 	}
 	if _, err := utils.SlowStartBatch(len(podsToKeep), utils.SlowStartInitialBatchSize, uncordonFn); err != nil {
 		return err
@@ -593,7 +636,8 @@ func (r *NodeSetReconciler) doPodProcessing(
 	_, podsToKeep := r.splitUpdatePods(ctx, nodeset, pods, hash)
 	uncordonFn := func(i int) error {
 		pod := podsToKeep[i]
-		return r.makePodUncordonAndUndrain(ctx, nodeset, pod)
+
+		return r.handleUncordonWithSynchronization(ctx, nodeset, pod)
 	}
 	if _, err := utils.SlowStartBatch(len(podsToKeep), utils.SlowStartInitialBatchSize, uncordonFn); err != nil {
 		return err
@@ -654,6 +698,22 @@ func (r *NodeSetReconciler) makePodCordonAndDrain(
 		return err
 	}
 
+	// Check if drain is complete and update annotation
+	if isDrained, err := r.slurmControl.IsNodeDrained(ctx, nodeset, pod); err == nil {
+		toUpdate := pod.DeepCopy()
+		if toUpdate.Annotations == nil {
+			toUpdate.Annotations = make(map[string]string)
+		}
+		if isDrained {
+			toUpdate.Annotations[slinkyv1alpha1.AnnotationPodDrainState] = "drained"
+		} else {
+			toUpdate.Annotations[slinkyv1alpha1.AnnotationPodDrainState] = "draining"
+		}
+		if err := r.Patch(ctx, toUpdate, client.StrategicMergeFrom(pod)); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -674,6 +734,8 @@ func (r *NodeSetReconciler) makePodCordon(
 		toUpdate.Annotations = make(map[string]string)
 	}
 	toUpdate.Annotations[slinkyv1alpha1.AnnotationPodCordon] = "true"
+	toUpdate.Annotations[slinkyv1alpha1.AnnotationPodDrainState] = "draining"
+	toUpdate.Annotations[slinkyv1alpha1.AnnotationPodDrainReason] = "k8s-node-cordoned"
 	if err := r.Patch(ctx, toUpdate, client.StrategicMergeFrom(pod)); err != nil {
 		return err
 	}
@@ -710,11 +772,44 @@ func (r *NodeSetReconciler) makePodUncordon(ctx context.Context, pod *corev1.Pod
 	toUpdate := pod.DeepCopy()
 	logger.Info("Uncordon Pod", "Pod", klog.KObj(toUpdate))
 	delete(toUpdate.Annotations, slinkyv1alpha1.AnnotationPodCordon)
+	delete(toUpdate.Annotations, slinkyv1alpha1.AnnotationPodDrainState)
+	delete(toUpdate.Annotations, slinkyv1alpha1.AnnotationPodDrainReason)
 	if err := r.Patch(ctx, toUpdate, client.StrategicMergeFrom(pod)); err != nil {
 		return err
 	}
 
 	return nil
+}
+
+// shouldSkipUncordon checks if a pod should skip uncordoning due to external node cordoning
+func (r *NodeSetReconciler) shouldSkipUncordon(ctx context.Context, pod *corev1.Pod) bool {
+	// Check if pod is currently cordoned
+	if !podutils.IsPodCordon(pod) {
+		return false // Pod is not cordoned, no need to skip
+	}
+
+	// Check if the Kubernetes node is externally cordoned
+	node := &corev1.Node{}
+	if err := r.Get(ctx, types.NamespacedName{Name: pod.Spec.NodeName}, node); err != nil {
+		return false // Can't get node info, don't skip
+	}
+
+	// Skip uncordoning if node is externally cordoned
+	return node.Spec.Unschedulable
+}
+
+// handleUncordonWithSynchronization handles uncordoning with K8s node state synchronization
+func (r *NodeSetReconciler) handleUncordonWithSynchronization(ctx context.Context, nodeset *slinkyv1alpha1.NodeSet, pod *corev1.Pod) error {
+	logger := log.FromContext(ctx)
+
+	// K8s node state synchronization: skip uncordoning pods on externally cordoned nodes
+	if r.shouldSkipUncordon(ctx, pod) {
+		logger.V(1).Info("Skipping uncordon for pod on externally cordoned node",
+			"pod", klog.KObj(pod), "node", pod.Spec.NodeName)
+		return nil // Skip uncordoning this pod
+	}
+
+	return r.makePodUncordonAndUndrain(ctx, nodeset, pod)
 }
 
 // syncUpdate will synchronize NodeSet pod version updates based on update type.

--- a/internal/controller/nodeset/nodeset_sync_test.go
+++ b/internal/controller/nodeset/nodeset_sync_test.go
@@ -960,6 +960,32 @@ func TestNodeSetReconciler_makePodCordonAndDrain(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "success with drain state annotations",
+			fields: fields{
+				Client: fake.NewFakeClient(nodeset.DeepCopy(), pod.DeepCopy()),
+				ClientMap: func() *clientmap.ClientMap {
+					nodeList := &slurmtypes.V0043NodeList{
+						Items: []slurmtypes.V0043Node{
+							{
+								V0043Node: api.V0043Node{
+									Name:  ptr.To(nodesetutils.GetNodeName(pod)),
+									State: ptr.To([]api.V0043NodeState{api.V0043NodeStateDRAIN}),
+								},
+							},
+						},
+					}
+					sclient := newFakeClientList(sinterceptor.Funcs{}, nodeList)
+					return newClientMap(controller.Name, sclient)
+				}(),
+			},
+			args: args{
+				ctx:     context.TODO(),
+				nodeset: nodeset.DeepCopy(),
+				pod:     pod.DeepCopy(),
+			},
+			wantErr: false,
+		},
+		{
 			name: "kubernetes update failure",
 			fields: fields{
 				Client: fake.NewClientBuilder().
@@ -1041,6 +1067,13 @@ func TestNodeSetReconciler_makePodCordonAndDrain(t *testing.T) {
 			} else if !tt.wantErr {
 				if ok := podutils.IsPodCordon(gotPod); !ok {
 					t.Errorf("IsPodCordon() = %v", ok)
+				}
+				// Check drain state annotations
+				if drainState := podutils.GetPodDrainState(gotPod); drainState == "" {
+					t.Errorf("Expected drain state annotation, got empty")
+				}
+				if drainReason := podutils.GetPodDrainReason(gotPod); drainReason == "" {
+					t.Errorf("Expected drain reason annotation, got empty")
 				}
 			}
 			// Check Slurm Node State
@@ -1921,6 +1954,397 @@ func TestNodeSetReconciler_syncClusterWorkerService(t *testing.T) {
 			r := newNodeSetController(tt.fields.Client, nil)
 			if err := r.syncClusterWorkerService(tt.args.ctx, tt.args.nodeset); (err != nil) != tt.wantErr {
 				t.Errorf("NodeSetReconciler.syncClusterWorkerService() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func Test_shouldSkipUncordon(t *testing.T) {
+	utilruntime.Must(slinkyv1alpha1.AddToScheme(clientgoscheme.Scheme))
+
+	type fields struct {
+		Client client.Client
+	}
+	type args struct {
+		ctx context.Context
+		pod *corev1.Pod
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   bool
+	}{
+		{
+			name: "Pod not cordoned - should not skip",
+			fields: fields{
+				Client: fake.NewFakeClient(
+					&corev1.Node{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-node",
+						},
+						Spec: corev1.NodeSpec{
+							Unschedulable: false,
+						},
+					},
+				),
+			},
+			args: args{
+				ctx: context.TODO(),
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "test-pod",
+						Annotations: map[string]string{
+							// No cordon annotation
+						},
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "test-node",
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Pod cordoned but node not cordoned - should not skip",
+			fields: fields{
+				Client: fake.NewFakeClient(
+					&corev1.Node{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-node",
+						},
+						Spec: corev1.NodeSpec{
+							Unschedulable: false,
+						},
+					},
+				),
+			},
+			args: args{
+				ctx: context.TODO(),
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-pod",
+						Annotations: map[string]string{
+							slinkyv1alpha1.AnnotationPodCordon: "true",
+						},
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "test-node",
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Pod cordoned and node cordoned - should skip",
+			fields: fields{
+				Client: fake.NewFakeClient(
+					&corev1.Node{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-node",
+						},
+						Spec: corev1.NodeSpec{
+							Unschedulable: true, // Node is cordoned
+						},
+					},
+				),
+			},
+			args: args{
+				ctx: context.TODO(),
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-pod",
+						Annotations: map[string]string{
+							slinkyv1alpha1.AnnotationPodCordon: "true",
+						},
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "test-node",
+					},
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newNodeSetController(tt.fields.Client, nil)
+			if got := r.shouldSkipUncordon(tt.args.ctx, tt.args.pod); got != tt.want {
+				t.Errorf("shouldSkipUncordon() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_handleUncordonWithSynchronization(t *testing.T) {
+	utilruntime.Must(slinkyv1alpha1.AddToScheme(clientgoscheme.Scheme))
+	controller := &slinkyv1alpha1.Controller{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "slurm",
+		},
+	}
+	nodeset := newNodeSet("foo", controller.Name, 2)
+	pod := nodesetutils.NewNodeSetPod(nodeset, controller, 0, "")
+	pod.Annotations[slinkyv1alpha1.AnnotationPodCordon] = "true"
+
+	type fields struct {
+		Client    client.Client
+		ClientMap *clientmap.ClientMap
+	}
+	type args struct {
+		ctx     context.Context
+		nodeset *slinkyv1alpha1.NodeSet
+		pod     *corev1.Pod
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "success - pod uncordoned when node not cordoned",
+			fields: fields{
+				Client: fake.NewFakeClient(
+					nodeset.DeepCopy(),
+					pod.DeepCopy(),
+					&corev1.Node{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-node",
+						},
+						Spec: corev1.NodeSpec{
+							Unschedulable: false, // Node not cordoned
+						},
+					},
+				),
+				ClientMap: func() *clientmap.ClientMap {
+					nodeList := &slurmtypes.V0043NodeList{
+						Items: []slurmtypes.V0043Node{
+							{
+								V0043Node: api.V0043Node{
+									Name: ptr.To(nodesetutils.GetNodeName(pod)),
+									State: ptr.To([]api.V0043NodeState{
+										api.V0043NodeStateIDLE,
+										api.V0043NodeStateDRAIN,
+									}),
+								},
+							},
+						},
+					}
+					sclient := newFakeClientList(sinterceptor.Funcs{}, nodeList)
+					return newClientMap(controller.Name, sclient)
+				}(),
+			},
+			args: args{
+				ctx:     context.TODO(),
+				nodeset: nodeset.DeepCopy(),
+				pod:     pod.DeepCopy(),
+			},
+			wantErr: false,
+		},
+		{
+			name: "skip - pod not uncordoned when node is cordoned",
+			fields: fields{
+				Client: fake.NewFakeClient(
+					nodeset.DeepCopy(),
+					pod.DeepCopy(),
+					&corev1.Node{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-node",
+						},
+						Spec: corev1.NodeSpec{
+							Unschedulable: true, // Node is cordoned
+						},
+					},
+				),
+				ClientMap: func() *clientmap.ClientMap {
+					nodeList := &slurmtypes.V0043NodeList{
+						Items: []slurmtypes.V0043Node{
+							{
+								V0043Node: api.V0043Node{
+									Name: ptr.To(nodesetutils.GetNodeName(pod)),
+									State: ptr.To([]api.V0043NodeState{
+										api.V0043NodeStateIDLE,
+										api.V0043NodeStateDRAIN,
+									}),
+								},
+							},
+						},
+					}
+					sclient := newFakeClientList(sinterceptor.Funcs{}, nodeList)
+					return newClientMap(controller.Name, sclient)
+				}(),
+			},
+			args: args{
+				ctx:     context.TODO(),
+				nodeset: nodeset.DeepCopy(),
+				pod:     pod.DeepCopy(),
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newNodeSetController(tt.fields.Client, tt.fields.ClientMap)
+			if err := r.handleUncordonWithSynchronization(tt.args.ctx, tt.args.nodeset, tt.args.pod); (err != nil) != tt.wantErr {
+				t.Errorf("handleUncordonWithSynchronization() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestNodeSetReconciler_drainStateMonitoring(t *testing.T) {
+	utilruntime.Must(slinkyv1alpha1.AddToScheme(clientgoscheme.Scheme))
+	controller := &slinkyv1alpha1.Controller{ObjectMeta: metav1.ObjectMeta{Name: "slurm"}}
+	nodeset := newNodeSet("foo", controller.Name, 2)
+
+	type fields struct {
+		Client    client.Client
+		ClientMap *clientmap.ClientMap
+	}
+	type args struct {
+		ctx     context.Context
+		nodeset *slinkyv1alpha1.NodeSet
+		pod     *corev1.Pod
+	}
+	tests := []struct {
+		name           string
+		fields         fields
+		args           args
+		wantDrainState string
+		wantErr        bool
+	}{
+		{
+			name: "draining - node has jobs but is draining",
+			fields: fields{
+				Client: func() client.Client {
+					pod := nodesetutils.NewNodeSetPod(nodeset, controller, 0, "")
+					pod.Annotations[slinkyv1alpha1.AnnotationPodCordon] = "true"
+					return fake.NewFakeClient(nodeset.DeepCopy(), pod.DeepCopy())
+				}(),
+				ClientMap: func() *clientmap.ClientMap {
+					pod := nodesetutils.NewNodeSetPod(nodeset, controller, 0, "")
+					pod.Annotations[slinkyv1alpha1.AnnotationPodCordon] = "true"
+					nodeList := &slurmtypes.V0043NodeList{
+						Items: []slurmtypes.V0043Node{{
+							V0043Node: api.V0043Node{
+								Name:  ptr.To(nodesetutils.GetNodeName(pod)),
+								State: ptr.To([]api.V0043NodeState{api.V0043NodeStateALLOCATED, api.V0043NodeStateDRAIN}),
+							},
+						}},
+					}
+					return newClientMap(controller.Name, newFakeClientList(sinterceptor.Funcs{}, nodeList))
+				}(),
+			},
+			args: args{
+				ctx:     context.TODO(),
+				nodeset: nodeset.DeepCopy(),
+				pod: func() *corev1.Pod {
+					pod := nodesetutils.NewNodeSetPod(nodeset, controller, 0, "")
+					pod.Annotations[slinkyv1alpha1.AnnotationPodCordon] = "true"
+					return pod
+				}(),
+			},
+			wantDrainState: "draining",
+			wantErr:        false,
+		},
+		{
+			name: "drained - node is idle and drained",
+			fields: fields{
+				Client: func() client.Client {
+					pod := nodesetutils.NewNodeSetPod(nodeset, controller, 0, "")
+					pod.Annotations[slinkyv1alpha1.AnnotationPodCordon] = "true"
+					return fake.NewFakeClient(nodeset.DeepCopy(), pod.DeepCopy())
+				}(),
+				ClientMap: func() *clientmap.ClientMap {
+					pod := nodesetutils.NewNodeSetPod(nodeset, controller, 0, "")
+					pod.Annotations[slinkyv1alpha1.AnnotationPodCordon] = "true"
+					nodeList := &slurmtypes.V0043NodeList{
+						Items: []slurmtypes.V0043Node{{
+							V0043Node: api.V0043Node{
+								Name:  ptr.To(nodesetutils.GetNodeName(pod)),
+								State: ptr.To([]api.V0043NodeState{api.V0043NodeStateIDLE, api.V0043NodeStateDRAIN}),
+							},
+						}},
+					}
+					return newClientMap(controller.Name, newFakeClientList(sinterceptor.Funcs{}, nodeList))
+				}(),
+			},
+			args: args{
+				ctx:     context.TODO(),
+				nodeset: nodeset.DeepCopy(),
+				pod: func() *corev1.Pod {
+					pod := nodesetutils.NewNodeSetPod(nodeset, controller, 0, "")
+					pod.Annotations[slinkyv1alpha1.AnnotationPodCordon] = "true"
+					return pod
+				}(),
+			},
+			wantDrainState: "drained",
+			wantErr:        false,
+		},
+		{
+			name: "drained - node is down and drained",
+			fields: fields{
+				Client: func() client.Client {
+					pod := nodesetutils.NewNodeSetPod(nodeset, controller, 0, "")
+					pod.Annotations[slinkyv1alpha1.AnnotationPodCordon] = "true"
+					return fake.NewFakeClient(nodeset.DeepCopy(), pod.DeepCopy())
+				}(),
+				ClientMap: func() *clientmap.ClientMap {
+					pod := nodesetutils.NewNodeSetPod(nodeset, controller, 0, "")
+					pod.Annotations[slinkyv1alpha1.AnnotationPodCordon] = "true"
+					nodeList := &slurmtypes.V0043NodeList{
+						Items: []slurmtypes.V0043Node{{
+							V0043Node: api.V0043Node{
+								Name:  ptr.To(nodesetutils.GetNodeName(pod)),
+								State: ptr.To([]api.V0043NodeState{api.V0043NodeStateDOWN, api.V0043NodeStateDRAIN}),
+							},
+						}},
+					}
+					return newClientMap(controller.Name, newFakeClientList(sinterceptor.Funcs{}, nodeList))
+				}(),
+			},
+			args: args{
+				ctx:     context.TODO(),
+				nodeset: nodeset.DeepCopy(),
+				pod: func() *corev1.Pod {
+					pod := nodesetutils.NewNodeSetPod(nodeset, controller, 0, "")
+					pod.Annotations[slinkyv1alpha1.AnnotationPodCordon] = "true"
+					return pod
+				}(),
+			},
+			wantDrainState: "drained",
+			wantErr:        false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newNodeSetController(tt.fields.Client, tt.fields.ClientMap)
+
+			// Test the syncSlurmFn logic for drain state monitoring
+			if podutils.IsPodCordon(tt.args.pod) {
+				if isDrained, err := r.slurmControl.IsNodeDrained(tt.args.ctx, tt.args.nodeset, tt.args.pod); err == nil {
+					toUpdate := tt.args.pod.DeepCopy()
+					if toUpdate.Annotations == nil {
+						toUpdate.Annotations = make(map[string]string)
+					}
+					if isDrained {
+						toUpdate.Annotations[slinkyv1alpha1.AnnotationPodDrainState] = "drained"
+					} else {
+						toUpdate.Annotations[slinkyv1alpha1.AnnotationPodDrainState] = "draining"
+					}
+					if err := r.Patch(tt.args.ctx, toUpdate, client.StrategicMergeFrom(tt.args.pod)); (err != nil) != tt.wantErr {
+						t.Errorf("Patch() error = %v, wantErr %v", err, tt.wantErr)
+					}
+				}
+			}
+
+			gotPod := &corev1.Pod{}
+			if err := r.Get(tt.args.ctx, client.ObjectKeyFromObject(tt.args.pod), gotPod); err != nil {
+				t.Errorf("Get() error = %v", err)
+			}
+			if gotState := podutils.GetPodDrainState(gotPod); gotState != tt.wantDrainState {
+				t.Errorf("Expected drain state %v, got %v", tt.wantDrainState, gotState)
 			}
 		})
 	}

--- a/internal/utils/podutils/pod.go
+++ b/internal/utils/podutils/pod.go
@@ -16,6 +16,26 @@ func IsPodCordon(pod *corev1.Pod) bool {
 	return pod.GetAnnotations()[slinkyv1alpha1.AnnotationPodCordon] == "true"
 }
 
+// GetPodDrainState returns the current drain state of a pod.
+func GetPodDrainState(pod *corev1.Pod) string {
+	return pod.GetAnnotations()[slinkyv1alpha1.AnnotationPodDrainState]
+}
+
+// GetPodDrainReason returns the reason why a pod was drained.
+func GetPodDrainReason(pod *corev1.Pod) string {
+	return pod.GetAnnotations()[slinkyv1alpha1.AnnotationPodDrainReason]
+}
+
+// IsPodDraining returns true if the pod is currently draining.
+func IsPodDraining(pod *corev1.Pod) bool {
+	return GetPodDrainState(pod) == "draining"
+}
+
+// IsPodDrained returns true if the pod has been drained.
+func IsPodDrained(pod *corev1.Pod) bool {
+	return GetPodDrainState(pod) == "drained"
+}
+
 // isRunningAndReady returns true if pod is in the PodRunning Phase, if it has a condition of PodReady.
 func IsRunningAndReady(pod *corev1.Pod) bool {
 	return IsRunning(pod) && podutil.IsPodReady(pod)

--- a/internal/utils/podutils/pod_test.go
+++ b/internal/utils/podutils/pod_test.go
@@ -9,6 +9,8 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	slinkyv1alpha1 "github.com/SlinkyProject/slurm-operator/api/v1alpha1"
 )
 
 func TestIsRunningAndReady(t *testing.T) {
@@ -359,6 +361,226 @@ func TestIsHealthy(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := IsHealthy(tt.args.pod); got != tt.want {
 				t.Errorf("IsHealthy() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetPodDrainState(t *testing.T) {
+	var podWithDraining, podWithDrained, podWithEmpty, podWithInvalid, podWithoutAnnotation corev1.Pod
+
+	podWithDraining.ObjectMeta.Annotations = map[string]string{
+		slinkyv1alpha1.AnnotationPodDrainState: "draining",
+	}
+	podWithDrained.ObjectMeta.Annotations = map[string]string{
+		slinkyv1alpha1.AnnotationPodDrainState: "drained",
+	}
+	podWithEmpty.ObjectMeta.Annotations = map[string]string{
+		slinkyv1alpha1.AnnotationPodDrainState: "",
+	}
+	podWithInvalid.ObjectMeta.Annotations = map[string]string{
+		slinkyv1alpha1.AnnotationPodDrainState: "invalid-state",
+	}
+
+	type args struct {
+		pod *corev1.Pod
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "Pod with draining state",
+			args: args{pod: &podWithDraining},
+			want: "draining",
+		},
+		{
+			name: "Pod with drained state",
+			args: args{pod: &podWithDrained},
+			want: "drained",
+		},
+		{
+			name: "Pod with empty drain state",
+			args: args{pod: &podWithEmpty},
+			want: "",
+		},
+		{
+			name: "Pod with invalid drain state",
+			args: args{pod: &podWithInvalid},
+			want: "invalid-state",
+		},
+		{
+			name: "Pod without drain state annotation",
+			args: args{pod: &podWithoutAnnotation},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetPodDrainState(tt.args.pod); got != tt.want {
+				t.Errorf("GetPodDrainState() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetPodDrainReason(t *testing.T) {
+	var podWithReason, podWithEmpty, podWithoutAnnotation corev1.Pod
+
+	podWithReason.ObjectMeta.Annotations = map[string]string{
+		slinkyv1alpha1.AnnotationPodDrainReason: "k8s-node-cordoned",
+	}
+	podWithEmpty.ObjectMeta.Annotations = map[string]string{
+		slinkyv1alpha1.AnnotationPodDrainReason: "",
+	}
+
+	type args struct {
+		pod *corev1.Pod
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "Pod with drain reason",
+			args: args{pod: &podWithReason},
+			want: "k8s-node-cordoned",
+		},
+		{
+			name: "Pod with empty drain reason",
+			args: args{pod: &podWithEmpty},
+			want: "",
+		},
+		{
+			name: "Pod without drain reason annotation",
+			args: args{pod: &podWithoutAnnotation},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetPodDrainReason(tt.args.pod); got != tt.want {
+				t.Errorf("GetPodDrainReason() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsPodDraining(t *testing.T) {
+	var podDraining, podDrained, podWithEmpty, podWithInvalid, podWithoutAnnotation corev1.Pod
+
+	podDraining.ObjectMeta.Annotations = map[string]string{
+		slinkyv1alpha1.AnnotationPodDrainState: "draining",
+	}
+	podDrained.ObjectMeta.Annotations = map[string]string{
+		slinkyv1alpha1.AnnotationPodDrainState: "drained",
+	}
+	podWithEmpty.ObjectMeta.Annotations = map[string]string{
+		slinkyv1alpha1.AnnotationPodDrainState: "",
+	}
+	podWithInvalid.ObjectMeta.Annotations = map[string]string{
+		slinkyv1alpha1.AnnotationPodDrainState: "invalid-state",
+	}
+
+	type args struct {
+		pod *corev1.Pod
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "Pod is draining",
+			args: args{pod: &podDraining},
+			want: true,
+		},
+		{
+			name: "Pod is drained (not draining)",
+			args: args{pod: &podDrained},
+			want: false,
+		},
+		{
+			name: "Pod with empty drain state (not draining)",
+			args: args{pod: &podWithEmpty},
+			want: false,
+		},
+		{
+			name: "Pod with invalid drain state (not draining)",
+			args: args{pod: &podWithInvalid},
+			want: false,
+		},
+		{
+			name: "Pod without drain state annotation",
+			args: args{pod: &podWithoutAnnotation},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsPodDraining(tt.args.pod); got != tt.want {
+				t.Errorf("IsPodDraining() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsPodDrained(t *testing.T) {
+	var podDraining, podDrained, podWithEmpty, podWithInvalid, podWithoutAnnotation corev1.Pod
+
+	podDraining.ObjectMeta.Annotations = map[string]string{
+		slinkyv1alpha1.AnnotationPodDrainState: "draining",
+	}
+	podDrained.ObjectMeta.Annotations = map[string]string{
+		slinkyv1alpha1.AnnotationPodDrainState: "drained",
+	}
+	podWithEmpty.ObjectMeta.Annotations = map[string]string{
+		slinkyv1alpha1.AnnotationPodDrainState: "",
+	}
+	podWithInvalid.ObjectMeta.Annotations = map[string]string{
+		slinkyv1alpha1.AnnotationPodDrainState: "invalid-state",
+	}
+
+	type args struct {
+		pod *corev1.Pod
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "Pod is drained",
+			args: args{pod: &podDrained},
+			want: true,
+		},
+		{
+			name: "Pod is draining (not drained)",
+			args: args{pod: &podDraining},
+			want: false,
+		},
+		{
+			name: "Pod with empty drain state (not drained)",
+			args: args{pod: &podWithEmpty},
+			want: false,
+		},
+		{
+			name: "Pod with invalid drain state (not drained)",
+			args: args{pod: &podWithInvalid},
+			want: false,
+		},
+		{
+			name: "Pod without drain state annotation",
+			args: args{pod: &podWithoutAnnotation},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsPodDrained(tt.args.pod); got != tt.want {
+				t.Errorf("IsPodDrained() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

This PR implements **Kubernetes Node State Synchronization** for the Slurm Operator, enabling automatic coordination between Kubernetes node cordoning/uncordoning and Slurm node draining/undraining. This feature addresses the gap where external Kubernetes node maintenance operations (e.g., `kubectl cordon`) were not automatically coordinated with Slurm workload management.

## Breaking Changes

N/A

## Testing Notes

### **Test Scenario: K8s Node State Synchronization with Continuous Drain State Monitoring**

**1. Initial State:**
```bash
# K8s Node Status
ip-10-0-241-93.ec2.internal    Ready    customer-gpu   147d   v1.30.11   10.0.241.93

# Slurm Job Status  
JOBID NAME NODELIST STATE
11    test-job gpu-1-0 RUNNING

# Pod Annotations (Initial)
{
  "kubectl.kubernetes.io/default-container": "slurmd"
}
```

**2. Node Cordoning Trigger:**
```bash

kubectl cordon ip-10-0-241-93.ec2.internal
node/ip-10-0-241-93.ec2.internal cordoned

# Pod Annotations After Cordoning
{
  "kubectl.kubernetes.io/default-container": "slurmd",
  "nodeset.slinky.slurm.net/pod-cordon": "true",
  "nodeset.slinky.slurm.net/pod-deadline": "2025-09-25T12:05:59Z",
  "nodeset.slinky.slurm.net/pod-drain-reason": "k8s-node-cordoned",
  "nodeset.slinky.slurm.net/pod-drain-state": "draining"
}
```

**3. Slurm Node State Transition:**
```bash
# Before cordoning
gpu-1-0 idle

# During drain process  
gpu-1-0 draining

# After job completion
gpu-1-0 drained
```

**4. Continuous Drain State Monitoring:**
```bash
# Pod annotation evolution during test
# Initial: "draining" (while job running)
# Final: "drained" (after job completed)

# Final pod annotations
{
  "kubectl.kubernetes.io/default-container": "slurmd",
  "nodeset.slinky.slurm.net/pod-cordon": "true",
  "nodeset.slinky.slurm.net/pod-drain-reason": "k8s-node-cordoned",
  "nodeset.slinky.slurm.net/pod-drain-state": "drained"
}
```

**5. Node Uncordoning and Recovery:**
```bash

kubectl uncordon ip-10-0-241-93.ec2.internal
node/ip-10-0-241-93.ec2.internal uncordoned

# Final pod annotations (clean state)
{
  "kubectl.kubernetes.io/default-container": "slurmd"
}

# Final Slurm state (restored)
gpu-1-0 idle
```

**6. Operator Logs Evidence:**
```json
{"level":"info","ts":"2025-09-25T12:02:06Z","msg":"Node cordoned - triggering workload coordination","node":"ip-10-0-241-93.ec2.internal"}
{"level":"info","ts":"2025-09-25T12:02:06Z","msg":"K8s node state synchronization: node cordoned externally, cordoning pod for workload protection","pod":{"name":"slurm-worker-gpu-1-0","namespace":"slinky"},"node":"ip-10-0-241-93.ec2.internal"}
{"level":"info","ts":"2025-09-25T12:02:06Z","msg":"Cordon Pod, pending deletion","Pod":{"name":"slurm-worker-gpu-1-0","namespace":"slinky"}}

```

**Test Results:**
```bash
=== RUN   Test_shouldSkipUncordon
=== RUN   Test_handleUncordonWithSynchronization  
=== RUN   TestNodeSetReconciler_drainStateMonitoring
=== RUN   Test_nodeEventHandler_Update
=== RUN   TestGetPodDrainState/Reason/Draining/Drained
--- PASS: All tests (0.828s)
PASS
```