### PR TITLE
fix(builder): Ensure deterministic order of merged environment variables

### DIFF
--- a/internal/builder/common.go
+++ b/internal/builder/common.go
@@ -6,6 +6,7 @@ package builder
 import (
 	_ "embed"
 	"fmt"
+	"sort"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -193,8 +194,16 @@ func mergeEnvVar(envVarList1, envVarList2 []corev1.EnvVar, sep string) []corev1.
 		}
 		envVarMap[env.Name] = ev
 	}
+	// Sort keys to ensure deterministic ordering of environment variables
+	keys := make([]string, 0, len(envVarMap))
+	for k := range envVarMap {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
 	envVarList := make([]corev1.EnvVar, 0, len(envVarMap))
-	for k, v := range envVarMap {
+	for _, k := range keys {
+		v := envVarMap[k]
 		envVar := corev1.EnvVar{
 			Name:      k,
 			Value:     strings.Join(v.Values, sep),


### PR DESCRIPTION
The `mergeEnvVar` function previously iterated directly over a map to build the final list of environment variables. Since map iteration order is not guaranteed in Go, this resulted in a non-deterministic order in the output list.

This indeterministic ordering caused the `slurm-operator` to incorrectly detect changes in the `loginset` pod spec, leading to an endless reconciliation loop where it would continuously create new ReplicaSets.

This PR fixes this behavior by:
1.  Importing the `sort` package.
2.  Extracting all map keys into a new slice.
3.  Sorting the slice of keys alphabetically using `sort.Strings`.
4.  Iterating over the sorted slice (instead of the map) to build the final environment variable list.

This ensures that the order of environment variables is always stable and deterministic, preventing unnecessary spec diffs and resolving the `loginset` reconciliation loop.