### PR TITLE
Merge prolog/epilog scripts from ConfigMaps

### DIFF
--- a/internal/builder/controller_config.go
+++ b/internal/builder/controller_config.go
@@ -78,8 +78,9 @@ func (b *Builder) BuildControllerConfig(controller *slinkyv1beta1.Controller) (*
 		}
 		filenames := structutils.Keys(cm.Data)
 		sort.Strings(filenames)
-		prologScripts = filenames
+		prologScripts = append(prologScripts, filenames...)
 	}
+	sort.Strings(prologScripts)
 
 	epilogScripts := []string{}
 	for _, ref := range controller.Spec.EpilogScriptRefs {
@@ -93,8 +94,9 @@ func (b *Builder) BuildControllerConfig(controller *slinkyv1beta1.Controller) (*
 		}
 		filenames := structutils.Keys(cm.Data)
 		sort.Strings(filenames)
-		epilogScripts = filenames
+		epilogScripts = append(epilogScripts, filenames...)
 	}
+	sort.Strings(epilogScripts)
 
 	prologSlurmctldScripts := []string{}
 	for _, ref := range controller.Spec.PrologSlurmctldScriptRefs {
@@ -108,8 +110,9 @@ func (b *Builder) BuildControllerConfig(controller *slinkyv1beta1.Controller) (*
 		}
 		filenames := structutils.Keys(cm.Data)
 		sort.Strings(filenames)
-		prologSlurmctldScripts = filenames
+		prologSlurmctldScripts = append(prologSlurmctldScripts, filenames...)
 	}
+	sort.Strings(prologSlurmctldScripts)
 
 	epilogSlurmctldScripts := []string{}
 	for _, ref := range controller.Spec.EpilogSlurmctldScriptRefs {
@@ -123,8 +126,9 @@ func (b *Builder) BuildControllerConfig(controller *slinkyv1beta1.Controller) (*
 		}
 		filenames := structutils.Keys(cm.Data)
 		sort.Strings(filenames)
-		epilogSlurmctldScripts = filenames
+		epilogSlurmctldScripts = append(epilogSlurmctldScripts, filenames...)
 	}
+	sort.Strings(epilogSlurmctldScripts)
 
 	opts := ConfigMapOpts{
 		Key: controller.ConfigKey(),


### PR DESCRIPTION
<!--
Feature requests, code contributions, and bug reports are welcome!
Github/Gitlab submitted issues and PRs/MRs are handled on a best effort basis.
The SchedMD official issue tracker is at <https://support.schedmd.com/>.
-->

## Summary

Fixes a bug where enabling DCGM (`vendor.nvidia.dcgm.enabled=true`) caused custom `prologScripts` and `epilogScripts` to be overwritten instead of merged with the DCGM scripts.

In `internal/builder/controller_config.go`, the loop iterating over multiple ConfigMap references was using assignment (`=`) instead of append, causing each iteration to overwrite the previous script list.

## Breaking Changes

N/A

## Testing Notes

**Unit Tests:**
- Added test cases for multiple prolog/epilog ConfigMaps in `controller_config_test.go`
- Run: `go test ./internal/builder/... -run TestBuilder_BuildControllerConfig -v`

**Manual Verification:**

1. Deployed operator with fix
2. Created cluster with both custom scripts and DCGM enabled
3. Verified `slurm.conf` contains all scripts:
   ```
   Prolog=prolog-90-dcgm.sh
   Prolog=prolog-prolog-launch.sh
   Epilog=epilog-90-dcgm.sh
   Epilog=epilog-epilog-launch.sh
   ```
4. Confirmed scripts execute on job run:
   ```
   [Mon Dec 15 09:14:46 UTC 2025] Prolog executed for job 5
   [Mon Dec 15 09:14:46 UTC 2025] Epilog executed for job 5
   ```

## Additional Context

The fix adds `sort.Strings()` after merging to ensure consistent script ordering across reconciliation cycles.
