### PR TITLE
feat: add helm unit tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -105,6 +105,13 @@ repos:
         files: ^helm/
         language: system
         pass_filenames: false
+      - id: make-helm-unittest
+        name: Make Helm Unittest
+        entry: make helm-unittest
+        types: [yaml]
+        files: ^helm/
+        language: system
+        pass_filenames: false
       # https://github.com/golangci/golangci-lint/blob/main/.pre-commit-hooks.yaml
       - id: make-golangci-lint
         name: make-golangci-lint

--- a/Makefile
+++ b/Makefile
@@ -224,6 +224,14 @@ helm-docs: helm-docs-bin ## Run helm-docs.
 helm-lint: ## Lint Helm charts.
 	find "helm/" -depth -mindepth 1 -maxdepth 1 -type d -print0 | xargs -0r -n1 helm lint --strict
 
+.PHONY: helm-unittest
+helm-unittest: ## Run helm-unittest.
+	@if ! helm plugin list | grep -q "unittest"; then \
+		helm plugin install https://github.com/helm-unittest/helm-unittest ;\
+	fi
+	find "helm/" -depth -mindepth 1 -maxdepth 1 -type d -print0 | xargs -0r -n1 helm unittest --strict
+
+
 .PHONY: helm-dependency-update
 helm-dependency-update: ## Update Helm chart dependencies.
 	find "helm/" -depth -mindepth 1 -maxdepth 1 -type d -print0 | xargs -0r -n1 helm dependency update

--- a/helm/slurm-operator/.helmignore
+++ b/helm/slurm-operator/.helmignore
@@ -23,3 +23,4 @@
 .vscode/
 # Development files
 skaffold.yaml
+tests/

--- a/helm/slurm-operator/tests/__snapshot__/operator_deployment_test.yaml.snap
+++ b/helm/slurm-operator/tests/__snapshot__/operator_deployment_test.yaml.snap
@@ -1,0 +1,68 @@
+manifest should match snapshot:
+  1: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app.kubernetes.io/instance: test-release
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: slurm-operator
+        app.kubernetes.io/version: 1.2.3
+        helm.sh/chart: slurm-operator-1.2.3
+      name: slurm-operator
+      namespace: test-namespace
+    spec:
+      replicas: 1
+      revisionHistoryLimit: 0
+      selector:
+        matchLabels:
+          app.kubernetes.io/instance: test-release
+          app.kubernetes.io/name: slurm-operator
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/instance: test-release
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: slurm-operator
+            app.kubernetes.io/version: 1.2.3
+            helm.sh/chart: slurm-operator-1.2.3
+        spec:
+          containers:
+            - args:
+                - --accounting-workers
+                - "4"
+                - --controller-workers
+                - "4"
+                - --loginset-workers
+                - "4"
+                - --nodeset-workers
+                - "4"
+                - --restapi-workers
+                - "4"
+                - --token-workers
+                - "4"
+                - --slurmclient-workers
+                - "2"
+                - --zap-log-level
+                - info
+                - --health-addr
+                - :8081
+                - --metrics-addr
+                - :8080
+                - --leader-elect
+                - --leader-elect-namespace
+                - test-namespace
+              image: ghcr.io/slinkyproject/slurm-operator:1.2.3
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                httpGet:
+                  path: /healthz
+                  port: 8081
+              name: slurm-operator
+              readinessProbe:
+                httpGet:
+                  path: /readyz
+                  port: 8081
+          hostname: slurm-operator
+          priorityClassName: null
+          serviceAccountName: test-release-slurm-operator

--- a/helm/slurm-operator/tests/__snapshot__/operator_rbac_test.yaml.snap
+++ b/helm/slurm-operator/tests/__snapshot__/operator_rbac_test.yaml.snap
@@ -1,0 +1,161 @@
+manifest should match snapshot:
+  1: |
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      labels:
+        app.kubernetes.io/instance: test-release
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: slurm-operator
+        app.kubernetes.io/version: 1.2.3
+        helm.sh/chart: slurm-operator-1.2.3
+      name: test-release-slurm-operator
+      namespace: test-namespace
+  2: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: test-release-slurm-operator
+      namespace: test-namespace
+    rules:
+      - apiGroups:
+          - ""
+        resources:
+          - configmaps
+          - events
+          - persistentvolumeclaims
+          - pods
+          - secrets
+          - services
+        verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+      - apiGroups:
+          - ""
+        resources:
+          - nodes
+        verbs:
+          - get
+          - list
+          - watch
+          - patch
+      - apiGroups:
+          - ""
+        resources:
+          - pods/status
+        verbs:
+          - get
+          - patch
+          - update
+      - apiGroups:
+          - apps
+        resources:
+          - controllerrevisions
+          - deployments
+          - statefulsets
+        verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+      - apiGroups:
+          - monitoring.coreos.com
+        resources:
+          - servicemonitors
+        verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+      - apiGroups:
+          - policy
+        resources:
+          - poddisruptionbudgets
+        verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+      - apiGroups:
+          - slinky.slurm.net
+        resources:
+          - accountings
+          - controllers
+          - loginsets
+          - nodesets
+          - restapis
+          - tokens
+        verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+      - apiGroups:
+          - slinky.slurm.net
+        resources:
+          - accountings/finalizers
+          - controllers/finalizers
+          - loginsets/finalizers
+          - nodesets/finalizers
+          - restapis/finalizers
+          - tokens/finalizers
+        verbs:
+          - update
+      - apiGroups:
+          - slinky.slurm.net
+        resources:
+          - accountings/status
+          - controllers/status
+          - loginsets/status
+          - nodesets/status
+          - restapis/status
+          - tokens/status
+        verbs:
+          - get
+          - patch
+          - update
+      - apiGroups:
+          - coordination.k8s.io
+        resources:
+          - leases
+        verbs:
+          - get
+          - create
+          - update
+          - patch
+  3: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      labels:
+        app.kubernetes.io/instance: test-release
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: slurm-operator
+        app.kubernetes.io/version: 1.2.3
+        helm.sh/chart: slurm-operator-1.2.3
+      name: test-release-slurm-operator
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: test-release-slurm-operator
+    subjects:
+      - kind: ServiceAccount
+        name: test-release-slurm-operator
+        namespace: test-namespace

--- a/helm/slurm-operator/tests/__snapshot__/operator_service_test.yaml.snap
+++ b/helm/slurm-operator/tests/__snapshot__/operator_service_test.yaml.snap
@@ -1,0 +1,30 @@
+manifest should match snapshot:
+  1: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app.kubernetes.io/instance: test-release
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: slurm-operator
+        app.kubernetes.io/version: 1.2.3
+        helm.sh/chart: slurm-operator-1.2.3
+      name: slurm-operator
+      namespace: test-namespace
+    spec:
+      clusterIP: None
+      ports:
+        - name: metrics
+          port: 8080
+          protocol: TCP
+          targetPort: 8080
+        - name: health
+          port: 8081
+          protocol: TCP
+          targetPort: 8081
+      selector:
+        app.kubernetes.io/instance: test-release
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: slurm-operator
+        app.kubernetes.io/version: 1.2.3
+        helm.sh/chart: slurm-operator-1.2.3

--- a/helm/slurm-operator/tests/__snapshot__/webhook_deployment_test.yaml.snap
+++ b/helm/slurm-operator/tests/__snapshot__/webhook_deployment_test.yaml.snap
@@ -1,0 +1,67 @@
+manifest should match snapshot:
+  1: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app.kubernetes.io/instance: test-release
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: slurm-operator-webhook
+        app.kubernetes.io/version: 1.2.3
+        helm.sh/chart: slurm-operator-1.2.3
+      name: slurm-operator-webhook
+      namespace: test-namespace
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/instance: test-release
+          app.kubernetes.io/name: slurm-operator-webhook
+      strategy:
+        rollingUpdate:
+          maxSurge: 1
+          maxUnavailable: 0
+        type: RollingUpdate
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/instance: test-release
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: slurm-operator-webhook
+            app.kubernetes.io/version: 1.2.3
+            helm.sh/chart: slurm-operator-1.2.3
+        spec:
+          containers:
+            - args:
+                - --zap-log-level
+                - info
+                - --server-addr
+                - :9443
+                - --health-addr
+                - :8081
+                - --leader-elect
+                - --leader-elect-namespace
+                - test-namespace
+              image: ghcr.io/slinkyproject/slurm-operator-webhook:1.2.3
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                httpGet:
+                  path: /healthz
+                  port: 8081
+              name: webhook
+              readinessProbe:
+                httpGet:
+                  path: /readyz
+                  port: 8081
+              volumeMounts:
+                - mountPath: /tmp/k8s-webhook-server/serving-certs/
+                  name: certificates
+                  readOnly: true
+          hostname: slurm-operator-webhook
+          priorityClassName: null
+          serviceAccountName: slurm-operator-webhook
+          volumes:
+            - name: certificates
+              secret:
+                defaultMode: 420
+                secretName: slurm-operator-webhook-ca

--- a/helm/slurm-operator/tests/__snapshot__/webhook_rbac_test.yaml.snap
+++ b/helm/slurm-operator/tests/__snapshot__/webhook_rbac_test.yaml.snap
@@ -1,0 +1,108 @@
+manifest should match snapshot:
+  1: |
+    apiVersion: v1
+    automountServiceAccountToken: true
+    kind: ServiceAccount
+    metadata:
+      labels:
+        app.kubernetes.io/instance: test-release
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: slurm-operator-webhook
+        app.kubernetes.io/version: 1.2.3
+        helm.sh/chart: slurm-operator-1.2.3
+      name: slurm-operator-webhook
+      namespace: test-namespace
+  2: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        app.kubernetes.io/instance: test-release
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: slurm-operator-webhook
+        app.kubernetes.io/version: 1.2.3
+        helm.sh/chart: slurm-operator-1.2.3
+      name: slurm-operator-webhook
+      namespace: test-namespace
+    rules:
+      - apiGroups:
+          - slinky.slurm.net
+        resources:
+          - accountings
+          - controllers
+          - loginsets
+          - nodesets
+          - restapis
+          - tokens
+        verbs:
+          - create
+          - delete
+          - update
+      - apiGroups:
+          - ""
+        resources:
+          - configmaps
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - ""
+        resources:
+          - events
+        verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+      - apiGroups:
+          - ""
+        resources:
+          - pods
+        verbs:
+          - get
+          - list
+          - patch
+          - update
+          - watch
+      - apiGroups:
+          - ""
+        resources:
+          - nodes
+          - pods/binding
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - coordination.k8s.io
+        resources:
+          - leases
+        verbs:
+          - get
+          - create
+          - update
+          - patch
+  3: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      labels:
+        app.kubernetes.io/instance: test-release
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: slurm-operator-webhook
+        app.kubernetes.io/version: 1.2.3
+        helm.sh/chart: slurm-operator-1.2.3
+      name: slurm-operator-webhook
+      namespace: test-namespace
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: slurm-operator-webhook
+    subjects:
+      - kind: ServiceAccount
+        name: slurm-operator-webhook
+        namespace: test-namespace

--- a/helm/slurm-operator/tests/__snapshot__/webhook_service_test.yaml.snap
+++ b/helm/slurm-operator/tests/__snapshot__/webhook_service_test.yaml.snap
@@ -1,0 +1,27 @@
+manifest should match snapshot:
+  1: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app.kubernetes.io/instance: test-release
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: slurm-operator-webhook
+        app.kubernetes.io/version: 1.2.3
+        helm.sh/chart: slurm-operator-1.2.3
+      name: slurm-operator-webhook
+      namespace: test-namespace
+    spec:
+      ports:
+        - name: https
+          port: 443
+          protocol: TCP
+          targetPort: 9443
+        - name: health
+          port: 8081
+          protocol: TCP
+          targetPort: 8081
+      selector:
+        app.kubernetes.io/instance: test-release
+        app.kubernetes.io/name: slurm-operator-webhook
+      type: ClusterIP

--- a/helm/slurm-operator/tests/operator_deployment_test.yaml
+++ b/helm/slurm-operator/tests/operator_deployment_test.yaml
@@ -1,0 +1,103 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+---
+suite: test operator deployment
+templates:
+- operator/deployment.yaml
+chart:
+  version: 1.2.3
+  appVersion: 1.2.3
+release:
+  name: test-release
+  namespace: test-namespace
+
+tests:
+- it: manifest should match snapshot
+  asserts:
+  - matchSnapshot: {}
+
+
+- it: should add affinity
+  set:
+    operator:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: arch
+                operator: In
+                values:
+                - x86_64
+  asserts:
+  - equal:
+      path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]
+      value: x86_64
+
+
+- it: should add tolerations
+  set:
+    operator:
+      tolerations:
+      - key: test
+        operator: Exists
+        effect: NoExecute
+        tolerationSeconds: 6000
+  asserts:
+  - equal:
+      path: spec.template.spec.tolerations[0].key
+      value: test
+
+
+- it: should set imagePullSecrets
+  set:
+    imagePullSecrets:
+    - name: test-docker-secret
+  asserts:
+  - equal:
+      path: spec.template.spec.imagePullSecrets[0].name
+      value: test-docker-secret
+
+- it: should set priorityClassName
+  set:
+    priorityClassName: test-priority-class
+  asserts:
+  - equal:
+      path: spec.template.spec.priorityClassName
+      value: test-priority-class
+
+
+- it: should set replica count
+  set:
+    operator:
+      replicas: 42
+  asserts:
+  - equal:
+      path: spec.replicas
+      value: 42
+
+- it: should set namespace
+  set:
+    namespaceOverride: custom-namespace
+  asserts:
+  - equal:
+      path: metadata.namespace
+      value: custom-namespace
+
+- it: should set name
+  set:
+    nameOverride: custom-name
+  asserts:
+  - equal:
+      path: metadata.name
+      value: custom-name
+
+
+- it: should set serviceAccount
+  set:
+    operator:
+      serviceAccount:
+        name: custom-service-account
+  asserts:
+  - equal:
+      path: spec.template.spec.serviceAccountName
+      value: custom-service-account

--- a/helm/slurm-operator/tests/operator_rbac_test.yaml
+++ b/helm/slurm-operator/tests/operator_rbac_test.yaml
@@ -1,0 +1,56 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+---
+suite: test operator rbac
+templates:
+- operator/rbac.yaml
+chart:
+  version: 1.2.3
+  appVersion: 1.2.3
+release:
+  name: test-release
+  namespace: test-namespace
+
+tests:
+- it: manifest should match snapshot
+  asserts:
+  - matchSnapshot: {}
+
+- it: should not render when disabled
+  set:
+    operator:
+      enabled: false
+  asserts:
+  - hasDocuments:
+      count: 0
+
+- it: should not render when serviceAccount.create is false
+  set:
+    operator:
+      serviceAccount:
+        create: false
+  asserts:
+  - hasDocuments:
+      count: 0
+
+
+
+- it: should set namespace
+  documentSelector:
+    path: kind
+    value: ServiceAccount
+  set:
+    namespaceOverride: custom-namespace
+  asserts:
+  - equal:
+      path: metadata.namespace
+      value: custom-namespace
+
+- it: should set serviceAccount name
+  set:
+    operator:
+      serviceAccount:
+        name: custom-service-account
+  asserts:
+  - equal:
+      path: metadata.name
+      value: custom-service-account

--- a/helm/slurm-operator/tests/operator_service_test.yaml
+++ b/helm/slurm-operator/tests/operator_service_test.yaml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+---
+suite: test operator service
+templates:
+- operator/service.yaml
+chart:
+  version: 1.2.3
+  appVersion: 1.2.3
+release:
+  name: test-release
+  namespace: test-namespace
+
+tests:
+- it: manifest should match snapshot
+  asserts:
+  - matchSnapshot: {}
+
+- it: should not render when disabled
+  set:
+    operator:
+      enabled: false
+  asserts:
+  - hasDocuments:
+      count: 0
+
+- it: should set namespace
+  set:
+    namespaceOverride: custom-namespace
+  asserts:
+  - equal:
+      path: metadata.namespace
+      value: custom-namespace
+
+
+- it: should set name
+  set:
+    nameOverride: custom-name
+  asserts:
+  - equal:
+      path: metadata.name
+      value: custom-name

--- a/helm/slurm-operator/tests/webhook_deployment_test.yaml
+++ b/helm/slurm-operator/tests/webhook_deployment_test.yaml
@@ -1,0 +1,103 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+---
+suite: test webhook deployment
+templates:
+- webhook/deployment.yaml
+chart:
+  version: 1.2.3
+  appVersion: 1.2.3
+release:
+  name: test-release
+  namespace: test-namespace
+
+tests:
+- it: manifest should match snapshot
+  asserts:
+  - matchSnapshot: {}
+
+
+- it: should add affinity
+  set:
+    webhook:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: arch
+                operator: In
+                values:
+                - x86_64
+  asserts:
+  - equal:
+      path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]
+      value: x86_64
+
+
+- it: should add tolerations
+  set:
+    webhook:
+      tolerations:
+      - key: test
+        operator: Exists
+        effect: NoExecute
+        tolerationSeconds: 6000
+  asserts:
+  - equal:
+      path: spec.template.spec.tolerations[0].key
+      value: test
+
+
+- it: should set imagePullSecrets
+  set:
+    imagePullSecrets:
+    - name: test-docker-secret
+  asserts:
+  - equal:
+      path: spec.template.spec.imagePullSecrets[0].name
+      value: test-docker-secret
+
+- it: should set priorityClassName
+  set:
+    priorityClassName: test-priority-class
+  asserts:
+  - equal:
+      path: spec.template.spec.priorityClassName
+      value: test-priority-class
+
+
+- it: should set replica count
+  set:
+    webhook:
+      replicas: 42
+  asserts:
+  - equal:
+      path: spec.replicas
+      value: 42
+
+- it: should set namespace
+  set:
+    namespaceOverride: custom-namespace
+  asserts:
+  - equal:
+      path: metadata.namespace
+      value: custom-namespace
+
+- it: should set name
+  set:
+    nameOverride: custom-name
+  asserts:
+  - equal:
+      path: metadata.name
+      value: custom-name-webhook
+
+
+- it: should set serviceAccount
+  set:
+    webhook:
+      serviceAccount:
+        name: custom-service-account
+  asserts:
+  - equal:
+      path: spec.template.spec.serviceAccountName
+      value: custom-service-account

--- a/helm/slurm-operator/tests/webhook_rbac_test.yaml
+++ b/helm/slurm-operator/tests/webhook_rbac_test.yaml
@@ -1,0 +1,59 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+---
+suite: test webhook rbac
+templates:
+- webhook/rbac.yaml
+chart:
+  version: 1.2.3
+  appVersion: 1.2.3
+release:
+  name: test-release
+  namespace: test-namespace
+
+tests:
+- it: manifest should match snapshot
+  asserts:
+  - matchSnapshot: {}
+
+- it: should not render when disabled
+  set:
+    webhook:
+      enabled: false
+  asserts:
+  - hasDocuments:
+      count: 0
+
+- it: should not render when serviceAccount.create is false
+  set:
+    webhook:
+      serviceAccount:
+        create: false
+  asserts:
+  - hasDocuments:
+      count: 0
+
+
+- it: should set namespace
+  documentSelector:
+    path: kind
+    value: ServiceAccount
+  set:
+    namespaceOverride: custom-namespace
+  asserts:
+  - equal:
+      path: metadata.namespace
+      value: custom-namespace
+
+
+- it: should set serviceAccount name
+  documentSelector:
+    path: kind
+    value: ServiceAccount
+  set:
+    webhook:
+      serviceAccount:
+        name: custom-service-account
+  asserts:
+  - equal:
+      path: metadata.name
+      value: custom-service-account

--- a/helm/slurm-operator/tests/webhook_service_test.yaml
+++ b/helm/slurm-operator/tests/webhook_service_test.yaml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+---
+suite: test webhook service
+templates:
+- webhook/service.yaml
+chart:
+  version: 1.2.3
+  appVersion: 1.2.3
+release:
+  name: test-release
+  namespace: test-namespace
+
+tests:
+- it: manifest should match snapshot
+  asserts:
+  - matchSnapshot: {}
+
+- it: should not render when disabled
+  set:
+    webhook:
+      enabled: false
+  asserts:
+  - hasDocuments:
+      count: 0
+
+- it: should set namespace
+  set:
+    namespaceOverride: custom-namespace
+  asserts:
+  - equal:
+      path: metadata.namespace
+      value: custom-namespace
+
+
+- it: should set name
+  set:
+    nameOverride: custom-name
+  asserts:
+  - equal:
+      path: metadata.name
+      value: custom-name-webhook

--- a/helm/slurm/.helmignore
+++ b/helm/slurm/.helmignore
@@ -23,3 +23,4 @@
 .vscode/
 # Development files
 skaffold.yaml
+tests/

--- a/helm/slurm/tests/__snapshot__/accounting_test.yaml.snap
+++ b/helm/slurm/tests/__snapshot__/accounting_test.yaml.snap
@@ -1,0 +1,51 @@
+manifest should match snapshot:
+  1: |
+    apiVersion: slinky.slurm.net/v1beta1
+    kind: Accounting
+    metadata:
+      labels:
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: slurm
+        app.kubernetes.io/version: 1.2.3
+        helm.sh/chart: slurm-1.2.3
+      name: test-release-slurm
+      namespace: test-namespace
+    spec:
+      jwtHs256KeyRef:
+        key: jwt_hs256.key
+        name: test-release-slurm-auth-jwths256
+      service:
+        metadata: {}
+        spec: {}
+      slurmKeyRef:
+        key: slurm.key
+        name: test-release-slurm-auth-slurm
+      slurmdbd:
+        args: []
+        image: ghcr.io/slinkyproject/slurmdbd:v1.2.3
+        imagePullPolicy: IfNotPresent
+        resources: {}
+      storageConfig:
+        database: slurm_acct_db
+        host: mariadb
+        passwordKeyRef:
+          key: password
+          name: mariadb-password
+        port: 3306
+        username: slurm
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/part-of: slurm
+            app.kubernetes.io/version: 1.2.3
+            helm.sh/chart: slurm-1.2.3
+        spec:
+          affinity: {}
+          imagePullSecrets: null
+          initContainers: []
+          nodeSelector:
+            kubernetes.io/os: linux
+          priorityClassName: slurm-system-critical
+          resources: {}
+          tolerations: []

--- a/helm/slurm/tests/__snapshot__/controller_test.yaml.snap
+++ b/helm/slurm/tests/__snapshot__/controller_test.yaml.snap
@@ -1,0 +1,80 @@
+manifest should match snapshot:
+  1: |
+    apiVersion: slinky.slurm.net/v1beta1
+    kind: Controller
+    metadata:
+      labels:
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: slurm
+        app.kubernetes.io/version: 1.2.3
+        helm.sh/chart: slurm-1.2.3
+      name: test-release-slurm
+      namespace: test-namespace
+    spec:
+      epilogScriptRefs:
+        - name: test-release-slurm-epilog-dcgm
+      epilogSlurmctldScriptRefs: null
+      extraConf: |
+        PartitionName=all Nodes=ALL Default=YES MaxTime=UNLIMITED State=UP
+      jwtHs256KeyRef:
+        key: jwt_hs256.key
+        name: test-release-slurm-auth-jwths256
+      logfile:
+        image: docker.io/library/alpine:latest
+        imagePullPolicy: IfNotPresent
+        resources: {}
+      metrics:
+        enabled: false
+        serviceMonitor:
+          annotations: {}
+          enabled: false
+          endpoints:
+            - path: /metrics/jobs
+            - path: /metrics/nodes
+            - path: /metrics/partitions
+            - path: /metrics/scheduler
+          interval: 30s
+          labels: {}
+          scrapeTimeout: 25s
+      persistence:
+        accessModes:
+          - ReadWriteOnce
+        enabled: true
+        existingClaim: ""
+        resources:
+          requests:
+            storage: 4Gi
+      prologScriptRefs:
+        - name: test-release-slurm-prolog-dcgm
+      prologSlurmctldScriptRefs: null
+      reconfigure:
+        image: ghcr.io/slinkyproject/slurmctld:v1.2.3
+        imagePullPolicy: IfNotPresent
+        resources: {}
+      service:
+        metadata: {}
+        spec: {}
+      slurmKeyRef:
+        key: slurm.key
+        name: test-release-slurm-auth-slurm
+      slurmctld:
+        args: []
+        image: ghcr.io/slinkyproject/slurmctld:v1.2.3
+        imagePullPolicy: IfNotPresent
+        resources: {}
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/part-of: slurm
+            app.kubernetes.io/version: 1.2.3
+            helm.sh/chart: slurm-1.2.3
+        spec:
+          affinity: {}
+          imagePullSecrets: null
+          initContainers: []
+          nodeSelector:
+            kubernetes.io/os: linux
+          priorityClassName: slurm-system-critical
+          resources: {}
+          tolerations: []

--- a/helm/slurm/tests/__snapshot__/loginset_test.yaml.snap
+++ b/helm/slurm/tests/__snapshot__/loginset_test.yaml.snap
@@ -1,0 +1,53 @@
+manifest should match snapshot:
+  1: |
+    apiVersion: slinky.slurm.net/v1beta1
+    kind: LoginSet
+    metadata:
+      labels:
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: slurm
+        app.kubernetes.io/version: 1.2.3
+        helm.sh/chart: slurm-1.2.3
+      name: test-release-slurm-login-slinky
+      namespace: test-namespace
+    spec:
+      controllerRef:
+        name: test-release-slurm
+        namespace: test-namespace
+      initconf:
+        image: docker.io/library/alpine:latest
+        imagePullPolicy: IfNotPresent
+        resources: {}
+      login:
+        env: []
+        image: ghcr.io/slinkyproject/login:v1.2.3
+        imagePullPolicy: IfNotPresent
+        resources: {}
+        securityContext:
+          privileged: false
+        volumeMounts: []
+      replicas: 1
+      service:
+        metadata: {}
+        spec:
+          type: LoadBalancer
+      sssdConfRef:
+        key: sssd.conf
+        name: test-release-slurm-sssd-conf
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/part-of: slurm
+            app.kubernetes.io/version: 1.2.3
+            helm.sh/chart: slurm-1.2.3
+        spec:
+          affinity: {}
+          imagePullSecrets: null
+          initContainers: []
+          nodeSelector:
+            kubernetes.io/os: linux
+          priorityClassName: slurm-system-critical
+          resources: {}
+          tolerations: []
+          volumes: []

--- a/helm/slurm/tests/__snapshot__/nodeset_test.yaml.snap
+++ b/helm/slurm/tests/__snapshot__/nodeset_test.yaml.snap
@@ -1,0 +1,58 @@
+manifest should match snapshot:
+  1: |
+    apiVersion: slinky.slurm.net/v1beta1
+    kind: NodeSet
+    metadata:
+      labels:
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: slurm
+        app.kubernetes.io/version: 1.2.3
+        helm.sh/chart: slurm-1.2.3
+      name: test-release-slurm-worker-slinky
+      namespace: test-namespace
+    spec:
+      controllerRef:
+        name: test-release-slurm
+        namespace: test-namespace
+      logfile:
+        image: docker.io/library/alpine:latest
+        imagePullPolicy: IfNotPresent
+        resources: {}
+      partition:
+        enabled: true
+      replicas: 1
+      slurmd:
+        args: []
+        env:
+          - name: POD_CPUS
+            value: "0"
+          - name: POD_MEMORY
+            value: "0"
+        image: ghcr.io/slinkyproject/slurmd:v1.2.3
+        imagePullPolicy: IfNotPresent
+        resources: {}
+        volumeMounts: []
+      taintKubeNodes: false
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/part-of: slurm
+            app.kubernetes.io/version: 1.2.3
+            helm.sh/chart: slurm-1.2.3
+        spec:
+          affinity: {}
+          hostname: slinky-
+          imagePullSecrets: null
+          initContainers: []
+          nodeSelector:
+            kubernetes.io/os: linux
+          priorityClassName: slurm-system-critical
+          resources: {}
+          tolerations: []
+          volumes: []
+      updateStrategy:
+        rollingUpdate:
+          maxUnavailable: 25%
+        type: RollingUpdate
+      workloadDisruptionProtection: true

--- a/helm/slurm/tests/__snapshot__/restapi_test.yaml.snap
+++ b/helm/slurm/tests/__snapshot__/restapi_test.yaml.snap
@@ -1,0 +1,48 @@
+manifest should match snapshot:
+  1: |
+    apiVersion: slinky.slurm.net/v1beta1
+    kind: RestApi
+    metadata:
+      annotations:
+        baz: qux
+      labels:
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: slurm
+        app.kubernetes.io/version: 1.2.3
+        foo: bar
+        helm.sh/chart: slurm-1.2.3
+      name: test-release-slurm
+      namespace: test-namespace
+    spec:
+      controllerRef:
+        name: test-release-slurm
+        namespace: test-namespace
+      replicas: 1
+      service:
+        metadata: {}
+        spec: {}
+      slurmrestd:
+        args: []
+        env: []
+        image: ghcr.io/slinkyproject/slurmrestd:v1.2.3
+        imagePullPolicy: IfNotPresent
+        resources: {}
+      template:
+        metadata:
+          annotations:
+            baz: qux
+          labels:
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/part-of: slurm
+            app.kubernetes.io/version: 1.2.3
+            foo: bar
+            helm.sh/chart: slurm-1.2.3
+        spec:
+          affinity: {}
+          imagePullSecrets: null
+          initContainers: []
+          nodeSelector:
+            kubernetes.io/os: linux
+          priorityClassName: slurm-system-critical
+          resources: {}
+          tolerations: []

--- a/helm/slurm/tests/accounting_test.yaml
+++ b/helm/slurm/tests/accounting_test.yaml
@@ -1,0 +1,128 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+---
+suite: test accounting
+templates:
+- accounting/accounting-cr.yaml
+release:
+  name: test-release
+  namespace: test-namespace
+chart:
+  version: 1.2.3
+  appVersion: 1.2.3
+tests:
+- it: manifest should match snapshot
+  set:
+    accounting:
+      enabled: true
+      slurmdbd:
+        image:
+          tag: v1.2.3
+  asserts:
+  - matchSnapshot: {}
+
+- it: should set imagePullSecrets
+  set:
+    imagePullSecrets:
+    - name: "docker-secret-1"
+    - name: "docker-secret-2"
+    accounting:
+      enabled: true
+  asserts:
+  - equal:
+      path: spec.template.spec.imagePullSecrets[0].name
+      value: docker-secret-1
+  - equal:
+      path: spec.template.spec.imagePullSecrets[1].name
+      value: docker-secret-2
+
+
+
+- it: should set resourceSettings
+  set:
+    accounting:
+      enabled: true
+      podSpec:
+        resources:
+          limits:
+            cpu: "2"
+            memory: "4"
+          requests:
+            cpu: "1"
+            memory: "2"
+  asserts:
+  - equal:
+      path: spec.template.spec.resources
+      value:
+        limits:
+          cpu: "2"
+          memory: "4"
+        requests:
+          cpu: "1"
+          memory: "2"
+
+- it: should add nodeSelector
+  set:
+    accounting:
+      enabled: true
+      podSpec:
+        nodeSelector:
+          beta.kubernetes.io/os: linux
+  asserts:
+  - equal:
+      path: spec.template.spec.nodeSelector["beta.kubernetes.io/os"]
+      value: linux
+
+
+- it: should set affinity
+  set:
+    accounting:
+      enabled: true
+      podSpec:
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                  - key: arch
+                    operator: In
+                    values:
+                    - x86_64
+  asserts:
+  - equal:
+      path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]
+      value: x86_64
+
+
+- it: should add tolerations
+  set:
+    accounting:
+      enabled: true
+      podSpec:
+        tolerations:
+        - key: "test"
+          operator: "Exists"
+          effect: "NoExecute"
+          tolerationSeconds: 6000
+  asserts:
+  - equal:
+      path: spec.template.spec.tolerations[0].key
+      value: test
+
+
+
+- it: should add topologySpreadConstraints
+  set:
+    accounting:
+      enabled: true
+      podSpec:
+        topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              foo: bar
+  asserts:
+  - equal:
+      path: spec.template.spec.topologySpreadConstraints[0].labelSelector.matchLabels.foo
+      value: bar

--- a/helm/slurm/tests/controller_test.yaml
+++ b/helm/slurm/tests/controller_test.yaml
@@ -1,0 +1,123 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+---
+suite: test controller
+templates:
+- controller/controller-cr.yaml
+release:
+  name: test-release
+  namespace: test-namespace
+chart:
+  version: 1.2.3
+  appVersion: 1.2.3
+tests:
+- it: manifest should match snapshot
+  set:
+    controller:
+      slurmctld:
+        image:
+          tag: v1.2.3
+      reconfigure:
+        image:
+          tag: v1.2.3
+  asserts:
+  - matchSnapshot: {}
+
+- it: should set imagePullSecrets
+  set:
+    imagePullSecrets:
+    - name: "docker-secret-1"
+    - name: "docker-secret-2"
+
+  asserts:
+  - equal:
+      path: spec.template.spec.imagePullSecrets[0].name
+      value: docker-secret-1
+  - equal:
+      path: spec.template.spec.imagePullSecrets[1].name
+      value: docker-secret-2
+
+
+
+- it: should set resourceSettings
+  set:
+    controller:
+      podSpec:
+        resources:
+          limits:
+            cpu: "2"
+            memory: "4"
+          requests:
+            cpu: "1"
+            memory: "2"
+  asserts:
+  - equal:
+      path: spec.template.spec.resources
+      value:
+        limits:
+          cpu: "2"
+          memory: "4"
+        requests:
+          cpu: "1"
+          memory: "2"
+
+- it: should add nodeSelector
+  set:
+    controller:
+      podSpec:
+        nodeSelector:
+          beta.kubernetes.io/os: linux
+  asserts:
+  - equal:
+      path: spec.template.spec.nodeSelector["beta.kubernetes.io/os"]
+      value: linux
+
+
+- it: should set affinity
+  set:
+    controller:
+      podSpec:
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                  - key: arch
+                    operator: In
+                    values:
+                    - x86_64
+  asserts:
+  - equal:
+      path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]
+      value: x86_64
+
+
+- it: should add tolerations
+  set:
+    controller:
+      podSpec:
+        tolerations:
+        - key: "test"
+          operator: "Exists"
+          effect: "NoExecute"
+          tolerationSeconds: 6000
+  asserts:
+  - equal:
+      path: spec.template.spec.tolerations[0].key
+      value: test
+
+
+- it: should add topologySpreadConstraints
+  set:
+    controller:
+      podSpec:
+        topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              foo: bar
+  asserts:
+  - equal:
+      path: spec.template.spec.topologySpreadConstraints[0].labelSelector.matchLabels.foo
+      value: bar

--- a/helm/slurm/tests/loginset_test.yaml
+++ b/helm/slurm/tests/loginset_test.yaml
@@ -1,0 +1,135 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+---
+suite: test logigset
+templates:
+- loginset/loginset-cr.yaml
+release:
+  name: test-release
+  namespace: test-namespace
+chart:
+  version: 1.2.3
+  appVersion: 1.2.3
+tests:
+- it: manifest should match snapshot
+  set:
+    loginsets:
+      slinky:
+        enabled: true
+        login:
+          image:
+            tag: v1.2.3
+  asserts:
+  - matchSnapshot: {}
+
+- it: should set imagePullSecrets
+  set:
+    imagePullSecrets:
+    - name: "docker-secret-1"
+    - name: "docker-secret-2"
+    loginsets:
+      slinky:
+        enabled: true
+  asserts:
+  - equal:
+      path: spec.template.spec.imagePullSecrets[0].name
+      value: docker-secret-1
+  - equal:
+      path: spec.template.spec.imagePullSecrets[1].name
+      value: docker-secret-2
+
+
+
+- it: should set resourceSettings
+  set:
+    loginsets:
+      slinky:
+        enabled: true
+        podSpec:
+          resources:
+            limits:
+              cpu: "2"
+              memory: "4"
+            requests:
+              cpu: "1"
+              memory: "2"
+  asserts:
+  - equal:
+      path: spec.template.spec.resources
+      value:
+        limits:
+          cpu: "2"
+          memory: "4"
+        requests:
+          cpu: "1"
+          memory: "2"
+
+- it: should add nodeSelector
+  set:
+    loginsets:
+      slinky:
+        enabled: true
+        podSpec:
+          nodeSelector:
+            beta.kubernetes.io/os: linux
+  asserts:
+  - equal:
+      path: spec.template.spec.nodeSelector["beta.kubernetes.io/os"]
+      value: linux
+
+
+- it: should set affinity
+  set:
+    loginsets:
+      slinky:
+        enabled: true
+        podSpec:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                    - key: arch
+                      operator: In
+                      values:
+                      - x86_64
+  asserts:
+  - equal:
+      path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]
+      value: x86_64
+
+
+- it: should add tolerations
+  set:
+    loginsets:
+      slinky:
+        enabled: true
+        podSpec:
+          tolerations:
+          - key: "test"
+            operator: "Exists"
+            effect: "NoExecute"
+            tolerationSeconds: 6000
+  asserts:
+  - equal:
+      path: spec.template.spec.tolerations[0].key
+      value: test
+
+
+
+- it: should add topologySpreadConstraints
+  set:
+    loginsets:
+      slinky:
+        enabled: true
+        podSpec:
+          topologySpreadConstraints:
+            - maxSkew: 1
+              topologyKey: topology.kubernetes.io/zone
+              whenUnsatisfiable: ScheduleAnyway
+              labelSelector:
+                matchLabels:
+                  foo: bar
+  asserts:
+  - equal:
+      path: spec.template.spec.topologySpreadConstraints[0].labelSelector.matchLabels.foo
+      value: bar

--- a/helm/slurm/tests/nodeset_test.yaml
+++ b/helm/slurm/tests/nodeset_test.yaml
@@ -1,0 +1,134 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+---
+suite: test nodeset
+templates:
+- nodeset/nodeset-cr.yaml
+release:
+  name: test-release
+  namespace: test-namespace
+chart:
+  version: 1.2.3
+  appVersion: 1.2.3
+tests:
+- it: manifest should match snapshot
+  set:
+    nodesets:
+      slinky:
+        enabled: true
+        slurmd:
+          image:
+            tag: v1.2.3
+  asserts:
+  - matchSnapshot: {}
+
+
+
+- it: should set imagePullSecrets
+  set:
+    imagePullSecrets:
+    - name: "docker-secret-1"
+    - name: "docker-secret-2"
+
+  asserts:
+  - equal:
+      path: spec.template.spec.imagePullSecrets[0].name
+      value: docker-secret-1
+  - equal:
+      path: spec.template.spec.imagePullSecrets[1].name
+      value: docker-secret-2
+
+
+
+- it: should set resourceSettings
+  set:
+    nodesets:
+      slinky:
+        enabled: true
+        podSpec:
+          resources:
+            limits:
+              cpu: "2"
+              memory: "4"
+            requests:
+              cpu: "1"
+              memory: "2"
+  asserts:
+  - equal:
+      path: spec.template.spec.resources
+      value:
+        limits:
+          cpu: "2"
+          memory: "4"
+        requests:
+          cpu: "1"
+          memory: "2"
+
+- it: should add nodeSelector
+  set:
+    nodesets:
+      slinky:
+        enabled: true
+        podSpec:
+          nodeSelector:
+            beta.kubernetes.io/os: linux
+  asserts:
+  - equal:
+      path: spec.template.spec.nodeSelector["beta.kubernetes.io/os"]
+      value: linux
+
+
+- it: should set affinity
+  set:
+    nodesets:
+      slinky:
+        enabled: true
+        podSpec:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                    - key: arch
+                      operator: In
+                      values:
+                      - x86_64
+  asserts:
+  - equal:
+      path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]
+      value: x86_64
+
+
+- it: should add tolerations
+  set:
+    nodesets:
+      slinky:
+        enabled: true
+        podSpec:
+          tolerations:
+          - key: "test"
+            operator: "Exists"
+            effect: "NoExecute"
+            tolerationSeconds: 6000
+  asserts:
+  - equal:
+      path: spec.template.spec.tolerations[0].key
+      value: test
+
+
+- it: should add topologySpreadConstraints
+  set:
+    nodesets:
+      slinky:
+        enabled: true
+        podSpec:
+          topologySpreadConstraints:
+          - maxSkew: 1
+            topologyKey: topology.kubernetes.io/zone
+            whenUnsatisfiable: ScheduleAnyway
+            labelSelector:
+              matchLabels:
+                foo: bar
+  asserts:
+  - equal:
+      path: spec.template.spec.topologySpreadConstraints[0].labelSelector.matchLabels.foo
+      value: bar

--- a/helm/slurm/tests/restapi_test.yaml
+++ b/helm/slurm/tests/restapi_test.yaml
@@ -1,0 +1,167 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+---
+suite: test restapi
+templates:
+- restapi/restapi-cr.yaml
+release:
+  name: test-release
+  namespace: test-namespace
+chart:
+  version: 1.2.3
+  appVersion: 1.2.3
+tests:
+- it: manifest should match snapshot
+  set:
+    restapi:
+      slurmrestd:
+        image:
+          tag: v1.2.3
+  asserts:
+  - matchSnapshot: {}
+
+- it: should set imagePullSecrets
+  set:
+    imagePullSecrets:
+    - name: "docker-secret-1"
+    - name: "docker-secret-2"
+
+  asserts:
+  - equal:
+      path: spec.template.spec.imagePullSecrets[0].name
+      value: docker-secret-1
+  - equal:
+      path: spec.template.spec.imagePullSecrets[1].name
+      value: docker-secret-2
+
+
+
+- it: should set resourceSettings
+  set:
+    restapi:
+      podSpec:
+        resources:
+          limits:
+            cpu: "2"
+            memory: "4"
+          requests:
+            cpu: "1"
+            memory: "2"
+  asserts:
+  - equal:
+      path: spec.template.spec.resources
+      value:
+        limits:
+          cpu: "2"
+          memory: "4"
+        requests:
+          cpu: "1"
+          memory: "2"
+
+- it: should add nodeSelector
+  set:
+    restapi:
+      podSpec:
+        nodeSelector:
+          beta.kubernetes.io/os: linux
+  asserts:
+  - equal:
+      path: spec.template.spec.nodeSelector["beta.kubernetes.io/os"]
+      value: linux
+
+
+- it: should set affinity
+  set:
+    restapi:
+      podSpec:
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                  - key: arch
+                    operator: In
+                    values:
+                    - x86_64
+  asserts:
+  - equal:
+      path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]
+      value: x86_64
+
+
+- it: should add tolerations
+  set:
+    restapi:
+      podSpec:
+        tolerations:
+        - key: "test"
+          operator: "Exists"
+          effect: "NoExecute"
+          tolerationSeconds: 6000
+  asserts:
+  - equal:
+      path: spec.template.spec.tolerations[0].key
+      value: test
+
+
+- it: should add topologySpreadConstraints
+  set:
+    restapi:
+      podSpec:
+        topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              foo: bar
+  asserts:
+  - equal:
+      path: spec.template.spec.topologySpreadConstraints[0].labelSelector.matchLabels.foo
+      value: bar
+
+
+- it: should set replica count
+  set:
+    restapi:
+      replicas: 42
+  asserts:
+  - equal:
+      path: spec.replicas
+      value: 42
+
+
+- it: should set env
+  set:
+    restapi:
+      slurmrestd:
+        env:
+        - name: foo
+          value: bar
+  asserts:
+  - contains:
+      path: spec.slurmrestd.env
+      content:
+        name: foo
+        value: bar
+
+- it: should set metadata
+  set:
+    restapi:
+      metadata:
+        labels:
+          foo: bar
+        annotations:
+          baz: qux
+  asserts:
+  - equal:
+      path: metadata.labels.foo
+      value: bar
+  - equal:
+      path: metadata.annotations.baz
+      value: qux
+  - equal:
+      path: .spec.template.metadata.labels.foo
+      value: bar
+  - equal:
+      path: .spec.template.metadata.annotations.baz
+      value: qux

--- a/helm/slurm/tests/secrets_test.yaml
+++ b/helm/slurm/tests/secrets_test.yaml
@@ -1,0 +1,70 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+---
+suite: test secrets
+templates:
+- secrets/jwths256key.yaml
+- secrets/slurmkey.yaml
+release:
+  name: test-release
+  namespace: test-namespace
+kubernetesProvider:
+  scheme:
+    "v1/Secret":
+      gvr:
+        version: "v1"
+        resource: "secrets"
+      namespaced: true
+tests:
+- it: should not create a jwt hs256 secret if it exists
+  template: secrets/jwths256key.yaml
+  kubernetesProvider:
+    objects:
+      - kind: Secret
+        apiVersion: v1
+        metadata:
+          name: test-release-slurm-auth-jwths256
+          namespace: test-namespace
+        data:
+          jwt_hs256.key: dGVzdAo=
+  asserts:
+  - hasDocuments:
+      count: 0
+
+- it: should not create a slurm secret if controller and accounting are external
+  template: secrets/jwths256key.yaml
+  set:
+    controller:
+      external: true
+    accounting:
+      external: true
+  asserts:
+  - hasDocuments:
+      count: 0
+
+
+- it: should not create a slurm secret if it exists
+  template: secrets/slurmkey.yaml
+  kubernetesProvider:
+    objects:
+      - kind: Secret
+        apiVersion: v1
+        metadata:
+          name: test-release-slurm-auth-slurm
+          namespace: test-namespace
+        data:
+          slurm.key: dGVzdAo=
+  asserts:
+  - hasDocuments:
+      count: 0
+
+- it: should not create a slurm secret if controller and accounting are external
+  template: secrets/slurmkey.yaml
+  set:
+    controller:
+      external: true
+    accounting:
+      external: true
+  asserts:
+  - hasDocuments:
+      count: 0
+


### PR DESCRIPTION
## Description
This pull request introduces [Helm unit testing](https://github.com/helm-unittest/helm-unittest) to slinky project, enabling more robust and reliable Kubernetes chart development. By integrating the Helm unittest plugin, we can now validate our Helm chart configurations and templates before deployment, catching potential issues early in the development process.

## Changes
- Added Helm unittest plugin to project dependencies
- Configured initial unit test structure for Helm charts
- Implemented basic test cases for chart templates and values

## Proposed Changes
This PR runs `helm unittest` whenever the helm chart source code is changed.