### PR TITLE
Add support for different service types in loginset

### DIFF
--- a/helm/slurm/templates/loginset/loginset-cr.yaml
+++ b/helm/slurm/templates/loginset/loginset-cr.yaml
@@ -47,7 +47,16 @@ spec:
   {{- include "format-podTemplate" $podTemplate | nindent 2 }}
   {{- with $loginset.service }}
   service:
-    {{- toYaml . | nindent 4 }}
+    {{- if .port }}
+    port: {{ .port }}
+    {{- end }}
+    {{- if .nodePort }}
+    nodePort: {{ .nodePort }}
+    {{- end }}
+    {{- if .type }}
+    spec:
+      type: {{ .type }}
+    {{- end }}
   {{- end }}{{- /* with $loginset.service */}}
 {{- end }}{{- /* $loginset.enabled */}}
 {{- end }}{{- /* range $loginset := $.Values.loginsets */}}


### PR DESCRIPTION
## Summary

Add support for different service types (NodePort, LoadBalancer) to loginset while maintaining default ClusterIP behavior. This enables use cases where external access to login nodes is needed via NodePort.

## Breaking Changes

N/A

## Testing Notes

Tested internally with values below and works as expected

```
loginsets:
  slinky:
    enabled: true
    service:
      type: NodePort
      port: 22
      nodePort: 32222
```

## Additional Context

Alternative option might be to update **ServiceSpec** in go code
