### PR TITLE
test: add helm unit tests for untested templates

### DIFF
--- a/helm/slurm-operator/tests/certmanager_pki_test.yaml
+++ b/helm/slurm-operator/tests/certmanager_pki_test.yaml
@@ -1,0 +1,128 @@
+---
+suite: test cert-manager pki
+templates:
+  - cert-manager/pki.yaml
+chart:
+  version: 1.2.3
+  appVersion: 1.2.3
+release:
+  name: test-release
+  namespace: test-namespace
+tests:
+  - it: should not render when webhook is disabled
+    set:
+      webhook:
+        enabled: false
+      certManager:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render when certManager is disabled
+    set:
+      webhook:
+        enabled: true
+      certManager:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render 4 documents when both webhook and certManager are enabled
+    set:
+      webhook:
+        enabled: true
+      certManager:
+        enabled: true
+        secretName: slurm-operator-webhook-ca
+        duration: 43800h0m0s
+        renewBefore: 8760h0m0s
+    asserts:
+      - hasDocuments:
+          count: 4
+
+  - it: should render self-signed Issuer as first document
+    documentIndex: 0
+    set:
+      webhook:
+        enabled: true
+      certManager:
+        enabled: true
+        secretName: slurm-operator-webhook-ca
+    asserts:
+      - equal:
+          path: apiVersion
+          value: cert-manager.io/v1
+      - equal:
+          path: kind
+          value: Issuer
+      - equal:
+          path: metadata.namespace
+          value: test-namespace
+      - exists:
+          path: spec.selfSigned
+
+  - it: should render root CA Certificate with correct spec
+    documentIndex: 1
+    set:
+      webhook:
+        enabled: true
+      certManager:
+        enabled: true
+        secretName: slurm-operator-webhook-ca
+        duration: 43800h0m0s
+        renewBefore: 8760h0m0s
+    asserts:
+      - equal:
+          path: kind
+          value: Certificate
+      - equal:
+          path: spec.isCA
+          value: true
+      - equal:
+          path: spec.duration
+          value: "43800h0m0s"
+      - equal:
+          path: spec.renewBefore
+          value: "8760h0m0s"
+
+  - it: should render serving Certificate with dnsNames and custom duration
+    documentIndex: 3
+    set:
+      webhook:
+        enabled: true
+      certManager:
+        enabled: true
+        secretName: slurm-operator-webhook-ca
+        duration: 87600h0m0s
+        renewBefore: 17520h0m0s
+    asserts:
+      - equal:
+          path: kind
+          value: Certificate
+      - equal:
+          path: spec.secretName
+          value: slurm-operator-webhook-ca
+      - equal:
+          path: spec.duration
+          value: "87600h0m0s"
+      - equal:
+          path: spec.renewBefore
+          value: "17520h0m0s"
+      - exists:
+          path: spec.dnsNames
+
+  - it: should override namespace when namespaceOverride is set
+    documentIndex: 0
+    set:
+      namespaceOverride: custom-namespace
+      webhook:
+        enabled: true
+      certManager:
+        enabled: true
+        secretName: slurm-operator-webhook-ca
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: custom-namespace

--- a/helm/slurm-operator/tests/operator_pdb_test.yaml
+++ b/helm/slurm-operator/tests/operator_pdb_test.yaml
@@ -1,0 +1,81 @@
+---
+suite: test operator poddisruptionbudget
+templates:
+  - operator/poddisruptionbudget.yaml
+chart:
+  version: 1.2.3
+  appVersion: 1.2.3
+release:
+  name: test-release
+  namespace: test-namespace
+tests:
+  - it: should not render when operator is disabled
+    set:
+      operator:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render when pdb is not enabled
+    set:
+      operator:
+        enabled: true
+        pdb:
+          enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render with correct metadata and spec when pdb is enabled
+    set:
+      operator:
+        enabled: true
+        pdb:
+          enabled: true
+          minAvailable: 1
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: apiVersion
+          value: policy/v1
+      - equal:
+          path: kind
+          value: PodDisruptionBudget
+      - equal:
+          path: metadata.name
+          value: slurm-operator
+      - equal:
+          path: metadata.namespace
+          value: test-namespace
+      - equal:
+          path: spec.minAvailable
+          value: 1
+      - exists:
+          path: spec.selector.matchLabels
+
+  - it: should set custom minAvailable
+    set:
+      operator:
+        enabled: true
+        pdb:
+          enabled: true
+          minAvailable: 2
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 2
+
+  - it: should override namespace when namespaceOverride is set
+    set:
+      namespaceOverride: custom-namespace
+      operator:
+        enabled: true
+        pdb:
+          enabled: true
+          minAvailable: 1
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: custom-namespace

--- a/helm/slurm-operator/tests/webhook_pdb_test.yaml
+++ b/helm/slurm-operator/tests/webhook_pdb_test.yaml
@@ -1,0 +1,81 @@
+---
+suite: test webhook poddisruptionbudget
+templates:
+  - webhook/poddisruptionbudget.yaml
+chart:
+  version: 1.2.3
+  appVersion: 1.2.3
+release:
+  name: test-release
+  namespace: test-namespace
+tests:
+  - it: should not render when webhook is disabled
+    set:
+      webhook:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render when pdb is not enabled
+    set:
+      webhook:
+        enabled: true
+        pdb:
+          enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render with correct metadata and spec when pdb is enabled
+    set:
+      webhook:
+        enabled: true
+        pdb:
+          enabled: true
+          minAvailable: 1
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: apiVersion
+          value: policy/v1
+      - equal:
+          path: kind
+          value: PodDisruptionBudget
+      - equal:
+          path: metadata.name
+          value: slurm-operator-webhook
+      - equal:
+          path: metadata.namespace
+          value: test-namespace
+      - equal:
+          path: spec.minAvailable
+          value: 1
+      - exists:
+          path: spec.selector.matchLabels
+
+  - it: should set custom minAvailable
+    set:
+      webhook:
+        enabled: true
+        pdb:
+          enabled: true
+          minAvailable: 3
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 3
+
+  - it: should override namespace when namespaceOverride is set
+    set:
+      namespaceOverride: custom-namespace
+      webhook:
+        enabled: true
+        pdb:
+          enabled: true
+          minAvailable: 1
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: custom-namespace

--- a/helm/slurm-operator/tests/webhook_webhook_test.yaml
+++ b/helm/slurm-operator/tests/webhook_webhook_test.yaml
@@ -1,0 +1,158 @@
+---
+suite: test webhook configuration
+templates:
+  - webhook/webhook.yaml
+chart:
+  version: 1.2.3
+  appVersion: 1.2.3
+release:
+  name: test-release
+  namespace: test-namespace
+tests:
+  - it: should not render when webhook is disabled
+    set:
+      webhook:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render ValidatingWebhookConfiguration with correct webhooks
+    documentSelector:
+      path: kind
+      value: ValidatingWebhookConfiguration
+    set:
+      webhook:
+        enabled: true
+        timeoutSeconds: 10
+      certManager:
+        enabled: false
+        secretName: slurm-operator-webhook-ca
+    asserts:
+      - equal:
+          path: metadata.name
+          value: slurm-operator-webhook
+      - equal:
+          path: webhooks[0].name
+          value: accounting-v1beta1.kb.io
+      - equal:
+          path: webhooks[0].failurePolicy
+          value: Fail
+      - equal:
+          path: webhooks[0].timeoutSeconds
+          value: 10
+      - equal:
+          path: webhooks[0].sideEffects
+          value: None
+      - equal:
+          path: webhooks[1].name
+          value: controller-v1beta1.kb.io
+      - equal:
+          path: webhooks[2].name
+          value: loginset-v1beta1.kb.io
+      - equal:
+          path: webhooks[3].name
+          value: nodeset-v1beta1.kb.io
+      - equal:
+          path: webhooks[4].name
+          value: restapi-v1beta1.kb.io
+      - equal:
+          path: webhooks[5].name
+          value: token-v1beta1.kb.io
+
+  - it: should render MutatingWebhookConfiguration for pods/binding
+    documentSelector:
+      path: kind
+      value: MutatingWebhookConfiguration
+    set:
+      webhook:
+        enabled: true
+        timeoutSeconds: 10
+      certManager:
+        enabled: false
+        secretName: slurm-operator-webhook-ca
+    asserts:
+      - equal:
+          path: metadata.name
+          value: slurm-operator-webhook
+      - equal:
+          path: webhooks[0].name
+          value: podsbinding-v1.kb.io
+      - equal:
+          path: webhooks[0].failurePolicy
+          value: Fail
+      - equal:
+          path: webhooks[0].timeoutSeconds
+          value: 10
+      - equal:
+          path: webhooks[0].rules[0].resources[0]
+          value: pods/binding
+
+  - it: should include cert-manager annotations when certManager is enabled
+    documentSelector:
+      path: kind
+      value: ValidatingWebhookConfiguration
+    set:
+      webhook:
+        enabled: true
+      certManager:
+        enabled: true
+        secretName: slurm-operator-webhook-ca
+    asserts:
+      - exists:
+          path: metadata.annotations["cert-manager.io/inject-ca-from"]
+
+  - it: should include caBundle when certManager is disabled
+    documentSelector:
+      path: kind
+      value: ValidatingWebhookConfiguration
+    set:
+      webhook:
+        enabled: true
+      certManager:
+        enabled: false
+        secretName: slurm-operator-webhook-ca
+    asserts:
+      - exists:
+          path: webhooks[0].clientConfig.caBundle
+
+  - it: should render TLS secret when certManager is disabled
+    documentIndex: 0
+    set:
+      webhook:
+        enabled: true
+      certManager:
+        enabled: false
+        secretName: slurm-operator-webhook-ca
+    asserts:
+      - equal:
+          path: kind
+          value: Secret
+      - equal:
+          path: type
+          value: kubernetes.io/tls
+      - equal:
+          path: metadata.name
+          value: slurm-operator-webhook-ca
+      - equal:
+          path: metadata.namespace
+          value: test-namespace
+      - exists:
+          path: data["tls.crt"]
+      - exists:
+          path: data["tls.key"]
+      - exists:
+          path: data["ca.crt"]
+
+  - it: should not render TLS secret when certManager is enabled
+    documentIndex: 0
+    set:
+      webhook:
+        enabled: true
+      certManager:
+        enabled: true
+        secretName: slurm-operator-webhook-ca
+    asserts:
+      - equal:
+          path: kind
+          value: ValidatingWebhookConfiguration

--- a/helm/slurm/tests/controller_configmaps_test.yaml
+++ b/helm/slurm/tests/controller_configmaps_test.yaml
@@ -1,0 +1,185 @@
+---
+suite: test controller configmaps
+templates:
+  - controller/config-configmap.yaml
+  - controller/prolog-configmap.yaml
+  - controller/epilog-configmap.yaml
+  - controller/prolog-slurmctld-configmap.yaml
+  - controller/epilog-slurmctld-configmap.yaml
+release:
+  name: test-release
+  namespace: test-namespace
+chart:
+  version: 1.2.3
+  appVersion: 1.2.3
+tests:
+# config-configmap
+  - it: should not render config configmap when configFiles is empty
+    template: controller/config-configmap.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render config configmap with correct metadata and data
+    template: controller/config-configmap.yaml
+    set:
+      configFiles:
+        cgroup.conf: |
+          CgroupPlugin=cgroup/v2
+          ConstrainCores=yes
+        gres.conf: |
+          AutoDetect=nvidia
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: kind
+          value: ConfigMap
+      - equal:
+          path: metadata.name
+          value: test-release-slurm-config-extra
+      - equal:
+          path: metadata.namespace
+          value: test-namespace
+      - equal:
+          path: metadata.labels["app.kubernetes.io/part-of"]
+          value: slurm
+      - exists:
+          path: data["cgroup.conf"]
+      - exists:
+          path: data["gres.conf"]
+
+  - it: should override config configmap namespace
+    template: controller/config-configmap.yaml
+    set:
+      namespaceOverride: custom-namespace
+      configFiles:
+        cgroup.conf: |
+          CgroupPlugin=cgroup/v2
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: custom-namespace
+
+# prolog-configmap
+  - it: should not render prolog configmap when prologScripts is empty
+    template: controller/prolog-configmap.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render prolog configmap with correct metadata and prefixed keys
+    template: controller/prolog-configmap.yaml
+    set:
+      prologScripts:
+        00-setup.sh: |
+          #!/usr/bin/env bash
+          set -euo pipefail
+          exit 0
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: kind
+          value: ConfigMap
+      - equal:
+          path: metadata.name
+          value: test-release-slurm-prolog-scripts
+      - equal:
+          path: metadata.namespace
+          value: test-namespace
+      - exists:
+          path: data["prolog-00-setup.sh"]
+
+# epilog-configmap
+  - it: should not render epilog configmap when epilogScripts is empty
+    template: controller/epilog-configmap.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render epilog configmap with correct metadata and prefixed keys
+    template: controller/epilog-configmap.yaml
+    set:
+      epilogScripts:
+        00-cleanup.sh: |
+          #!/usr/bin/env bash
+          set -euo pipefail
+          exit 0
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: kind
+          value: ConfigMap
+      - equal:
+          path: metadata.name
+          value: test-release-slurm-epilog-scripts
+      - equal:
+          path: metadata.namespace
+          value: test-namespace
+      - exists:
+          path: data["epilog-00-cleanup.sh"]
+
+# prolog-slurmctld-configmap
+  - it: should not render prolog-slurmctld configmap when prologSlurmctldScripts is empty
+    template: controller/prolog-slurmctld-configmap.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render prolog-slurmctld configmap with correct metadata and prefixed keys
+    template: controller/prolog-slurmctld-configmap.yaml
+    set:
+      prologSlurmctldScripts:
+        00-pre-alloc.sh: |
+          #!/usr/bin/env bash
+          set -euo pipefail
+          exit 0
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: kind
+          value: ConfigMap
+      - equal:
+          path: metadata.name
+          value: test-release-slurm-prolog-slurmctld-scripts
+      - equal:
+          path: metadata.namespace
+          value: test-namespace
+      - exists:
+          path: data["prolog-slurmctld-00-pre-alloc.sh"]
+
+# epilog-slurmctld-configmap
+  - it: should not render epilog-slurmctld configmap when epilogSlurmctldScripts is empty
+    template: controller/epilog-slurmctld-configmap.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render epilog-slurmctld configmap with correct metadata and prefixed keys
+    template: controller/epilog-slurmctld-configmap.yaml
+    set:
+      epilogSlurmctldScripts:
+        00-post-complete.sh: |
+          #!/usr/bin/env bash
+          set -euo pipefail
+          exit 0
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: kind
+          value: ConfigMap
+      - equal:
+          path: metadata.name
+          value: test-release-slurm-epilog-slurmctld-scripts
+      - equal:
+          path: metadata.namespace
+          value: test-namespace
+      - equal:
+          path: metadata.labels["app.kubernetes.io/part-of"]
+          value: slurm
+      - exists:
+          path: data["epilog-slurmctld-00-post-complete.sh"]

--- a/helm/slurm/tests/sssd_secret_test.yaml
+++ b/helm/slurm/tests/sssd_secret_test.yaml
@@ -1,0 +1,103 @@
+---
+suite: test sssd config secret
+templates:
+  - cluster/sssd-conf-secret.yaml
+release:
+  name: test-release
+  namespace: test-namespace
+chart:
+  version: 1.2.3
+  appVersion: 1.2.3
+tests:
+  - it: should not render when no loginsets or nodesets with SSH are enabled
+    set:
+      loginsets:
+        slinky:
+          enabled: false
+      nodesets:
+        slinky:
+          enabled: true
+          ssh:
+            enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render correctly when a loginset is enabled
+    set:
+      loginsets:
+        slinky:
+          enabled: true
+      sssd:
+        conf: |
+          [sssd]
+          config_file_version = 2
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: kind
+          value: Secret
+      - equal:
+          path: type
+          value: Opaque
+      - equal:
+          path: metadata.name
+          value: test-release-slurm-sssd-conf
+      - equal:
+          path: metadata.namespace
+          value: test-namespace
+      - exists:
+          path: stringData["sssd.conf"]
+
+  - it: should render when a nodeset with SSH is enabled
+    set:
+      loginsets:
+        slinky:
+          enabled: false
+      nodesets:
+        slinky:
+          enabled: true
+          ssh:
+            enabled: true
+      sssd:
+        conf: |
+          [sssd]
+          config_file_version = 2
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: kind
+          value: Secret
+
+  - it: should not render when secretRef is set
+    set:
+      loginsets:
+        slinky:
+          enabled: true
+      sssd:
+        secretRef:
+          name: my-sssd-secret
+          key: sssd.conf
+        conf: |
+          [sssd]
+          config_file_version = 2
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should override namespace when namespaceOverride is set
+    set:
+      namespaceOverride: custom-namespace
+      loginsets:
+        slinky:
+          enabled: true
+      sssd:
+        conf: |
+          [sssd]
+          config_file_version = 2
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: custom-namespace

--- a/helm/slurm/tests/vendor_dcgm_test.yaml
+++ b/helm/slurm/tests/vendor_dcgm_test.yaml
@@ -1,0 +1,76 @@
+---
+suite: test vendor nvidia dcgm configmaps
+templates:
+  - vendor/nvidia/dcgm/prolog-configmap.yaml
+  - vendor/nvidia/dcgm/epilog-configmap.yaml
+release:
+  name: test-release
+  namespace: test-namespace
+chart:
+  version: 1.2.3
+  appVersion: 1.2.3
+tests:
+  - it: should render dcgm prolog configmap with correct metadata when enabled
+    template: vendor/nvidia/dcgm/prolog-configmap.yaml
+    set:
+      vendor:
+        nvidia:
+          dcgm:
+            enabled: true
+            jobMappingDir: /var/lib/dcgm-exporter/job-mapping
+            scriptPriority: "90"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: kind
+          value: ConfigMap
+      - equal:
+          path: metadata.name
+          value: test-release-slurm-prolog-dcgm
+      - equal:
+          path: metadata.namespace
+          value: test-namespace
+      - equal:
+          path: metadata.labels["app.kubernetes.io/part-of"]
+          value: slurm
+
+  - it: should render dcgm epilog configmap with correct metadata when enabled
+    template: vendor/nvidia/dcgm/epilog-configmap.yaml
+    set:
+      vendor:
+        nvidia:
+          dcgm:
+            enabled: true
+            jobMappingDir: /var/lib/dcgm-exporter/job-mapping
+            scriptPriority: "90"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: kind
+          value: ConfigMap
+      - equal:
+          path: metadata.name
+          value: test-release-slurm-epilog-dcgm
+      - equal:
+          path: metadata.namespace
+          value: test-namespace
+      - equal:
+          path: metadata.labels["app.kubernetes.io/part-of"]
+          value: slurm
+
+  - it: should override dcgm namespace when namespaceOverride is set
+    template: vendor/nvidia/dcgm/epilog-configmap.yaml
+    set:
+      namespaceOverride: custom-namespace
+      vendor:
+        nvidia:
+          dcgm:
+            enabled: true
+            jobMappingDir: /var/lib/dcgm-exporter/job-mapping
+            scriptPriority: "90"
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: custom-namespace


### PR DESCRIPTION
## Summary

Cover previously untested templates in both charts:
- slurm: priorityclass, sssd secret, controller configmaps, vendor DCGM
- slurm-operator: operator/webhook PDB, cert-manager PKI, webhook config


## Breaking Changes

none

## Testing Notes

```
$ helm unittest helm/slurm

### Chart [ slurm ] helm/slurm

 PASS  test accounting  helm/slurm/tests/accounting_test.yaml
 PASS  test controller configmaps       helm/slurm/tests/controller_configmaps_test.yaml
 PASS  test controller  helm/slurm/tests/controller_test.yaml
 PASS  test logigset    helm/slurm/tests/loginset_test.yaml
 PASS  test nodeset     helm/slurm/tests/nodeset_test.yaml
 PASS  test priorityclass       helm/slurm/tests/priorityclass_test.yaml
 PASS  test restapi     helm/slurm/tests/restapi_test.yaml
 PASS  test secrets     helm/slurm/tests/secrets_test.yaml
 PASS  test sssd config secret  helm/slurm/tests/sssd_secret_test.yaml
 PASS  test vendor nvidia dcgm configmaps       helm/slurm/tests/vendor_dcgm_test.yaml

Charts:      1 passed, 1 total
Test Suites: 10 passed, 10 total
Tests:       74 passed, 74 total
Snapshot:    5 passed, 5 total
Time:        101.065875ms

$ helm unittest helm/slurm-operator

### Chart [ slurm-operator ] helm/slurm-operator

 PASS  test cert-manager pki    helm/slurm-operator/tests/certmanager_pki_test.yaml
 PASS  test operator deployment helm/slurm-operator/tests/operator_deployment_test.yaml
 PASS  test operator poddisruptionbudget        helm/slurm-operator/tests/operator_pdb_test.yaml
 PASS  test operator rbac       helm/slurm-operator/tests/operator_rbac_test.yaml
 PASS  test operator service    helm/slurm-operator/tests/operator_service_test.yaml
 PASS  test webhook deployment  helm/slurm-operator/tests/webhook_deployment_test.yaml
 PASS  test webhook poddisruptionbudget helm/slurm-operator/tests/webhook_pdb_test.yaml
 PASS  test webhook rbac        helm/slurm-operator/tests/webhook_rbac_test.yaml
 PASS  test webhook service     helm/slurm-operator/tests/webhook_service_test.yaml
 PASS  test webhook configuration       helm/slurm-operator/tests/webhook_webhook_test.yaml

Charts:      1 passed, 1 total
Test Suites: 10 passed, 10 total
Tests:       62 passed, 62 total
Snapshot:    10 passed, 10 total
Time:        976.643542ms
```

## Additional Context

<!--
Provide any other additional information here.
(e.g. which commits are critical or superfluous; why this implementation)
-->
