### PR TITLE
feat: add helm unit tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,7 +70,7 @@ repos:
           - -s
           - -l
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.11.0.1
+    rev: 3.18.6-1.0.2
     hooks:
       - id: shellcheck
         args:
@@ -82,6 +82,13 @@ repos:
       - id: go-mod-tidy
       - id: go-vet-mod
       - id: go-build-mod
+  - repo: https://github.com/tekwizely/pre-commit-golang
+    rev: v1.0.0-rc.2
+    hooks:
+      - id: go-fmt
+      - id: go-mod-tidy
+      - id: go-vet-mod
+      - id: go-build-mod      
   - repo: local
     hooks:
       # https://github.com/norwoodj/helm-docs/blob/master/.pre-commit-hooks.yaml
@@ -99,6 +106,13 @@ repos:
         files: ^helm/
         language: system
         pass_filenames: false
+      - id: make-helm-unittest
+        name: Make Helm Validate
+        entry: make helm-validate
+        types: [yaml]
+        files: ^helm/
+        language: system
+        pass_filenames: false        
       # https://github.com/golangci/golangci-lint/blob/main/.pre-commit-hooks.yaml
       - id: make-golangci-lint
         name: make-golangci-lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,7 +70,7 @@ repos:
           - -s
           - -l
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: 3.18.6-1.0.2
+    rev: v0.11.0.1
     hooks:
       - id: shellcheck
         args:
@@ -81,14 +81,7 @@ repos:
       - id: go-fmt
       - id: go-mod-tidy
       - id: go-vet-mod
-      - id: go-build-mod
-  - repo: https://github.com/tekwizely/pre-commit-golang
-    rev: v1.0.0-rc.2
-    hooks:
-      - id: go-fmt
-      - id: go-mod-tidy
-      - id: go-vet-mod
-      - id: go-build-mod      
+      - id: go-build-mod    
   - repo: local
     hooks:
       # https://github.com/norwoodj/helm-docs/blob/master/.pre-commit-hooks.yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,7 +81,7 @@ repos:
       - id: go-fmt
       - id: go-mod-tidy
       - id: go-vet-mod
-      - id: go-build-mod    
+      - id: go-build-mod
   - repo: local
     hooks:
       # https://github.com/norwoodj/helm-docs/blob/master/.pre-commit-hooks.yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -100,8 +100,8 @@ repos:
         language: system
         pass_filenames: false
       - id: make-helm-unittest
-        name: Make Helm Validate
-        entry: make helm-validate
+        name: Make Helm Unittest
+        entry: make helm-unittest
         types: [yaml]
         files: ^helm/
         language: system

--- a/Makefile
+++ b/Makefile
@@ -226,6 +226,12 @@ install-dev: ## Install binaries for development environment.
 .PHONY: helm-validate
 helm-validate: helm-dependency-update helm-lint ## Validate Helm charts.
 
+.PHONY: helm-unittest
+helm-unittest: ## Run helm-unittest.
+	@command -v helm unittest >/dev/null 2>&1 || helm plugin install https://github.com/helm-unittest/helm-unittest
+	@echo "Running helm unittest for slurm-operator chart"
+	@helm unittest helm/slurm-operator
+
 .PHONY: helm-docs
 helm-docs: helm-docs-bin ## Run helm-docs.
 	$(HELM_DOCS) --chart-search-root=helm

--- a/helm/slurm-operator/.helmignore
+++ b/helm/slurm-operator/.helmignore
@@ -23,3 +23,4 @@
 .vscode/
 # Development files
 skaffold.yaml
+tests/

--- a/helm/slurm-operator/tests/__snapshot__/operator_deployment_test.yaml.snap
+++ b/helm/slurm-operator/tests/__snapshot__/operator_deployment_test.yaml.snap
@@ -1,0 +1,61 @@
+manifest should match snapshot:
+  1: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app.kubernetes.io/instance: test-release
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: slurm-operator
+        app.kubernetes.io/version: 1.2.3
+        helm.sh/chart: slurm-operator-1.2.3
+      name: slurm-operator
+      namespace: test-namespace
+    spec:
+      replicas: 1
+      revisionHistoryLimit: 0
+      selector:
+        matchLabels:
+          app.kubernetes.io/instance: test-release
+          app.kubernetes.io/name: slurm-operator
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/instance: test-release
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: slurm-operator
+            app.kubernetes.io/version: 1.2.3
+            helm.sh/chart: slurm-operator-1.2.3
+        spec:
+          containers:
+            - args:
+                - --accounting-workers
+                - "4"
+                - --controller-workers
+                - "4"
+                - --loginset-workers
+                - "4"
+                - --nodeset-workers
+                - "4"
+                - --restapi-workers
+                - "4"
+                - --token-workers
+                - "4"
+                - --slurmclient-workers
+                - "2"
+                - --zap-log-level
+                - info
+              image: ghcr.io/slinkyproject/slurm-operator:1.2.3
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                httpGet:
+                  path: /healthz
+                  port: 8081
+              name: slurm-operator
+              readinessProbe:
+                httpGet:
+                  path: /readyz
+                  port: 8081
+          hostname: slurm-operator
+          priorityClassName: null
+          serviceAccountName: test-release-slurm-operator

--- a/helm/slurm-operator/tests/__snapshot__/operator_rbac_test.yaml.snap
+++ b/helm/slurm-operator/tests/__snapshot__/operator_rbac_test.yaml.snap
@@ -1,0 +1,127 @@
+manifest should match snapshot:
+  1: |
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      labels:
+        app.kubernetes.io/instance: test-release
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: slurm-operator
+        app.kubernetes.io/version: 1.2.3
+        helm.sh/chart: slurm-operator-1.2.3
+      name: test-release-slurm-operator
+      namespace: test-namespace
+  2: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: test-release-slurm-operator
+      namespace: test-namespace
+    rules:
+      - apiGroups:
+          - ""
+        resources:
+          - configmaps
+          - events
+          - persistentvolumeclaims
+          - pods
+          - secrets
+          - services
+        verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+      - apiGroups:
+          - ""
+        resources:
+          - nodes
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - ""
+        resources:
+          - pods/status
+        verbs:
+          - get
+          - patch
+          - update
+      - apiGroups:
+          - apps
+        resources:
+          - controllerrevisions
+          - deployments
+          - statefulsets
+        verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+      - apiGroups:
+          - slinky.slurm.net
+        resources:
+          - accountings
+          - controllers
+          - loginsets
+          - nodesets
+          - restapis
+          - tokens
+        verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+      - apiGroups:
+          - slinky.slurm.net
+        resources:
+          - accountings/finalizers
+          - controllers/finalizers
+          - loginsets/finalizers
+          - nodesets/finalizers
+          - restapis/finalizers
+          - tokens/finalizers
+        verbs:
+          - update
+      - apiGroups:
+          - slinky.slurm.net
+        resources:
+          - accountings/status
+          - controllers/status
+          - loginsets/status
+          - nodesets/status
+          - restapis/status
+          - tokens/status
+        verbs:
+          - get
+          - patch
+          - update
+  3: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      labels:
+        app.kubernetes.io/instance: test-release
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: slurm-operator
+        app.kubernetes.io/version: 1.2.3
+        helm.sh/chart: slurm-operator-1.2.3
+      name: test-release-slurm-operator
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: test-release-slurm-operator
+    subjects:
+      - kind: ServiceAccount
+        name: test-release-slurm-operator
+        namespace: test-namespace

--- a/helm/slurm-operator/tests/__snapshot__/operator_service_test.yaml.snap
+++ b/helm/slurm-operator/tests/__snapshot__/operator_service_test.yaml.snap
@@ -1,0 +1,30 @@
+manifest should match snapshot:
+  1: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app.kubernetes.io/instance: test-release
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: slurm-operator
+        app.kubernetes.io/version: 1.2.3
+        helm.sh/chart: slurm-operator-1.2.3
+      name: slurm-operator
+      namespace: test-namespace
+    spec:
+      clusterIP: None
+      ports:
+        - name: metrics
+          port: 8080
+          protocol: TCP
+          targetPort: 8080
+        - name: health
+          port: 8081
+          protocol: TCP
+          targetPort: 8081
+      selector:
+        app.kubernetes.io/instance: test-release
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: slurm-operator
+        app.kubernetes.io/version: 1.2.3
+        helm.sh/chart: slurm-operator-1.2.3

--- a/helm/slurm-operator/tests/__snapshot__/webhook_deployment_test.yaml.snap
+++ b/helm/slurm-operator/tests/__snapshot__/webhook_deployment_test.yaml.snap
@@ -1,0 +1,60 @@
+manifest should match snapshot:
+  1: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app.kubernetes.io/instance: test-release
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: slurm-operator-webhook
+        app.kubernetes.io/version: 1.2.3
+        helm.sh/chart: slurm-operator-1.2.3
+      name: slurm-operator-webhook
+      namespace: test-namespace
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/instance: test-release
+          app.kubernetes.io/name: slurm-operator-webhook
+      strategy:
+        rollingUpdate:
+          maxSurge: 1
+          maxUnavailable: 0
+        type: RollingUpdate
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/instance: test-release
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: slurm-operator-webhook
+            app.kubernetes.io/version: 1.2.3
+            helm.sh/chart: slurm-operator-1.2.3
+        spec:
+          containers:
+            - args:
+                - --zap-log-level
+                - info
+              image: ghcr.io/slinkyproject/slurm-operator-webhook:1.2.3
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                httpGet:
+                  path: /healthz
+                  port: 8081
+              name: webhook
+              readinessProbe:
+                httpGet:
+                  path: /readyz
+                  port: 8081
+              volumeMounts:
+                - mountPath: /tmp/k8s-webhook-server/serving-certs/
+                  name: certificates
+                  readOnly: true
+          hostname: slurm-operator-webhook
+          priorityClassName: null
+          serviceAccountName: slurm-operator-webhook
+          volumes:
+            - name: certificates
+              secret:
+                defaultMode: 420
+                secretName: slurm-operator-webhook-ca

--- a/helm/slurm-operator/tests/__snapshot__/webhook_rbac_test.yaml.snap
+++ b/helm/slurm-operator/tests/__snapshot__/webhook_rbac_test.yaml.snap
@@ -1,0 +1,68 @@
+manifest should match snapshot:
+  1: |
+    apiVersion: v1
+    automountServiceAccountToken: true
+    kind: ServiceAccount
+    metadata:
+      labels:
+        app.kubernetes.io/instance: test-release
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: slurm-operator-webhook
+        app.kubernetes.io/version: 1.2.3
+        helm.sh/chart: slurm-operator-1.2.3
+      name: slurm-operator-webhook
+      namespace: test-namespace
+  2: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        app.kubernetes.io/instance: test-release
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: slurm-operator-webhook
+        app.kubernetes.io/version: 1.2.3
+        helm.sh/chart: slurm-operator-1.2.3
+      name: slurm-operator-webhook
+      namespace: test-namespace
+    rules:
+      - apiGroups:
+          - slinky.slurm.net
+        resources:
+          - accountings
+          - controllers
+          - loginsets
+          - nodesets
+          - restapis
+          - tokens
+        verbs:
+          - create
+          - delete
+          - update
+      - apiGroups:
+          - ""
+        resources:
+          - configmaps
+        verbs:
+          - get
+          - list
+          - watch
+  3: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      labels:
+        app.kubernetes.io/instance: test-release
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: slurm-operator-webhook
+        app.kubernetes.io/version: 1.2.3
+        helm.sh/chart: slurm-operator-1.2.3
+      name: slurm-operator-webhook
+      namespace: test-namespace
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: slurm-operator-webhook
+    subjects:
+      - kind: ServiceAccount
+        name: slurm-operator-webhook
+        namespace: test-namespace

--- a/helm/slurm-operator/tests/__snapshot__/webhook_service_test.yaml.snap
+++ b/helm/slurm-operator/tests/__snapshot__/webhook_service_test.yaml.snap
@@ -1,0 +1,27 @@
+manifest should match snapshot:
+  1: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app.kubernetes.io/instance: test-release
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: slurm-operator-webhook
+        app.kubernetes.io/version: 1.2.3
+        helm.sh/chart: slurm-operator-1.2.3
+      name: slurm-operator-webhook
+      namespace: test-namespace
+    spec:
+      ports:
+        - name: https
+          port: 443
+          protocol: TCP
+          targetPort: 9443
+        - name: health
+          port: 8081
+          protocol: TCP
+          targetPort: 8081
+      selector:
+        app.kubernetes.io/instance: test-release
+        app.kubernetes.io/name: slurm-operator-webhook
+      type: ClusterIP

--- a/helm/slurm-operator/tests/operator_deployment_test.yaml
+++ b/helm/slurm-operator/tests/operator_deployment_test.yaml
@@ -1,0 +1,84 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+---
+suite: test operator deployment
+templates:
+- operator/deployment.yaml
+chart:
+  version: 1.2.3
+  appVersion: 1.2.3
+release:
+  name: test-release
+  namespace: test-namespace
+
+tests:
+- it: manifest should match snapshot
+  asserts:
+  - matchSnapshot: {}
+
+
+- it: should add affinity
+  set:
+    operator:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: arch
+                operator: In
+                values:
+                - x86_64
+  asserts:
+  - equal:
+      path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]
+      value: x86_64
+
+
+- it: should add tolerations
+  set:
+    operator:
+      tolerations:
+      - key: "test"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 6000
+  asserts:
+  - equal:
+      path: spec.template.spec.tolerations[0].key
+      value: test
+
+
+- it: should set imagePullSecrets
+  set:
+    imagePullSecrets:
+    - name: "test-docker-secret"
+  asserts:
+  - equal:
+      path: spec.template.spec.imagePullSecrets[0].name
+      value: test-docker-secret
+
+- it: should set priorityClassName
+  set:
+    priorityClassName: "test-priority-class"
+  asserts:
+  - equal:
+      path: spec.template.spec.priorityClassName
+      value: test-priority-class
+
+
+- it: should set replica count
+  set:
+    operator:
+      replicas: 42
+  asserts:
+  - equal:
+      path: spec.replicas
+      value: 42
+
+- it: should set namespace
+  set:
+    namespaceOverride: "custom-namespace"
+  asserts:
+  - equal:
+      path: metadata.namespace
+      value: custom-namespace

--- a/helm/slurm-operator/tests/operator_deployment_test.yaml
+++ b/helm/slurm-operator/tests/operator_deployment_test.yaml
@@ -38,9 +38,9 @@ tests:
   set:
     operator:
       tolerations:
-      - key: "test"
-        operator: "Exists"
-        effect: "NoExecute"
+      - key: test
+        operator: Exists
+        effect: NoExecute
         tolerationSeconds: 6000
   asserts:
   - equal:
@@ -51,7 +51,7 @@ tests:
 - it: should set imagePullSecrets
   set:
     imagePullSecrets:
-    - name: "test-docker-secret"
+    - name: test-docker-secret
   asserts:
   - equal:
       path: spec.template.spec.imagePullSecrets[0].name
@@ -59,7 +59,7 @@ tests:
 
 - it: should set priorityClassName
   set:
-    priorityClassName: "test-priority-class"
+    priorityClassName: test-priority-class
   asserts:
   - equal:
       path: spec.template.spec.priorityClassName
@@ -77,7 +77,7 @@ tests:
 
 - it: should set namespace
   set:
-    namespaceOverride: "custom-namespace"
+    namespaceOverride: custom-namespace
   asserts:
   - equal:
       path: metadata.namespace
@@ -85,7 +85,7 @@ tests:
 
 - it: should set name
   set:
-    nameOverride: "custom-name"
+    nameOverride: custom-name
   asserts:
   - equal:
       path: metadata.name
@@ -96,7 +96,7 @@ tests:
   set:
     operator:
       serviceAccount:
-        name: "custom-service-account"
+        name: custom-service-account
   asserts:
   - equal:
       path: spec.template.spec.serviceAccountName

--- a/helm/slurm-operator/tests/operator_rbac_test.yaml
+++ b/helm/slurm-operator/tests/operator_rbac_test.yaml
@@ -31,3 +31,26 @@ tests:
   asserts:
   - hasDocuments:
       count: 0
+
+
+
+- it: should set namespace
+  documentSelector:
+    path: kind
+    value: ServiceAccount
+  set:
+    namespaceOverride: custom-namespace
+  asserts:
+  - equal:
+      path: metadata.namespace
+      value: custom-namespace
+
+- it: should set serviceAccount name
+  set:
+    operator:
+      serviceAccount:
+        name: custom-service-account
+  asserts:
+  - equal:
+      path: metadata.name
+      value: custom-service-account

--- a/helm/slurm-operator/tests/operator_rbac_test.yaml
+++ b/helm/slurm-operator/tests/operator_rbac_test.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+---
+suite: test operator rbac
+templates:
+- operator/rbac.yaml
+chart:
+  version: 1.2.3
+  appVersion: 1.2.3
+release:
+  name: test-release
+  namespace: test-namespace
+
+tests:
+- it: manifest should match snapshot
+  asserts:
+  - matchSnapshot: {}
+
+- it: should not render when disabled
+  set:
+    operator:
+      enabled: false
+  asserts:
+  - hasDocuments:
+      count: 0
+
+- it: should not render when serviceAccount.create is false
+  set:
+    operator:
+      serviceAccount:
+        create: false
+  asserts:
+  - hasDocuments:
+      count: 0

--- a/helm/slurm-operator/tests/operator_service_test.yaml
+++ b/helm/slurm-operator/tests/operator_service_test.yaml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+---
+suite: test operator service
+templates:
+- operator/service.yaml
+chart:
+  version: 1.2.3
+  appVersion: 1.2.3
+release:
+  name: test-release
+  namespace: test-namespace
+
+tests:
+- it: manifest should match snapshot
+  asserts:
+  - matchSnapshot: {}
+
+- it: should not render when disabled
+  set:
+    operator:
+      enabled: false
+  asserts:
+  - hasDocuments:
+      count: 0
+
+- it: should set namespace
+  set:
+    namespaceOverride: "custom-namespace"
+  asserts:
+  - equal:
+      path: metadata.namespace
+      value: custom-namespace
+
+
+- it: should set name
+  set:
+    nameOverride: "custom-name"
+  asserts:
+  - equal:
+      path: metadata.name
+      value: custom-name

--- a/helm/slurm-operator/tests/webhook_deployment_test.yaml
+++ b/helm/slurm-operator/tests/webhook_deployment_test.yaml
@@ -1,8 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
 ---
-suite: test operator deployment
+suite: test webhook deployment
 templates:
-- operator/deployment.yaml
+- webhook/deployment.yaml
 chart:
   version: 1.2.3
   appVersion: 1.2.3
@@ -18,7 +18,7 @@ tests:
 
 - it: should add affinity
   set:
-    operator:
+    webhook:
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -36,7 +36,7 @@ tests:
 
 - it: should add tolerations
   set:
-    operator:
+    webhook:
       tolerations:
       - key: "test"
         operator: "Exists"
@@ -68,7 +68,7 @@ tests:
 
 - it: should set replica count
   set:
-    operator:
+    webhook:
       replicas: 42
   asserts:
   - equal:
@@ -89,12 +89,12 @@ tests:
   asserts:
   - equal:
       path: metadata.name
-      value: custom-name
+      value: custom-name-webhook
 
 
 - it: should set serviceAccount
   set:
-    operator:
+    webhook:
       serviceAccount:
         name: "custom-service-account"
   asserts:

--- a/helm/slurm-operator/tests/webhook_deployment_test.yaml
+++ b/helm/slurm-operator/tests/webhook_deployment_test.yaml
@@ -38,9 +38,9 @@ tests:
   set:
     webhook:
       tolerations:
-      - key: "test"
-        operator: "Exists"
-        effect: "NoExecute"
+      - key: test
+        operator: Exists
+        effect: NoExecute
         tolerationSeconds: 6000
   asserts:
   - equal:
@@ -51,7 +51,7 @@ tests:
 - it: should set imagePullSecrets
   set:
     imagePullSecrets:
-    - name: "test-docker-secret"
+    - name: test-docker-secret
   asserts:
   - equal:
       path: spec.template.spec.imagePullSecrets[0].name
@@ -59,7 +59,7 @@ tests:
 
 - it: should set priorityClassName
   set:
-    priorityClassName: "test-priority-class"
+    priorityClassName: test-priority-class
   asserts:
   - equal:
       path: spec.template.spec.priorityClassName
@@ -77,7 +77,7 @@ tests:
 
 - it: should set namespace
   set:
-    namespaceOverride: "custom-namespace"
+    namespaceOverride: custom-namespace
   asserts:
   - equal:
       path: metadata.namespace
@@ -85,7 +85,7 @@ tests:
 
 - it: should set name
   set:
-    nameOverride: "custom-name"
+    nameOverride: custom-name
   asserts:
   - equal:
       path: metadata.name
@@ -96,7 +96,7 @@ tests:
   set:
     webhook:
       serviceAccount:
-        name: "custom-service-account"
+        name: custom-service-account
   asserts:
   - equal:
       path: spec.template.spec.serviceAccountName

--- a/helm/slurm-operator/tests/webhook_rbac_test.yaml
+++ b/helm/slurm-operator/tests/webhook_rbac_test.yaml
@@ -1,8 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
 ---
-suite: test operator service
+suite: test webhook rbac
 templates:
-- operator/service.yaml
+- webhook/rbac.yaml
 chart:
   version: 1.2.3
   appVersion: 1.2.3
@@ -17,13 +17,26 @@ tests:
 
 - it: should not render when disabled
   set:
-    operator:
+    webhook:
       enabled: false
   asserts:
   - hasDocuments:
       count: 0
 
+- it: should not render when serviceAccount.create is false
+  set:
+    webhook:
+      serviceAccount:
+        create: false
+  asserts:
+  - hasDocuments:
+      count: 0
+
+
 - it: should set namespace
+  documentSelector:
+    path: kind
+    value: ServiceAccount
   set:
     namespaceOverride: custom-namespace
   asserts:
@@ -32,10 +45,15 @@ tests:
       value: custom-namespace
 
 
-- it: should set name
+- it: should set serviceAccount name
+  documentSelector:
+    path: kind
+    value: ServiceAccount
   set:
-    nameOverride: custom-name
+    webhook:
+      serviceAccount:
+        name: custom-service-account
   asserts:
   - equal:
       path: metadata.name
-      value: custom-name
+      value: custom-service-account

--- a/helm/slurm-operator/tests/webhook_service_test.yaml
+++ b/helm/slurm-operator/tests/webhook_service_test.yaml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+---
+suite: test webhook service
+templates:
+- webhook/service.yaml
+chart:
+  version: 1.2.3
+  appVersion: 1.2.3
+release:
+  name: test-release
+  namespace: test-namespace
+
+tests:
+- it: manifest should match snapshot
+  asserts:
+  - matchSnapshot: {}
+
+- it: should not render when disabled
+  set:
+    webhook:
+      enabled: false
+  asserts:
+  - hasDocuments:
+      count: 0
+
+- it: should set namespace
+  set:
+    namespaceOverride: "custom-namespace"
+  asserts:
+  - equal:
+      path: metadata.namespace
+      value: custom-namespace
+
+
+- it: should set name
+  set:
+    nameOverride: "custom-name"
+  asserts:
+  - equal:
+      path: metadata.name
+      value: custom-name-webhook

--- a/helm/slurm-operator/tests/webhook_service_test.yaml
+++ b/helm/slurm-operator/tests/webhook_service_test.yaml
@@ -25,7 +25,7 @@ tests:
 
 - it: should set namespace
   set:
-    namespaceOverride: "custom-namespace"
+    namespaceOverride: custom-namespace
   asserts:
   - equal:
       path: metadata.namespace
@@ -34,7 +34,7 @@ tests:
 
 - it: should set name
   set:
-    nameOverride: "custom-name"
+    nameOverride: custom-name
   asserts:
   - equal:
       path: metadata.name


### PR DESCRIPTION
## Description
This pull request introduces [Helm unit testing](https://github.com/helm-unittest/helm-unittest) to slinky project, enabling more robust and reliable Kubernetes chart development. By integrating the Helm unittest plugin, we can now validate our Helm chart configurations and templates before deployment, catching potential issues early in the development process.

## Changes
- Added Helm unittest plugin to project dependencies
- Configured initial unit test structure for Helm charts
- Implemented basic test cases for chart templates and values

## Proposed Changes
This PR runs `helm unittest` whenever the helm chart source code is changed.