### PR TITLE
Prevent job termination on Slurm node lookup failures

### DIFF
--- a/internal/controller/nodeset/nodeset_sync_test.go
+++ b/internal/controller/nodeset/nodeset_sync_test.go
@@ -864,7 +864,8 @@ func TestNodeSetReconciler_processCondemned(t *testing.T) {
 					condemned: pods,
 					i:         0,
 				},
-				wantErr:    false,
+				// Expect error when Slurm node is not found
+				wantErr:    true,
 				wantDrain:  false,
 				wantDelete: true,
 			}
@@ -1054,7 +1055,9 @@ func TestNodeSetReconciler_processCondemned(t *testing.T) {
 			}
 			pod := tt.args.condemned[tt.args.i]
 			if isDrain, err := r.slurmControl.IsNodeDrain(tt.args.ctx, tt.args.nodeset, pod); err != nil {
-				t.Errorf("slurmControl.IsNodeDrain() error = %v", err)
+				if !tt.wantDelete {
+					t.Errorf("slurmControl.IsNodeDrain() error = %v", err)
+				}
 			} else if isDrain != tt.wantDrain && !tt.wantDelete {
 				t.Errorf("slurmControl.IsNodeDrain() = %v, wantDrain %v", isDrain, tt.wantDrain)
 			}
@@ -1897,7 +1900,8 @@ func TestNodeSetReconciler_syncRollingUpdate(t *testing.T) {
 					pods:    []*corev1.Pod{pod1, pod2},
 					hash:    hash,
 				},
-				wantErr: false,
+				// Expect error when Slurm node is not found
+				wantErr: true,
 			}
 		}(),
 	}

--- a/internal/controller/nodeset/slurmcontrol/slurmcontrol.go
+++ b/internal/controller/nodeset/slurmcontrol/slurmcontrol.go
@@ -280,15 +280,12 @@ func (r *realSlurmControl) IsNodeDrain(ctx context.Context, nodeset *slinkyv1bet
 	if slurmClient == nil {
 		logger.V(2).Info("no client for nodeset, cannot do IsNodeDrain()",
 			"pod", klog.KObj(pod))
-		return true, nil
+		return false, nil
 	}
 
 	slurmNode := &slurmtypes.V0044Node{}
 	key := slurmobject.ObjectKey(nodesetutils.GetNodeName(pod))
 	if err := slurmClient.Get(ctx, key, slurmNode); err != nil {
-		if tolerateError(err) {
-			return true, nil
-		}
 		return false, err
 	}
 
@@ -304,15 +301,12 @@ func (r *realSlurmControl) IsNodeDrained(ctx context.Context, nodeset *slinkyv1b
 	if slurmClient == nil {
 		logger.V(2).Info("no client for nodeset, cannot do IsNodeDrained()",
 			"pod", klog.KObj(pod))
-		return true, nil
+		return false, nil
 	}
 
 	slurmNode := &slurmtypes.V0044Node{}
 	key := slurmobject.ObjectKey(nodesetutils.GetNodeName(pod))
 	if err := slurmClient.Get(ctx, key, slurmNode); err != nil {
-		if tolerateError(err) {
-			return true, nil
-		}
 		return false, err
 	}
 

--- a/internal/controller/nodeset/slurmcontrol/slurmcontrol_test.go
+++ b/internal/controller/nodeset/slurmcontrol/slurmcontrol_test.go
@@ -465,6 +465,35 @@ func Test_realSlurmControl_IsNodeDrain(t *testing.T) {
 			want:    true,
 			wantErr: false,
 		},
+		{
+			name: "No Slurm client - fail closed",
+			fields: fields{
+				clientMap: clientmap.NewClientMap(),
+			},
+			args: args{
+				ctx:     ctx,
+				nodeset: nodeset,
+				pod:     pod,
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "Node not found - fail closed",
+			fields: func() fields {
+				sclient := fake.NewClientBuilder().Build()
+				return fields{
+					clientMap: newSlurmClientMap(controller.Name, sclient),
+				}
+			}(),
+			args: args{
+				ctx:     ctx,
+				nodeset: nodeset,
+				pod:     pod,
+			},
+			want:    false,
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -749,6 +778,35 @@ func Test_realSlurmControl_IsNodeDrained(t *testing.T) {
 				pod:     pod,
 			},
 			want: false,
+		},
+		{
+			name: "No Slurm client - fail closed",
+			fields: fields{
+				clientMap: clientmap.NewClientMap(),
+			},
+			args: args{
+				ctx:     ctx,
+				nodeset: nodeset,
+				pod:     pod,
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "Node not found - fail closed",
+			fields: func() fields {
+				sclient := fake.NewClientBuilder().Build()
+				return fields{
+					clientMap: newSlurmClientMap(controller.Name, sclient),
+				}
+			}(),
+			args: args{
+				ctx:     ctx,
+				nodeset: nodeset,
+				pod:     pod,
+			},
+			want:    false,
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

This PR fixes a critical bug where `IsNodeDrain()` and `IsNodeDrained()` functions use fail-open error handling, causing immediate pod deletion and job termination when SLURM node lookups fail.

Problem:

When the operator cannot query a Slurm node (e.g., node name mismatch, REST API unavailable, or node not yet registered), the current implementation returns `true` (indicating the node is drained), which causes the operator to immediately delete pods and kill running jobs..

Querying a non-existent Slurm node returns HTTP 200:


```
{ "errors": [ { "description": "Failure to query node bad-node-name", "error_number": 0, "error": "No error", "source": "_dump_nodes" } ], "warnings": [], "meta": { "plugin": { "type": "openapi\/slurmctld", "name": "Slurm OpenAPI slurmctld", "data_parser": "data_parser\/v0.0.43", "accounting_storage": "" }, "client": { "source": "localhost:6820(fd:11)", "user": "root", "group": "root" }, "command": [], "slurm": { "version": { "major": "25", "micro": "3", "minor": "05" }, "release": "25.05.3", "cluster": "slurm" } } } HTTP_STATUS:200
```

Solution:

Changed to fail-closed behavior - return `false` and the error when node status cannot be reliably determined. This prevents premature pod deletion and allows the operator to retry until it can properly verify the node is drained.

This fix makes the failure mode safe: if we cannot verify drain status, we wait and retry rather than destroying potentially busy nodes.

## Breaking Changes

N/A

## Testing

Deployed operator to verify fail-closed behavior:


```json
{"level":"error","ts":"2025-11-14T15:41:06+01:00",
 "msg":"encountered an error while reconciling request",
 "controller":"nodeset-controller",
 "controllerGroup":"slinky.slurm.net",
 "controllerKind":"NodeSet",
 "NodeSet":{"name":"slurm-worker-slinky","namespace":"slurm"},
 "error":"Not Found",
 "errorCauses":[{"error":"Not Found"}]}
```
