### PR TITLE
fix(builder): use bash for initconf container command

### DIFF
--- a/internal/builder/common.go
+++ b/internal/builder/common.go
@@ -225,7 +225,7 @@ func (b *Builder) initconfContainer(container slinkyv1beta1.ContainerWrapper) co
 				},
 			},
 			Command: []string{
-				"sh",
+				"bash",
 				"-c",
 				initConfScript,
 			},


### PR DESCRIPTION
Hi 👋 my first contribution here, please give me feedback if you find the PR lacking in any way :)

## Summary

initconf shell compatibility - Changed sh to bash for the initconf script execution, which uses bash-specific set -euo pipefail

The initconf container uses hardcoded `sh -c` to execute an embedded script containing `set -euo pipefail`. This fails with Debian/Ubuntu-based containers that use POSIX-compliant dash as /bin/sh.

You can reproduce this by defining an initConf container with eg. image `ghcr.io/slinkyproject/login:25.11-ubuntu24.04` which will then fail on startup.

The bug is masked for most users because the default Alpine image uses BusyBox, which has non-standard bash extensions including pipefail support.

## Breaking Changes

Zero breaking changes

## Testing Notes

1. Create a values file overriding initconf to use Ubuntu:

```yaml
loginsets:
  slinky:
  enabled: true
  replicas: 1
  initconf:
    image:
      repository: ghcr.io/slinkyproject/login
      tag: 25.11-ubuntu24.04
```

2. Deploy the Slurm cluster:

```bash
helm install slurm oci://ghcr.io/slinkyproject/charts/slurm \
--namespace slurm --create-namespace \
--values values-slurm.yaml \
--values values-ubuntu-initconf.yaml
```

3. Check the LoginSet pod status:

```bash
kubectl get pods -n slurm -l app.kubernetes.io/component=login
kubectl logs -n slurm <loginset-pod-name> -c initconf
```

Expected: Pod starts successfully
Actual: InitContainer fails with: `/bin/sh: 1: set: Illegal option -o pipefail`

Option 2: Quick verification with Docker

```bash
# Ubuntu (dash) - fails as expected
docker run --rm ubuntu:24.04 sh -c 'set -euo pipefail; echo "Ubuntu: OK"'`
# Output: /bin/sh: 1: set: Illegal option -o pipefail

# Alpine (BusyBox) - works by accident
docker run --rm alpine:latest sh -c 'set -euo pipefail; echo "Alpine: OK"'
# Output: Alpine: OK
```

## Additional Context


