### PR TITLE
fix(chart): Empty slices from default values override operator defaults in LoginSet, Worker, etc.

### DIFF
--- a/helm/slurm/values.yaml
+++ b/helm/slurm/values.yaml
@@ -229,6 +229,9 @@ controller:
     # labels: {}
   # -- (corev1.PodSpec) Extend the pod template, and/or override certain configurations.
   # Ref: https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates
+  # NOTE: To allow operator defaults to be applied, initContainers, containers,
+  # volumes, and ephemeralContainers should not be set to empty slices.
+  # Only specify these fields when you want to override the operator's defaults.
   podSpec:
     # -- The pod resource limits and requests.
     # Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container
@@ -239,7 +242,11 @@ controller:
     # -- Additional initContainers for the pod.
     # Ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
     # Ref: https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/
-    initContainers: []
+    # WARNING: Setting this field will override operator defaults. Uncomment only
+    # when you want to explicitly add or replace initContainers provided by the operator.
+    # initContainers:
+    #   - name: my-init
+    #     image: alpine:latest
     # -- (map[string]string) Node label selector for pod assignment.
     # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
     nodeSelector:
@@ -329,6 +336,9 @@ restapi:
     # labels: {}
   # -- (corev1.PodSpec) Extend the pod template, and/or override certain configurations.
   # Ref: https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates
+  # NOTE: To allow operator defaults to be applied, initContainers, containers,
+  # volumes, and ephemeralContainers should not be set to empty slices.
+  # Only specify these fields when you want to override the operator's defaults.
   podSpec:
     # -- The pod resource limits and requests.
     # Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container
@@ -339,7 +349,11 @@ restapi:
     # -- Additional initContainers for the pod.
     # Ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
     # Ref: https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/
-    initContainers: []
+    # WARNING: Setting this field will override operator defaults. Uncomment only
+    # when you want to explicitly add or replace initContainers provided by the operator.
+    # initContainers:
+    #   - name: my-init
+    #     image: alpine:latest
     # -- (map[string]string) Node label selector for pod assignment.
     # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
     nodeSelector:
@@ -441,6 +455,9 @@ accounting:
     # labels: {}
   # -- (corev1.PodSpec) Extend the pod template, and/or override certain configurations.
   # Ref: https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates
+  # NOTE: To allow operator defaults to be applied, initContainers, containers,
+  # volumes, and ephemeralContainers should not be set to empty slices.
+  # Only specify these fields when you want to override the operator's defaults.
   podSpec:
     # -- The pod resource limits and requests.
     # Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container
@@ -451,7 +468,11 @@ accounting:
     # -- Additional initContainers for the pod.
     # Ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
     # Ref: https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/
-    initContainers: []
+    # WARNING: Setting this field will override operator defaults. Uncomment only
+    # when you want to explicitly add or replace initContainers provided by the operator.
+    # initContainers:
+    #   - name: my-init
+    #     image: alpine:latest
     # -- (map[string]string) Node label selector for pod assignment.
     # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
     nodeSelector:
@@ -573,6 +594,9 @@ loginsets:
     workloadDisruptionProtection: true
     # -- (corev1.PodSpec) Extend the pod template, and/or override certain configurations.
     # Ref: https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates
+    # NOTE: To allow operator defaults to be applied, initContainers, containers,
+    # volumes, and ephemeralContainers should not be set to empty slices.
+    # Only specify these fields when you want to override the operator's defaults.
     podSpec:
       # -- The pod resource limits and requests.
       # Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container
@@ -583,7 +607,11 @@ loginsets:
       # -- Additional initContainers for the pod.
       # Ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
       # Ref: https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/
-      initContainers: []
+      # WARNING: Setting this field will override operator defaults. Uncomment only
+      # when you want to explicitly add or replace initContainers provided by the operator.
+      # initContainers:
+      #   - name: my-init
+      #     image: alpine:latest
       # -- (map[string]string) Node label selector for pod assignment.
       # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
       nodeSelector:
@@ -599,11 +627,13 @@ loginsets:
         #   effect: NoSchedule
       # -- List of volumes to use.
       # Ref: https://kubernetes.io/docs/concepts/storage/volumes/
-      volumes: []
-        # - name: nfs-home
-        #   nfs:
-        #     server: nfs-server.example.com
-        #     path: /exports/home
+      # WARNING: Setting this field will override operator defaults. Uncomment only
+      # when you want to explicitly add or replace volumes provided by the operator.
+      # volumes:
+      #   - name: nfs-home
+      #     nfs:
+      #       server: nfs-server.example.com
+      #       path: /exports/home
     # -- The service configuration.
     service:
       # -- Labels and annotations.
@@ -719,6 +749,9 @@ nodesets:
       # labels: {}
     # -- (corev1.PodSpec) Extend the pod template, and/or override certain configurations.
     # Ref: https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates
+    # NOTE: To allow operator defaults to be applied, initContainers, containers,
+    # volumes, and ephemeralContainers should not be set to empty slices.
+    # Only specify these fields when you want to override the operator's defaults.
     podSpec:
       # -- The pod resource limits and requests.
       # Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container
@@ -729,7 +762,11 @@ nodesets:
       # -- Additional initContainers for the pod.
       # Ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
       # Ref: https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/
-      initContainers: []
+      # WARNING: Setting this field will override operator defaults. Uncomment only
+      # when you want to explicitly add or replace initContainers provided by the operator.
+      # initContainers:
+      #   - name: my-init
+      #     image: alpine:latest
       # -- (map[string]string) Node label selector for pod assignment.
       # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
       nodeSelector:
@@ -744,11 +781,13 @@ nodesets:
         #   effect: NoSchedule
       # -- List of volumes to use.
       # Ref: https://kubernetes.io/docs/concepts/storage/volumes/
-      volumes: []
-        # - name: nfs-home
-        #   nfs:
-        #     server: nfs-server.example.com
-        #     path: /exports/home
+      # WARNING: Setting this field will override operator defaults. Uncomment only
+      # when you want to explicitly add or replace volumes provided by the operator.
+      # volumes:
+      #   - name: nfs-home
+      #     nfs:
+      #       server: nfs-server.example.com
+      #       path: /exports/home
 
 # -- (map[string]object) Slurm partition configurations.
 # The map key represents the partition name (must be unique); the map value represents the partition definition.


### PR DESCRIPTION
## Summary

The default values.yaml had `initContainers: []` and `volumes: []` which
would override operator-provided defaults, causing pods to start without
essential containers.

Rather than fixing this in the template (which would prevent legitimate
override use cases), we fix it in the default values by removing the
empty slices and adding documentation explaining that these fields will
override operator defaults.

Users who want to explicitly override operator defaults can uncomment
and populate these fields.

- Controller, LoginSet, Worker had their initContainers wiped
- LoginSet, Worker additionally had their volumes wiped
- Accounting only had volumes (not affected by values.yaml but has operator volumes)
- RestAPI only had volumes (not affected by values.yaml)

So the bug primarily broke:
1. LoginSet - lost initconf container AND volumes
2. Worker/NodeSet - lost logfile container AND volumes
3. Controller - lost reconfigure + logfile containers

LoginSet would fail completely because it needs initconf to set up slurm config before the login container starts. The LoginSet CRD would appear without any replicas value and was not possible to scale up.

## Breaking Changes

Users with default values.yaml will now receive the chart default init containers, volumes instead of none. LoginSet pods launching without this will enter a crash loop anyway, so we can assume that this behavior is not relied upon(?)

## Testing Notes

1. Helm Template Validation

```bash
# Verify template renders without errors
helm template slurm oci://ghcr.io/slinkyproject/charts/slurm \
  --namespace slurm \
  --values values.yaml \
  --debug > /dev/null
```

2. InitContainer Validation (verify operator defaults aren't overridden)

```bash
# Deploy and check that initContainers from operator are present
helm install slurm oci://ghcr.io/slinkyproject/charts/slurm \
  --namespace slurm --create-namespace \
  --values values.yaml

# Controller should have reconfigure + logfile initContainers
kubectl get pod -n slurm -l app.kubernetes.io/component=controller -o jsonpath='{.items[0].spec.initContainers[*].name}'

# LoginSet should have initconf initContainer
kubectl get pod -n slurm -l app.kubernetes.io/component=login -o jsonpath='{.items[0].spec.initContainers[*].name}'

# NodeSet should have logfile initContainer
kubectl get pod -n slurm -l app.kubernetes.io/component=worker -o jsonpath='{.items[0].spec.initContainers[*].name}'
```

3. Volume Validation (for LoginSet, NodeSet)

```bash
# LoginSet should have slurm-etc, sackd-dir volumes from operator
kubectl get pod -n slurm -l app.kubernetes.io/component=login -o jsonpath='{.items[0].spec.volumes[*].name}'

# NodeSet should have slurm-etc, socket volumes from operator
kubectl get pod -n slurm -l app.kubernetes.io/component=worker -o jsonpath='{.items[0].spec.volumes[*].name}'
```

4. Shell Compatibility (initconf with bash)

```bash
# Test initconf container starts without errors
kubectl logs -n slurm <loginset-pod-name> -c initconf
```
6. Scaling Test

```bash
# Verify LoginSet scaling works
kubectl scale loginsets.slurm.slurm.net slinky -n slurm --replicas=2
kubectl get pods -n slurm -l app.kubernetes.io/component=login
```

## Additional Context

<!--
Provide any other additional information here.
(e.g. which commits are critical or superfluous; why this implementation)
-->
