### PR TITLE
fix: update helm chart logos to point directly to images on GitHub

### DIFF
--- a/helm/slurm-operator-crds/Chart.yaml
+++ b/helm/slurm-operator-crds/Chart.yaml
@@ -10,7 +10,7 @@ annotations:
   license: Apache-2.0
 
 home: https://slinky.schedmd.com/
-icon: https://github.com/SlinkyProject/docs/blob/main/docs/_static/images/slinky.svg
+icon: https://raw.githubusercontent.com/SlinkyProject/docs/refs/heads/main/docs/_static/images/slinky.svg
 
 sources:
   - https://github.com/SlinkyProject/slurm-operator

--- a/helm/slurm-operator/Chart.yaml
+++ b/helm/slurm-operator/Chart.yaml
@@ -12,7 +12,7 @@ annotations:
   license: Apache-2.0
 
 home: https://slinky.schedmd.com/
-icon: https://github.com/SlinkyProject/docs/blob/main/docs/_static/images/slinky.svg
+icon: https://raw.githubusercontent.com/SlinkyProject/docs/refs/heads/main/docs/_static/images/slinky.svg
 
 sources:
   - https://github.com/SlinkyProject/slurm-operator

--- a/helm/slurm/Chart.yaml
+++ b/helm/slurm/Chart.yaml
@@ -12,7 +12,7 @@ annotations:
   license: Apache-2.0
 
 home: https://slurm.schedmd.com/
-icon: https://github.com/SlinkyProject/docs/blob/main/docs/_static/images/slurm-square-500.png
+icon: https://raw.githubusercontent.com/SlinkyProject/docs/refs/heads/main/docs/_static/images/slurm-square-500.png
 
 sources:
   - https://github.com/SchedMD/slurm


### PR DESCRIPTION
<!--
Feature requests, code contributions, and bug reports are welcome!
Github/Gitlab submitted issues and PRs/MRs are handled on a best effort basis.
The SchedMD official issue tracker is at <https://support.schedmd.com/>.
-->

## Summary

Simple fix to update logo paths of Helm charts