### PR TITLE
fix: nil pointer dereference when RollingUpdate is nil

### DIFF
--- a/internal/controller/nodeset/nodeset_sync.go
+++ b/internal/controller/nodeset/nodeset_sync.go
@@ -14,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
@@ -1117,7 +1118,11 @@ func (r *NodeSetReconciler) splitUpdatePods(
 		}
 
 		total := int(ptr.Deref(nodeset.Spec.Replicas, 0))
-		maxUnavailable := mathutils.GetScaledValueFromIntOrPercent(nodeset.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable, total, true, 1)
+		var maxUnavailableValue *intstr.IntOrString
+		if nodeset.Spec.UpdateStrategy.RollingUpdate != nil {
+			maxUnavailableValue = nodeset.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable
+		}
+		maxUnavailable := mathutils.GetScaledValueFromIntOrPercent(maxUnavailableValue, total, true, 1)
 		remainingUnavailable := mathutils.Clamp((maxUnavailable - numUnavailable), 0, maxUnavailable)
 		podsToDelete, remainingOldPods := nodesetutils.SplitActivePods(oldPods, remainingUnavailable)
 


### PR DESCRIPTION
## Summary

Fix a nil pointer dereference panic in `splitUpdatePods` when `UpdateStrategy.Type` is `RollingUpdate` but `UpdateStrategy.RollingUpdate` is not set.

## Breaking Changes

None

## Testing Notes

Pretty self explanatory, on main, if you create a nodeset and try to scale it when the update strategy is RollingUpdate but you do not set UpdateStrategy.RollingUpdate.MaxUnavailable variable, it will panic. This PR add a default 

## Additional Context

None

## Fix

Add a nil guard before accessing RollingUpdate.MaxUnavailable. When RollingUpdate is nil, a nil *IntOrString is passed to GetScaledValueFromIntOrPercent, which already handles it by returning the default value (1).