### PR TITLE
Use SLURM_JOB_GPUS for job mapping

### DIFF
--- a/helm/slurm/_vendor/nvidia/dcgm/scripts/epilog/dcgm.sh
+++ b/helm/slurm/_vendor/nvidia/dcgm/scripts/epilog/dcgm.sh
@@ -17,12 +17,12 @@ function set_globals() {
 }
 
 function clean_gpu_job_files() {
-	if [[ -z ${CUDA_VISIBLE_DEVICES:-} ]]; then
-		log_msg "no gres cuda devices requested by user"
+	if [[ -z ${SLURM_JOB_GPUS:-} ]]; then
+		log_msg "no gres gpus requested by user"
 		return
 	fi
 
-	mapfile -t -d ',' cuda_devs <<<"${CUDA_VISIBLE_DEVICES:-}"
+	mapfile -t -d ',' cuda_devs <<<"${SLURM_JOB_GPUS:-}"
 	cuda_devs[-1]="${cuda_devs[-1]%$'\n'}"
 
 	for gpu_id in "${cuda_devs[@]}"; do

--- a/helm/slurm/_vendor/nvidia/dcgm/scripts/prolog/dcgm.sh
+++ b/helm/slurm/_vendor/nvidia/dcgm/scripts/prolog/dcgm.sh
@@ -17,8 +17,8 @@ function set_globals() {
 }
 
 function make_gpu_job_files() {
-	if [[ -z ${CUDA_VISIBLE_DEVICES:-} ]]; then
-		log_msg "no gres cuda devices requested by user"
+	if [[ -z ${SLURM_JOB_GPUS:-} ]]; then
+		log_msg "no gres gpus requested by user"
 		return
 	fi
 
@@ -29,7 +29,7 @@ function make_gpu_job_files() {
 		)
 	fi
 
-	mapfile -t -d ',' cuda_devs <<<"${CUDA_VISIBLE_DEVICES:-}"
+	mapfile -t -d ',' cuda_devs <<<"${SLURM_JOB_GPUS:-}"
 	cuda_devs[-1]="${cuda_devs[-1]%$'\n'}"
 
 	for gpu_id in "${cuda_devs[@]}"; do


### PR DESCRIPTION
## Summary

With Slurm 25.11, `CUDA_VISIBLE_DEVICES` now contains GPU UUIDs instead of numeric indices. This breaks DCGM job mapping which expects numeric GPU indices as filenames (e.g., `/var/run/dcgm/job_mapping/0`).

This PR updates the DCGM prolog and epilog scripts to use `SLURM_JOB_GPUS` instead, which continues to provide numeric GPU indices regardless of Slurm version.

## Breaking Changes

None

## Testing Notes

- Deploy a Slurm cluster with DCGM enabled using Slurm 25.11
- Submit a GPU job: srun --gres=gpu:2 nvidia-smi
- Verify job mapping files are created with numeric indices