### PR TITLE
Explicitly set ProctrackType to proctrack/linuxproc when CGroup is di…

### DIFF
--- a/internal/builder/controller_config.go
+++ b/internal/builder/controller_config.go
@@ -196,6 +196,7 @@ func buildSlurmConf(
 		conf.AddProperty(config.NewProperty("TaskPlugin", "task/cgroup,task/affinity"))
 	} else {
 		conf.AddProperty(config.NewProperty("SlurmctldParameters", "enable_configless"))
+		conf.AddProperty(config.NewProperty("ProctrackType", "proctrack/linuxproc"))
 		conf.AddProperty(config.NewProperty("TaskPlugin", "task/affinity"))
 	}
 	if metricsEnabled {


### PR DESCRIPTION
…sabled

so that it won't default to proctrack/cgroup, crashing slurmd