### PR TITLE
Fix nodeset partition reference 

### DIFF
--- a/helm/slurm/templates/nodeset/nodeset-cr.yaml
+++ b/helm/slurm/templates/nodeset/nodeset-cr.yaml
@@ -50,7 +50,7 @@ spec:
   {{- end -}}{{- /* if (include "slurm.worker.extraConf" $nodeset) */}}
   {{- with $nodeset.partition }}
   partition:
-    enabled: {{ $nodeset.enabled | default false }}
+    enabled: {{ $nodeset.partition.enabled | default false }}
     {{- if (include "slurm.worker.partitionConfig" $nodeset.partition) }}
     config: {{ include "slurm.worker.partitionConfig" $nodeset.partition }}
     {{- end }}{{- /* if (include "slurm.worker.partitionConfig" $nodeset.partition) */}}


### PR DESCRIPTION
## Summary

This PR fixes a bug in the Slurm operator Helm templates where per-nodeset partitions were always created regardless of the `partition.enabled` setting in the values file. The fix enables users to properly control partition creation and create logical partitions that group multiple nodesets together.

## Breaking Changes

N/A

## Testing Notes

1. **Test per-nodeset partition control:**
   ```yaml
   nodesets:
     gpu-1:
       partition:
         enabled: false  # Should not create gpu-1 partition
   ```

2. **Test logical partitions:**
   ```yaml
   partitions:
     gpu-partition:
       enabled: true
       nodesets:
         - gpu-1
         - gpu-2
   ```

3. **Verify partition structure:**
   ```bash
   kubectl exec -n slinky $(kubectl get pods -n slinky | grep login | awk '{print $1}') -it -- sinfo
   ```

## Additional Context

**Error Messages Users Encountered:**
- `slurm_load_partitions: Unable to contact slurm controller (connect failure)`
- `Invalid node names in partition batch`
- `Node cpu-1 appears to have a different slurm.conf than the slurmctld`
- `partition 'batch' is referencing nodeset 'infprod12-atl02-node-002-0' that does not exist or is disabled`

**Logs from controller:**

```
[2025-09-29T14:18:07] error: _find_node_record: lookup failure for node "cpu-1"
[2025-09-29T14:18:07] build_part_bitmap: invalid node name cpu-1 in partition
[2025-09-29T14:18:07] error: _find_node_record: lookup failure for node "cpu-2"
[2025-09-29T14:18:07] build_part_bitmap: invalid node name cpu-2 in partition
[2025-09-29T14:18:07] error: _find_node_record: lookup failure for node "cpu-3"
[2025-09-29T14:18:07] build_part_bitmap: invalid node name cpu-3 in partition
[2025-09-29T14:18:07] error: _find_node_record: lookup failure for node "cpu-4"
[2025-09-29T14:18:07] build_part_bitmap: invalid node name cpu-4 in partition
[2025-09-29T14:18:07] error: _find_node_record: lookup failure for node "cpu-5"
[2025-09-29T14:18:07] build_part_bitmap: invalid node name cpu-5 in partition
[2025-09-29T14:18:07] error: _find_node_record: lookup failure for node "cpu-6"
[2025-09-29T14:18:07] build_part_bitmap: invalid node name cpu-6 in partition
[2025-09-29T14:18:07] fatal: Invalid node names in partition cpu-partition
2025-09-29 14:18:08,903 INFO success: slurmctld entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
2025-09-29 14:18:08,903 WARN exited: slurmctld (exit status 1; not expected)
2025-09-29 14:18:08,903 INFO reaped unknown pid 1175 (exit status 0)
```