### PR TITLE
Use binary MiB for POD_MEMORY calculation

### DIFF
--- a/helm/slurm/templates/nodeset/_helpers.tpl
+++ b/helm/slurm/templates/nodeset/_helpers.tpl
@@ -55,13 +55,12 @@ Returns the parsed resource limits for POD_CPUS.
 {{- end -}}
 
 {{/*
-Returns the parsed resource limits for POD_MEMORY, in Megabytes.
-*/}}
+Returns the parsed resource limits for POD_MEMORY, in Mebibytes (MiB).*/}}
 {{- define "slurm.worker.podMemory" -}}
 {{- $out := 0 -}}
 {{- with .resources }}{{- with .limits }}{{- with .memory }}
-  {{- $megabytes := (include "resource-quantity" "1M") | float64 -}}
-  {{- $out = divf (include "resource-quantity" . | float64) $megabytes | ceil | int -}}
+  {{- $mebibytes := (include "resource-quantity" "1Mi") | float64 -}}
+  {{- $out = divf (include "resource-quantity" . | float64) $mebibytes | ceil | int -}}
 {{- end }}{{- end }}{{- end }}
 {{- print $out -}}
 {{- end -}}


### PR DESCRIPTION
<!--
Feature requests, code contributions, and bug reports are welcome!
Github/Gitlab submitted issues and PRs/MRs are handled on a best effort basis.
The SchedMD official issue tracker is at <https://support.schedmd.com/>.
-->

## Summary

Fix incorrect unit conversion in slurm.worker.podMemory Helm template helper function.

The function was using decimal megabytes ("1M" = 1,000,000 bytes) instead of binary mebibytes ("1Mi" = 1,048,576 bytes) when converting Kubernetes memory limits to POD_MEMORY. This mismatch caused `MemSpecLimit` to be calculated incorrectly, reducing available memory for jobs.

Impact example from production GKE cluster with 238Gi CPU worker limit:

Before fix:
```
$ scontrol show node cpu-0

NodeName=cpu-0 
RealMemory=257734 AllocMem=0 FreeMem=249411   
MemSpecLimit=252365
```

After fix:
```
$ scontrol show node cpu-0

NodeName=cpu-0 
RealMemory=257734 AllocMem=0 FreeMem=249376   
MemSpecLimit=14022
```

## Breaking Changes

N/A

## Testing Notes

- Confirmed Slurm uses MiB by comparing slurmd -C output with /proc/meminfo
- Deployed in internal environment and verified the fix


## Additional Context

- Affects clusters with useResourceLimits: true (default) and memory limits configured
- The error is more severe with larger memory limits

