### PR TITLE
feat: bidirectional drain sync between Kubernetes and Slurm

### DIFF
--- a/CHANGELOG/CHANGELOG-1.0.md
+++ b/CHANGELOG/CHANGELOG-1.0.md
@@ -2,6 +2,12 @@
 
 ### Added
 
+- Bidirectional drain synchronization between Kubernetes and Slurm. When a Slurm
+  node is drained externally (e.g. via `scontrol`), the corresponding NodeSet
+  pod is now automatically cordoned with the `pod-cordon`, `pod-cordon-source`,
+  and `pod-cordon-reason` annotations. When the Slurm node is undrained
+  externally, the annotations are removed. This complements the existing K8s to
+  Slurm direction where cordoning a Kubernetes node drains the Slurm node.
 - JobAcctGatherType will default to `jobacct_gather/linux` when accounting is
   enabled but cgroups is disabled.
 

--- a/api/v1beta1/well_known.go
+++ b/api/v1beta1/well_known.go
@@ -30,6 +30,22 @@ const (
 	AnnotationPodDeadline = NodeSetPrefix + "pod-deadline"
 )
 
+// Well Known Annotations for drain source tracking
+const (
+	// AnnotationPodCordonSource indicates the origin of the pod cordon.
+	// When set to "slurm", the cordon was initiated from an external Slurm drain
+	// and should not cause the operator to re-drain the Slurm node.
+	AnnotationPodCordonSource = NodeSetPrefix + "pod-cordon-source"
+
+	// AnnotationPodCordonReason stores the Slurm drain reason when the pod was
+	// cordoned due to an external Slurm drain (source = "slurm").
+	AnnotationPodCordonReason = NodeSetPrefix + "pod-cordon-reason"
+
+	// PodCordonSourceSlurm is the value of AnnotationPodCordonSource when the
+	// cordon originates from an external Slurm drain (not managed by the operator).
+	PodCordonSourceSlurm = "slurm"
+)
+
 // Well Known Annotations for Objects of type corev1.Node
 const (
 	// AnnotationNodeCordonReason indicates a custom reason for the Slurm DRAIN action taken when the Kube node on which

--- a/docs/concepts/nodeset-controller.md
+++ b/docs/concepts/nodeset-controller.md
@@ -9,6 +9,13 @@
   - [Overview](#overview)
   - [Design](#design)
     - [Sequence Diagram](#sequence-diagram)
+  - [Drain and Cordon](#drain-and-cordon)
+    - [Kubernetes to Slurm (K8s → Slurm)](#kubernetes-to-slurm-k8s--slurm)
+    - [Slurm to Kubernetes (Slurm → K8s)](#slurm-to-kubernetes-slurm--k8s)
+    - [Loop Prevention](#loop-prevention)
+  - [Well-Known Annotations](#well-known-annotations)
+    - [Pod Annotations](#pod-annotations)
+    - [Node Annotations](#node-annotations)
 
 <!-- mdformat-toc end -->
 
@@ -66,3 +73,83 @@ sequenceDiagram
         end %% alt Slurm Node is Drained
     end %% opt Scale-in Replicas
 ```
+
+## Drain and Cordon
+
+The NodeSet controller synchronizes drain state **bidirectionally** between
+Kubernetes and Slurm. Draining a node on either side is reflected on the other.
+
+### Kubernetes to Slurm (K8s → Slurm)
+
+When a Kubernetes node is cordoned (`kubectl cordon <node>`), the NodeSet
+controller:
+
+1. Sets the `nodeset.slinky.slurm.net/pod-cordon: "true"` annotation on each
+   NodeSet pod running on that node.
+2. Drains the corresponding Slurm node via the Slurm REST API, prefixing the
+   reason with `slurm-operator:`.
+
+When the Kubernetes node is uncordoned, the pod annotation is removed and the
+Slurm node is undrained.
+
+The same flow applies when the `pod-cordon` annotation is set directly on a
+NodeSet pod (e.g. for targeted draining of a single Slurm node).
+
+A custom drain reason can be provided by setting the
+`nodeset.slinky.slurm.net/node-cordon-reason` annotation on the Kubernetes
+node before cordoning it.
+
+### Slurm to Kubernetes (Slurm → K8s)
+
+When a Slurm node is drained externally (e.g. via `scontrol update
+node=<name> state=drain reason="maintenance"`), the NodeSet controller detects
+this during its periodic reconciliation and:
+
+1. Sets `nodeset.slinky.slurm.net/pod-cordon: "true"` on the corresponding
+   pod.
+2. Sets `nodeset.slinky.slurm.net/pod-cordon-source: "slurm"` to record that
+   the cordon originated from the Slurm side.
+3. Sets `nodeset.slinky.slurm.net/pod-cordon-reason` to the Slurm node's
+   drain reason, making it visible from `kubectl describe pod`.
+
+When the Slurm node is undrained externally, the controller removes all three
+annotations from the pod.
+
+The operator distinguishes external drains from its own by checking the Slurm
+node reason prefix (`slurm-operator:`). Drains that do not carry this prefix
+are treated as externally initiated.
+
+### Loop Prevention
+
+A bidirectional sync must avoid infinite loops where each side re-triggers the
+other. The operator prevents this using the `pod-cordon-source` annotation:
+
+- When the controller sets `pod-cordon` because of an external Slurm drain, it
+  also sets `pod-cordon-source: "slurm"`.
+- On subsequent reconciles, if the pod is cordoned with source `"slurm"`, the
+  controller does **not** issue a drain command to Slurm (the node is already
+  drained).
+- If the Slurm node is later undrained, the controller detects the state change
+  and removes the pod annotations.
+- Cordons that originate from the Kubernetes side (node cordon or direct
+  annotation) do **not** set a source, so they continue to trigger the normal
+  K8s → Slurm drain flow.
+
+## Well-Known Annotations
+
+### Pod Annotations
+
+| Annotation | Value | Description |
+|---|---|---|
+| `nodeset.slinky.slurm.net/pod-cordon` | `"true"` | Marks the pod for Slurm node drain. When set, the corresponding Slurm node is drained (or already drained, in the Slurm → K8s direction). |
+| `nodeset.slinky.slurm.net/pod-cordon-source` | `"slurm"` | Present only when the cordon was initiated from the Slurm side (external drain). Prevents the operator from re-draining the Slurm node. |
+| `nodeset.slinky.slurm.net/pod-cordon-reason` | string | The Slurm node drain reason, stored when the cordon originates from an external Slurm drain. |
+| `nodeset.slinky.slurm.net/pod-deletion-cost` | integer | Influences pod deletion order during scale-in. Lower cost pods are deleted first. |
+| `nodeset.slinky.slurm.net/pod-deadline` | RFC 3339 timestamp | Indicates when the Slurm node's running workload is expected to complete. Earlier deadlines are preferred for deletion. |
+
+### Node Annotations
+
+| Annotation | Value | Description |
+|---|---|---|
+| `nodeset.slinky.slurm.net/node-cordon-reason` | string | When set on a Kubernetes node before cordoning, overrides the default Slurm drain reason used by the operator. |
+| `topology.slinky.slurm.net/line` | string | The Slurm dynamic topology line (e.g. `"topo-switch:s2,topo-block:b2"`). See [Topology](../usage/topology.md). |

--- a/internal/controller/nodeset/nodeset_sync.go
+++ b/internal/controller/nodeset/nodeset_sync.go
@@ -288,11 +288,12 @@ func (r *NodeSetReconciler) syncClusterWorkerService(ctx context.Context, nodese
 	return nil
 }
 
-// syncCordon handles propagating cordon/uncordon activity into the NodeSet pods.
+// syncCordon handles propagating cordon/uncordon activity between Kubernetes and Slurm bidirectionally.
 //
-// When the Kubernetes node is cordoned, the NodeSet pods on that node should have their Slurm node drained.
-// Conversely, when the Kubernetes node is uncordoned, the NodeSet pods on that node should have their Slurm node be undrained.
-// Otherwise the pods' pod-cordon label intent is propagated -- have the Slurm node drained or undrained.
+// K8s → Slurm: When the Kubernetes node is cordoned or the pod cordon annotation is set,
+// the corresponding Slurm node is drained.
+// Slurm → K8s: When a Slurm node is drained externally (reason without operator prefix),
+// the pod cordon annotation is applied to reflect the Slurm state.
 func (r *NodeSetReconciler) syncCordon(
 	ctx context.Context,
 	nodeset *slinkyv1beta1.NodeSet,
@@ -314,6 +315,7 @@ func (r *NodeSetReconciler) syncCordon(
 
 		nodeIsCordoned := node.Spec.Unschedulable
 		podIsCordoned := podutils.IsPodCordon(pod)
+		podCordonSource := podutils.GetPodCordonSource(pod)
 		slurmNodeIsUnresponsive, err := r.slurmControl.IsNodeDownForUnresponsive(ctx, nodeset, pod)
 		if err != nil {
 			return err
@@ -324,11 +326,33 @@ func (r *NodeSetReconciler) syncCordon(
 		}
 
 		switch {
-		// If Slurm node was externally set into a state, preserve it
-		case !ourReason, slurmNodeIsUnresponsive:
+		case slurmNodeIsUnresponsive:
 			return nil
 
-		// If Kubernetes node is cordoned but pod isn't, cordon the pod
+		// Slurm node has an externally set reason — sync K8s pod annotation
+		// to reflect the Slurm drain state (bidirectional: Slurm → K8s).
+		case !ourReason:
+			slurmIsDrain, err := r.slurmControl.IsNodeDrain(ctx, nodeset, pod)
+			if err != nil {
+				return err
+			}
+			if slurmIsDrain && !podIsCordoned {
+				reason, err := r.slurmControl.GetNodeReason(ctx, nodeset, pod)
+				if err != nil {
+					return err
+				}
+				logger.Info("Slurm node drained externally, cordoning pod",
+					"pod", klog.KObj(pod), "node", pod.Spec.NodeName, "reason", reason)
+				return r.makePodCordonFromSlurm(ctx, pod, reason)
+			}
+			if !slurmIsDrain && podIsCordoned && podCordonSource == slinkyv1beta1.PodCordonSourceSlurm {
+				logger.Info("Slurm node undrained externally, uncordoning pod",
+					"pod", klog.KObj(pod), "node", pod.Spec.NodeName)
+				return r.makePodUncordon(ctx, pod)
+			}
+			return nil
+
+		// If Kubernetes node is cordoned, cordon the pod and drain Slurm
 		case nodeIsCordoned:
 			logger.Info("Kubernetes node cordoned externally, cordoning pod",
 				"pod", klog.KObj(pod), "node", node.Name)
@@ -354,7 +378,20 @@ func (r *NodeSetReconciler) syncCordon(
 				return err
 			}
 
-		// If pod is cordoned, drain the Slurm node
+		// Pod was cordoned due to external Slurm drain. The Slurm reason may
+		// have been cleared (ourReason=true now), so verify Slurm is still drained.
+		case podIsCordoned && podCordonSource == slinkyv1beta1.PodCordonSourceSlurm:
+			slurmIsDrain, err := r.slurmControl.IsNodeDrain(ctx, nodeset, pod)
+			if err != nil {
+				return err
+			}
+			if !slurmIsDrain {
+				logger.Info("Slurm node no longer drained, uncordoning pod",
+					"pod", klog.KObj(pod))
+				return r.makePodUncordon(ctx, pod)
+			}
+
+		// If pod is cordoned (K8s-initiated), drain the Slurm node
 		case podIsCordoned:
 			reason := fmt.Sprintf("Pod (%s) was cordoned", klog.KObj(pod))
 			if err := r.slurmControl.MakeNodeDrain(ctx, nodeset, pod, reason); err != nil {
@@ -863,6 +900,40 @@ func (r *NodeSetReconciler) processReplica(
 	return r.podControl.UpdateNodeSetPod(ctx, nodeset, pod)
 }
 
+// makePodCordonFromSlurm will cordon the pod and mark it as originating from an external Slurm drain.
+// The Slurm drain reason is stored on the pod so it is visible from the K8s side.
+// This prevents the operator from re-issuing a drain command to Slurm on subsequent reconciles.
+func (r *NodeSetReconciler) makePodCordonFromSlurm(
+	ctx context.Context,
+	pod *corev1.Pod,
+	reason string,
+) error {
+	logger := log.FromContext(ctx)
+
+	if podutils.IsPodCordon(pod) && podutils.GetPodCordonSource(pod) == slinkyv1beta1.PodCordonSourceSlurm {
+		return nil
+	}
+
+	toUpdate := pod.DeepCopy()
+	logger.Info("Cordon Pod due to external Slurm drain", "Pod", klog.KObj(toUpdate), "reason", reason)
+	if toUpdate.Annotations == nil {
+		toUpdate.Annotations = make(map[string]string)
+	}
+	toUpdate.Annotations[slinkyv1beta1.AnnotationPodCordon] = "true"
+	toUpdate.Annotations[slinkyv1beta1.AnnotationPodCordonSource] = slinkyv1beta1.PodCordonSourceSlurm
+	if reason != "" {
+		toUpdate.Annotations[slinkyv1beta1.AnnotationPodCordonReason] = reason
+	}
+	if err := r.Patch(ctx, toUpdate, client.StrategicMergeFrom(pod)); err != nil {
+		return err
+	}
+	if err := r.Get(ctx, client.ObjectKeyFromObject(pod), pod); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // makePodCordonAndDrain will cordon the pod and drain the corresponding Slurm node.
 func (r *NodeSetReconciler) makePodCordonAndDrain(
 	ctx context.Context,
@@ -999,6 +1070,8 @@ func (r *NodeSetReconciler) makePodUncordon(ctx context.Context, pod *corev1.Pod
 	toUpdate := pod.DeepCopy()
 	logger.Info("Uncordon Pod", "Pod", klog.KObj(toUpdate))
 	delete(toUpdate.Annotations, slinkyv1beta1.AnnotationPodCordon)
+	delete(toUpdate.Annotations, slinkyv1beta1.AnnotationPodCordonSource)
+	delete(toUpdate.Annotations, slinkyv1beta1.AnnotationPodCordonReason)
 	if err := r.Patch(ctx, toUpdate, client.StrategicMergeFrom(pod)); err != nil {
 		return err
 	}

--- a/internal/controller/nodeset/nodeset_sync_test.go
+++ b/internal/controller/nodeset/nodeset_sync_test.go
@@ -2412,6 +2412,282 @@ func Test_syncPodUncordon(t *testing.T) {
 	}
 }
 
+func Test_syncCordon_externalSlurmDrain(t *testing.T) {
+	controller := &slinkyv1beta1.Controller{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "slurm",
+		},
+	}
+	nodeset := newNodeSet("foo", controller.Name, 1)
+
+	type fields struct {
+		Client    client.Client
+		ClientMap *clientmap.ClientMap
+	}
+	type args struct {
+		ctx     context.Context
+		nodeset *slinkyv1beta1.NodeSet
+		pods    []*corev1.Pod
+	}
+	tests := []struct {
+		name           string
+		fields         fields
+		args           args
+		wantErr        bool
+		wantCordon     bool
+		wantSource     string
+		wantReason     string
+		checkPodName   string
+	}{
+		{
+			name: "external drain sets pod cordon annotation with reason",
+			fields: func() fields {
+				pod := nodesetutils.NewNodeSetPod(fake.NewFakeClient(), nodeset, controller, 0, "")
+				pod.Spec.NodeName = "test-node"
+				return fields{
+					Client: fake.NewFakeClient(
+						nodeset.DeepCopy(),
+						pod.DeepCopy(),
+						&corev1.Node{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "test-node",
+							},
+						},
+					),
+					ClientMap: func() *clientmap.ClientMap {
+						nodeList := &slurmtypes.V0044NodeList{
+							Items: []slurmtypes.V0044Node{
+								{
+									V0044Node: slurmapi.V0044Node{
+										Name: ptr.To(nodesetutils.GetNodeName(pod)),
+										State: ptr.To([]slurmapi.V0044NodeState{
+											slurmapi.V0044NodeStateIDLE,
+											slurmapi.V0044NodeStateDRAIN,
+										}),
+										Reason: ptr.To("maintenance window"),
+									},
+								},
+							},
+						}
+						sclient := newFakeClientList(sinterceptor.Funcs{}, nodeList)
+						return newClientMap(controller.Name, sclient)
+					}(),
+				}
+			}(),
+			args: func() args {
+				pod := nodesetutils.NewNodeSetPod(fake.NewFakeClient(), nodeset, controller, 0, "")
+				pod.Spec.NodeName = "test-node"
+				return args{
+					ctx:     context.TODO(),
+					nodeset: nodeset.DeepCopy(),
+					pods:    []*corev1.Pod{pod},
+				}
+			}(),
+			wantErr:      false,
+			wantCordon:   true,
+			wantSource:   slinkyv1beta1.PodCordonSourceSlurm,
+			wantReason:   "maintenance window",
+			checkPodName: nodesetutils.NewNodeSetPod(fake.NewFakeClient(), nodeset, controller, 0, "").Name,
+		},
+		{
+			name: "external undrain removes pod cordon annotation",
+			fields: func() fields {
+				pod := nodesetutils.NewNodeSetPod(fake.NewFakeClient(), nodeset, controller, 0, "")
+				pod.Spec.NodeName = "test-node"
+				pod.Annotations[slinkyv1beta1.AnnotationPodCordon] = "true"
+				pod.Annotations[slinkyv1beta1.AnnotationPodCordonSource] = slinkyv1beta1.PodCordonSourceSlurm
+				pod.Annotations[slinkyv1beta1.AnnotationPodCordonReason] = "maintenance window"
+				return fields{
+					Client: fake.NewFakeClient(
+						nodeset.DeepCopy(),
+						pod.DeepCopy(),
+						&corev1.Node{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "test-node",
+							},
+						},
+					),
+					ClientMap: func() *clientmap.ClientMap {
+						nodeList := &slurmtypes.V0044NodeList{
+							Items: []slurmtypes.V0044Node{
+								{
+									V0044Node: slurmapi.V0044Node{
+										Name: ptr.To(nodesetutils.GetNodeName(pod)),
+										State: ptr.To([]slurmapi.V0044NodeState{
+											slurmapi.V0044NodeStateIDLE,
+										}),
+										Reason: ptr.To("maintenance window"),
+									},
+								},
+							},
+						}
+						sclient := newFakeClientList(sinterceptor.Funcs{}, nodeList)
+						return newClientMap(controller.Name, sclient)
+					}(),
+				}
+			}(),
+			args: func() args {
+				pod := nodesetutils.NewNodeSetPod(fake.NewFakeClient(), nodeset, controller, 0, "")
+				pod.Spec.NodeName = "test-node"
+				pod.Annotations[slinkyv1beta1.AnnotationPodCordon] = "true"
+				pod.Annotations[slinkyv1beta1.AnnotationPodCordonSource] = slinkyv1beta1.PodCordonSourceSlurm
+				pod.Annotations[slinkyv1beta1.AnnotationPodCordonReason] = "maintenance window"
+				return args{
+					ctx:     context.TODO(),
+					nodeset: nodeset.DeepCopy(),
+					pods:    []*corev1.Pod{pod},
+				}
+			}(),
+			wantErr:      false,
+			wantCordon:   false,
+			wantSource:   "",
+			wantReason:   "",
+			checkPodName: nodesetutils.NewNodeSetPod(fake.NewFakeClient(), nodeset, controller, 0, "").Name,
+		},
+		{
+			name: "external drain already cordoned is no-op",
+			fields: func() fields {
+				pod := nodesetutils.NewNodeSetPod(fake.NewFakeClient(), nodeset, controller, 0, "")
+				pod.Spec.NodeName = "test-node"
+				pod.Annotations[slinkyv1beta1.AnnotationPodCordon] = "true"
+				pod.Annotations[slinkyv1beta1.AnnotationPodCordonSource] = slinkyv1beta1.PodCordonSourceSlurm
+				pod.Annotations[slinkyv1beta1.AnnotationPodCordonReason] = "maintenance window"
+				return fields{
+					Client: fake.NewFakeClient(
+						nodeset.DeepCopy(),
+						pod.DeepCopy(),
+						&corev1.Node{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "test-node",
+							},
+						},
+					),
+					ClientMap: func() *clientmap.ClientMap {
+						nodeList := &slurmtypes.V0044NodeList{
+							Items: []slurmtypes.V0044Node{
+								{
+									V0044Node: slurmapi.V0044Node{
+										Name: ptr.To(nodesetutils.GetNodeName(pod)),
+										State: ptr.To([]slurmapi.V0044NodeState{
+											slurmapi.V0044NodeStateIDLE,
+											slurmapi.V0044NodeStateDRAIN,
+										}),
+										Reason: ptr.To("maintenance window"),
+									},
+								},
+							},
+						}
+						sclient := newFakeClientList(sinterceptor.Funcs{}, nodeList)
+						return newClientMap(controller.Name, sclient)
+					}(),
+				}
+			}(),
+			args: func() args {
+				pod := nodesetutils.NewNodeSetPod(fake.NewFakeClient(), nodeset, controller, 0, "")
+				pod.Spec.NodeName = "test-node"
+				pod.Annotations[slinkyv1beta1.AnnotationPodCordon] = "true"
+				pod.Annotations[slinkyv1beta1.AnnotationPodCordonSource] = slinkyv1beta1.PodCordonSourceSlurm
+				pod.Annotations[slinkyv1beta1.AnnotationPodCordonReason] = "maintenance window"
+				return args{
+					ctx:     context.TODO(),
+					nodeset: nodeset.DeepCopy(),
+					pods:    []*corev1.Pod{pod},
+				}
+			}(),
+			wantErr:      false,
+			wantCordon:   true,
+			wantSource:   slinkyv1beta1.PodCordonSourceSlurm,
+			wantReason:   "maintenance window",
+			checkPodName: nodesetutils.NewNodeSetPod(fake.NewFakeClient(), nodeset, controller, 0, "").Name,
+		},
+		{
+			name: "slurm-source cordon removed when slurm reason cleared and node undrained",
+			fields: func() fields {
+				pod := nodesetutils.NewNodeSetPod(fake.NewFakeClient(), nodeset, controller, 0, "")
+				pod.Spec.NodeName = "test-node"
+				pod.Annotations[slinkyv1beta1.AnnotationPodCordon] = "true"
+				pod.Annotations[slinkyv1beta1.AnnotationPodCordonSource] = slinkyv1beta1.PodCordonSourceSlurm
+				pod.Annotations[slinkyv1beta1.AnnotationPodCordonReason] = "maintenance window"
+				return fields{
+					Client: fake.NewFakeClient(
+						nodeset.DeepCopy(),
+						pod.DeepCopy(),
+						&corev1.Node{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "test-node",
+							},
+						},
+					),
+					ClientMap: func() *clientmap.ClientMap {
+						nodeList := &slurmtypes.V0044NodeList{
+							Items: []slurmtypes.V0044Node{
+								{
+									V0044Node: slurmapi.V0044Node{
+										Name: ptr.To(nodesetutils.GetNodeName(pod)),
+										State: ptr.To([]slurmapi.V0044NodeState{
+											slurmapi.V0044NodeStateIDLE,
+										}),
+									},
+								},
+							},
+						}
+						sclient := newFakeClientList(sinterceptor.Funcs{}, nodeList)
+						return newClientMap(controller.Name, sclient)
+					}(),
+				}
+			}(),
+			args: func() args {
+				pod := nodesetutils.NewNodeSetPod(fake.NewFakeClient(), nodeset, controller, 0, "")
+				pod.Spec.NodeName = "test-node"
+				pod.Annotations[slinkyv1beta1.AnnotationPodCordon] = "true"
+				pod.Annotations[slinkyv1beta1.AnnotationPodCordonSource] = slinkyv1beta1.PodCordonSourceSlurm
+				pod.Annotations[slinkyv1beta1.AnnotationPodCordonReason] = "maintenance window"
+				return args{
+					ctx:     context.TODO(),
+					nodeset: nodeset.DeepCopy(),
+					pods:    []*corev1.Pod{pod},
+				}
+			}(),
+			wantErr:      false,
+			wantCordon:   false,
+			wantSource:   "",
+			wantReason:   "",
+			checkPodName: nodesetutils.NewNodeSetPod(fake.NewFakeClient(), nodeset, controller, 0, "").Name,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newNodeSetController(tt.fields.Client, tt.fields.ClientMap)
+			if err := r.syncCordon(tt.args.ctx, tt.args.nodeset, tt.args.pods); (err != nil) != tt.wantErr {
+				t.Errorf("syncCordon() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			checkPod := &corev1.Pod{}
+			key := types.NamespacedName{
+				Namespace: corev1.NamespaceDefault,
+				Name:      tt.checkPodName,
+			}
+			if err := tt.fields.Client.Get(tt.args.ctx, key, checkPod); err != nil {
+				t.Fatalf("failed to get pod: %v", err)
+			}
+
+			gotCordon := podutils.IsPodCordon(checkPod)
+			if gotCordon != tt.wantCordon {
+				t.Errorf("pod cordon = %v, want %v", gotCordon, tt.wantCordon)
+			}
+			gotSource := podutils.GetPodCordonSource(checkPod)
+			if gotSource != tt.wantSource {
+				t.Errorf("pod cordon source = %v, want %v", gotSource, tt.wantSource)
+			}
+			gotReason := checkPod.Annotations[slinkyv1beta1.AnnotationPodCordonReason]
+			if gotReason != tt.wantReason {
+				t.Errorf("pod cordon reason = %v, want %v", gotReason, tt.wantReason)
+			}
+		})
+	}
+}
+
 func TestNodeSetReconciler_syncSlurmTopology(t *testing.T) {
 	node := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/controller/nodeset/slurmcontrol/slurmcontrol.go
+++ b/internal/controller/nodeset/slurmcontrol/slurmcontrol.go
@@ -51,6 +51,8 @@ type SlurmControlInterface interface {
 	IsNodeDownForUnresponsive(ctx context.Context, nodeset *slinkyv1beta1.NodeSet, pod *corev1.Pod) (bool, error)
 	// IsNodeReasonOurs reports if the node reason was set by the operator.
 	IsNodeReasonOurs(ctx context.Context, nodeset *slinkyv1beta1.NodeSet, pod *corev1.Pod) (bool, error)
+	// GetNodeReason returns the Slurm node's reason string.
+	GetNodeReason(ctx context.Context, nodeset *slinkyv1beta1.NodeSet, pod *corev1.Pod) (string, error)
 	// CalculateNodeStatus returns the current state of the registered slurm nodes.
 	CalculateNodeStatus(ctx context.Context, nodeset *slinkyv1beta1.NodeSet, pods []*corev1.Pod) (SlurmNodeStatus, error)
 	// GetNodeDeadlines returns a map of node to its deadline time.Time calculated from running jobs.
@@ -393,6 +395,29 @@ func (r *realSlurmControl) IsNodeReasonOurs(ctx context.Context, nodeset *slinky
 	}
 
 	return true, nil
+}
+
+// GetNodeReason implements SlurmControlInterface.
+func (r *realSlurmControl) GetNodeReason(ctx context.Context, nodeset *slinkyv1beta1.NodeSet, pod *corev1.Pod) (string, error) {
+	logger := log.FromContext(ctx)
+
+	slurmClient := r.lookupClient(nodeset)
+	if slurmClient == nil {
+		logger.V(2).Info("no client for nodeset, cannot do GetNodeReason()",
+			"pod", klog.KObj(pod))
+		return "", nil
+	}
+
+	slurmNode := &slurmtypes.V0044Node{}
+	key := slurmobject.ObjectKey(nodesetutils.GetNodeName(pod))
+	if err := slurmClient.Get(ctx, key, slurmNode); err != nil {
+		if tolerateError(err) {
+			return "", nil
+		}
+		return "", err
+	}
+
+	return ptr.Deref(slurmNode.Reason, ""), nil
 }
 
 type SlurmNodeStatus struct {

--- a/internal/controller/nodeset/slurmcontrol/slurmcontrol_test.go
+++ b/internal/controller/nodeset/slurmcontrol/slurmcontrol_test.go
@@ -1242,6 +1242,132 @@ func Test_realSlurmControl_IsNodeReasonOurs(t *testing.T) {
 	}
 }
 
+func Test_realSlurmControl_GetNodeReason(t *testing.T) {
+	ctx := context.Background()
+	controller := &slinkyv1beta1.Controller{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "slurm",
+		},
+	}
+	nodeset := newNodeSet("foo", controller.Name, 1)
+	pod := nodesetutils.NewNodeSetPod(kubefake.NewFakeClient(), nodeset, controller, 0, "")
+	type fields struct {
+		clientMap *clientmap.ClientMap
+	}
+	type args struct {
+		ctx     context.Context
+		nodeset *slinkyv1beta1.NodeSet
+		pod     *corev1.Pod
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "no reason",
+			fields: func() fields {
+				node := &types.V0044Node{
+					V0044Node: api.V0044Node{
+						Name: ptr.To(nodesetutils.GetNodeName(pod)),
+						State: ptr.To([]api.V0044NodeState{
+							api.V0044NodeStateIDLE,
+						}),
+					},
+				}
+				sclient := fake.NewClientBuilder().WithObjects(node).Build()
+				return fields{
+					clientMap: newSlurmClientMap(controller.Name, sclient),
+				}
+			}(),
+			args: args{
+				ctx:     ctx,
+				nodeset: nodeset,
+				pod:     pod,
+			},
+			want: "",
+		},
+		{
+			name: "external reason",
+			fields: func() fields {
+				node := &types.V0044Node{
+					V0044Node: api.V0044Node{
+						Name: ptr.To(nodesetutils.GetNodeName(pod)),
+						State: ptr.To([]api.V0044NodeState{
+							api.V0044NodeStateIDLE,
+							api.V0044NodeStateDRAIN,
+						}),
+						Reason: ptr.To("maintenance window"),
+					},
+				}
+				sclient := fake.NewClientBuilder().WithObjects(node).Build()
+				return fields{
+					clientMap: newSlurmClientMap(controller.Name, sclient),
+				}
+			}(),
+			args: args{
+				ctx:     ctx,
+				nodeset: nodeset,
+				pod:     pod,
+			},
+			want: "maintenance window",
+		},
+		{
+			name: "operator reason",
+			fields: func() fields {
+				node := &types.V0044Node{
+					V0044Node: api.V0044Node{
+						Name: ptr.To(nodesetutils.GetNodeName(pod)),
+						State: ptr.To([]api.V0044NodeState{
+							api.V0044NodeStateIDLE,
+							api.V0044NodeStateDRAIN,
+						}),
+						Reason: ptr.To(nodeReasonPrefix + " Pod (default/foo-0) was cordoned"),
+					},
+				}
+				sclient := fake.NewClientBuilder().WithObjects(node).Build()
+				return fields{
+					clientMap: newSlurmClientMap(controller.Name, sclient),
+				}
+			}(),
+			args: args{
+				ctx:     ctx,
+				nodeset: nodeset,
+				pod:     pod,
+			},
+			want: nodeReasonPrefix + " Pod (default/foo-0) was cordoned",
+		},
+		{
+			name: "no client",
+			fields: fields{
+				clientMap: clientmap.NewClientMap(),
+			},
+			args: args{
+				ctx:     ctx,
+				nodeset: nodeset,
+				pod:     pod,
+			},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &realSlurmControl{
+				clientMap: tt.fields.clientMap,
+			}
+			got, err := r.GetNodeReason(tt.args.ctx, tt.args.nodeset, tt.args.pod)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("realSlurmControl.GetNodeReason() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("realSlurmControl.GetNodeReason() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func Test_realSlurmControl_CalculateNodeStatus(t *testing.T) {
 	ctx := context.Background()
 	controller := &slinkyv1beta1.Controller{

--- a/internal/utils/podutils/pod.go
+++ b/internal/utils/podutils/pod.go
@@ -16,6 +16,11 @@ func IsPodCordon(pod *corev1.Pod) bool {
 	return pod.GetAnnotations()[slinkyv1beta1.AnnotationPodCordon] == "true"
 }
 
+// GetPodCordonSource returns the source that initiated the pod cordon, or empty string if not set.
+func GetPodCordonSource(pod *corev1.Pod) string {
+	return pod.GetAnnotations()[slinkyv1beta1.AnnotationPodCordonSource]
+}
+
 // isRunningAndReady returns true if pod is in the PodRunning Phase, if it has a condition of PodReady.
 func IsRunningAndReady(pod *corev1.Pod) bool {
 	return IsRunning(pod) && podutil.IsPodReady(pod)

--- a/internal/utils/podutils/pod_test.go
+++ b/internal/utils/podutils/pod_test.go
@@ -9,7 +9,102 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
 )
+
+func TestIsPodCordon(t *testing.T) {
+	tests := []struct {
+		name string
+		pod  *corev1.Pod
+		want bool
+	}{
+		{
+			name: "cordon annotation set to true",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						slinkyv1beta1.AnnotationPodCordon: "true",
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "cordon annotation set to false",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						slinkyv1beta1.AnnotationPodCordon: "false",
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "no annotations",
+			pod:  &corev1.Pod{},
+			want: false,
+		},
+		{
+			name: "empty annotations",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsPodCordon(tt.pod); got != tt.want {
+				t.Errorf("IsPodCordon() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetPodCordonSource(t *testing.T) {
+	tests := []struct {
+		name string
+		pod  *corev1.Pod
+		want string
+	}{
+		{
+			name: "source is slurm",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						slinkyv1beta1.AnnotationPodCordonSource: slinkyv1beta1.PodCordonSourceSlurm,
+					},
+				},
+			},
+			want: slinkyv1beta1.PodCordonSourceSlurm,
+		},
+		{
+			name: "source not set",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+			},
+			want: "",
+		},
+		{
+			name: "no annotations",
+			pod:  &corev1.Pod{},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetPodCordonSource(tt.pod); got != tt.want {
+				t.Errorf("GetPodCordonSource() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
 
 func TestIsRunningAndReady(t *testing.T) {
 	var podA, podB corev1.Pod


### PR DESCRIPTION
## Summary

When a Slurm node is drained externally (e.g. via scontrol), the operator now detects this during reconciliation and applies the pod-cordon annotation along with pod-cordon-source and pod-cordon-reason annotations to the corresponding NodeSet pod. When the Slurm node is undrained externally, the annotations are removed. A pod-cordon-source="slurm" annotation prevents infinite reconciliation loops by signaling that the cordon originated from the Slurm side and should not trigger a re-drain command.

## Breaking Changes

none

## Testing Notes

local kind

## Additional Context

<!--
Provide any other additional information here.
(e.g. which commits are critical or superfluous; why this implementation)
-->
