### PR TITLE
Fix hardcoded updateStrategy for NodeSets

### DIFF
--- a/helm/slurm/README.md
+++ b/helm/slurm/README.md
@@ -119,6 +119,8 @@ Kubernetes: `>= 1.29.0-0`
 | nodesets.slinky.slurmd.image | object | `{"repository":"ghcr.io/slinkyproject/slurmd","tag":"25.05-ubuntu24.04"}` | The image to use, `${repository}:${tag}`. Ref: https://kubernetes.io/docs/concepts/containers/images/#image-names |
 | nodesets.slinky.slurmd.resources | object | `{}` | The container resource limits and requests. Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container |
 | nodesets.slinky.slurmd.volumeMounts | list | `[]` | List of volume mounts to use. Ref: https://kubernetes.io/docs/concepts/storage/volumes/ |
+| nodesets.slinky.updateStrategy | object | `{"rollingUpdate":{"maxUnavailable":"25%"},"type":"RollingUpdate"}` | Update strategy for rolling updates. Ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies |
+| nodesets.slinky.updateStrategy.rollingUpdate.maxUnavailable | string | `"25%"` | Maximum number of pods that can be unavailable during update. Can be an absolute number (ex: 5) or a percentage (ex: 25%). |
 | nodesets.slinky.useResourceLimits | bool | `true` | Enable propagation of container `resources.limits` into slurmd. |
 | partitions.all.config | string | `nil` | The Slurm partition configuration options added to the partition line. Ref: https://slurm.schedmd.com/slurm.conf.html#SECTION_PARTITION-CONFIGURATION |
 | partitions.all.configMap | map[string]string \| map[string][]string | `{"Default":"YES","MaxTime":"UNLIMITED","State":"UP"}` | The Slurm partition configuration options added to the partition line. If `config` is not empty, it takes precedence. Ref: https://slurm.schedmd.com/slurm.conf.html#SECTION_PARTITION-CONFIGURATION |

--- a/helm/slurm/templates/nodeset/nodeset-cr.yaml
+++ b/helm/slurm/templates/nodeset/nodeset-cr.yaml
@@ -66,11 +66,6 @@ spec:
   {{- with $nodeset.updateStrategy }}
   updateStrategy:
     {{- toYaml . | nindent 4 }}
-  {{- else }}
-  updateStrategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 25%
   {{- end }}{{- /* with $nodeset.updateStrategy */}}
 {{- end }}{{- /* $nodeset.enabled */}}
 {{- end }}{{- /* range $nodeset := $.Values.nodesets */}}

--- a/helm/slurm/templates/nodeset/nodeset-cr.yaml
+++ b/helm/slurm/templates/nodeset/nodeset-cr.yaml
@@ -63,9 +63,14 @@ spec:
     {{- $_ := set $nodeset.logfile "imagePullPolicy" (default $.Values.imagePullPolicy $nodeset.logfile.imagePullPolicy) -}}
     {{- include "format-container" $nodeset.logfile | nindent 4 }}
   {{- include "format-podTemplate" $podTemplate | nindent 2 }}
+  {{- with $nodeset.updateStrategy }}
+  updateStrategy:
+    {{- toYaml . | nindent 4 }}
+  {{- else }}
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: 100%
+      maxUnavailable: 25%
+  {{- end }}{{- /* with $nodeset.updateStrategy */}}
 {{- end }}{{- /* $nodeset.enabled */}}
 {{- end }}{{- /* range $nodeset := $.Values.nodesets */}}

--- a/helm/slurm/values.yaml
+++ b/helm/slurm/values.yaml
@@ -586,6 +586,14 @@ nodesets:
         # MaxTime: UNLIMITED
     # -- Enable propagation of container `resources.limits` into slurmd.
     useResourceLimits: true
+    # -- Update strategy for rolling updates.
+    # Ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
+    updateStrategy:
+      type: RollingUpdate
+      rollingUpdate:
+        # -- Maximum number of pods that can be unavailable during update.
+        # Can be an absolute number (ex: 5) or a percentage (ex: 25%).
+        maxUnavailable: 25%
     # -- Labels and annotations.
     # Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
     metadata: {}


### PR DESCRIPTION
<!--
Feature requests, code contributions, and bug reports are welcome!
Github/Gitlab submitted issues and PRs/MRs are handled on a best effort basis.
The SchedMD official issue tracker is at <https://support.schedmd.com/>.
-->

## Summary

Fix hardcoded updateStrategy for NodeSets. Currently, it is not configurable

## Breaking Changes

N/A

## Testing Notes

Deployed and tested

```
kubectl get nodeset slurm-worker-gpu -n slurm -o yaml | grep -A 5 "updateStrategy"
  updateStrategy:
    rollingUpdate:
      maxUnavailable: 10%
    type: RollingUpdate
...
```
