### PR TITLE
feat(worker): use exec liveness probe for node registration check

### DIFF
--- a/internal/builder/workerbuilder/worker_app.go
+++ b/internal/builder/workerbuilder/worker_app.go
@@ -219,9 +219,8 @@ func (b *WorkerBuilder) slurmdContainer(nodeset *slinkyv1beta1.NodeSet, controll
 			},
 			LivenessProbe: &corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
-					HTTPGet: &corev1.HTTPGetAction{
-						Path: "/livez",
-						Port: intstr.FromString(labels.WorkerApp),
+					Exec: &corev1.ExecAction{
+						Command: []string{"/usr/local/bin/slurmd-liveness.sh"},
 					},
 				},
 				FailureThreshold: 6,

--- a/internal/builder/workerbuilder/worker_app_test.go
+++ b/internal/builder/workerbuilder/worker_app_test.go
@@ -102,6 +102,12 @@ func TestBuilder_BuildWorkerPodTemplate(t *testing.T) {
 
 			case len(got.Spec.DNSConfig.Searches) == 0:
 				t.Errorf("len(DNSConfig.Searches) = %v , want = > 0", len(got.Spec.DNSConfig.Searches))
+
+			case got.Spec.Containers[0].LivenessProbe == nil ||
+				got.Spec.Containers[0].LivenessProbe.Exec == nil ||
+				got.Spec.Containers[0].LivenessProbe.Exec.Command[0] != "/usr/local/bin/slurmd-liveness.sh":
+				t.Errorf("Containers[0].LivenessProbe.Exec.Command = %v, want = [/usr/local/bin/slurmd-liveness.sh]",
+					got.Spec.Containers[0].LivenessProbe)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Change the slurmd container's liveness probe from HTTPGet to Exec, using a custom script that verifies both local slurmd health and node registration with the controller.

The existing HTTPGet /livez probe only verifies local slurmd health. It doesn't detect when a node is not registered with the Slurm controller, which can leave worker pods running but unable to receive jobs.

## Solution

Use an Exec probe that runs `/usr/local/bin/slurmd-liveness.sh`, which:

1. Checks local slurmd health via `scontrol show slurmd`
2. Verifies node is registered with the controller via `scontrol show node`


## Breaking Changes

N/A

## Testing Notes

- [x] Built images locally
- [x] Deployed to Kind cluster
- [x] Verified probe passes when node is registered
- [x] Verified probe fails
- [x] Verified pod restarts and re-registers automatically

## Additional Context

- Requires corresponding change in https://github.com/SlinkyProject/containers/pull/13
