### PR TITLE
feat(loginset): add configurable deployment strategy

### DIFF
--- a/api/v1beta1/loginset_types.go
+++ b/api/v1beta1/loginset_types.go
@@ -4,6 +4,7 @@
 package v1beta1
 
 import (
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -60,6 +61,11 @@ type LoginSetSpec struct {
 	// SssdConfRef is a reference to a secret containing the `sssd.conf`.
 	// +required
 	SssdConfRef corev1.SecretKeySelector `json:"sssdConfRef,omitzero"`
+
+	// Strategy is the deployment strategy to use to replace existing pods with new ones.
+	// Ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+	// +optional
+	Strategy appsv1.DeploymentStrategy `json:"strategy,omitzero"`
 
 	// Service defines a template for a Kubernetes Service object.
 	// +optional

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -384,6 +384,7 @@ func (in *LoginSetSpec) DeepCopyInto(out *LoginSetSpec) {
 	in.InitConf.DeepCopyInto(&out.InitConf)
 	in.Template.DeepCopyInto(&out.Template)
 	in.SssdConfRef.DeepCopyInto(&out.SssdConfRef)
+	in.Strategy.DeepCopyInto(&out.Strategy)
 	in.Service.DeepCopyInto(&out.Service)
 }
 

--- a/config/crd/bases/slinky.slurm.net_loginsets.yaml
+++ b/config/crd/bases/slinky.slurm.net_loginsets.yaml
@@ -168,6 +168,55 @@ spec:
                 - key
                 type: object
                 x-kubernetes-map-type: atomic
+              strategy:
+                description: |-
+                  Strategy is the deployment strategy to use to replace existing pods with new ones.
+                  Ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+                properties:
+                  rollingUpdate:
+                    description: |-
+                      Rolling update config params. Present only if DeploymentStrategyType =
+                      RollingUpdate.
+                    properties:
+                      maxSurge:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          The maximum number of pods that can be scheduled above the desired number of
+                          pods.
+                          Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                          This can not be 0 if MaxUnavailable is 0.
+                          Absolute number is calculated from percentage by rounding up.
+                          Defaults to 25%.
+                          Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when
+                          the rolling update starts, such that the total number of old and new pods do not exceed
+                          130% of desired pods. Once old pods have been killed,
+                          new ReplicaSet can be scaled up further, ensuring that total number of pods running
+                          at any time during the update is at most 130% of desired pods.
+                        x-kubernetes-int-or-string: true
+                      maxUnavailable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          The maximum number of pods that can be unavailable during the update.
+                          Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                          Absolute number is calculated from percentage by rounding down.
+                          This can not be 0 if MaxSurge is 0.
+                          Defaults to 25%.
+                          Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods
+                          immediately when the rolling update starts. Once new pods are ready, old ReplicaSet
+                          can be scaled down further, followed by scaling up the new ReplicaSet, ensuring
+                          that the total number of pods available at all times during the update is at
+                          least 70% of desired pods.
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  type:
+                    description: Type of deployment. Can be "Recreate" or "RollingUpdate".
+                      Default is RollingUpdate.
+                    type: string
+                type: object
               template:
                 description: |-
                   Template is the object that describes the pod that will be created if

--- a/helm/slurm-operator-crds/templates/slinky.slurm.net_loginsets.yaml
+++ b/helm/slurm-operator-crds/templates/slinky.slurm.net_loginsets.yaml
@@ -168,6 +168,55 @@ spec:
                 - key
                 type: object
                 x-kubernetes-map-type: atomic
+              strategy:
+                description: |-
+                  Strategy is the deployment strategy to use to replace existing pods with new ones.
+                  Ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+                properties:
+                  rollingUpdate:
+                    description: |-
+                      Rolling update config params. Present only if DeploymentStrategyType =
+                      RollingUpdate.
+                    properties:
+                      maxSurge:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          The maximum number of pods that can be scheduled above the desired number of
+                          pods.
+                          Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                          This can not be 0 if MaxUnavailable is 0.
+                          Absolute number is calculated from percentage by rounding up.
+                          Defaults to 25%.
+                          Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when
+                          the rolling update starts, such that the total number of old and new pods do not exceed
+                          130% of desired pods. Once old pods have been killed,
+                          new ReplicaSet can be scaled up further, ensuring that total number of pods running
+                          at any time during the update is at most 130% of desired pods.
+                        x-kubernetes-int-or-string: true
+                      maxUnavailable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          The maximum number of pods that can be unavailable during the update.
+                          Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                          Absolute number is calculated from percentage by rounding down.
+                          This can not be 0 if MaxSurge is 0.
+                          Defaults to 25%.
+                          Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods
+                          immediately when the rolling update starts. Once new pods are ready, old ReplicaSet
+                          can be scaled down further, followed by scaling up the new ReplicaSet, ensuring
+                          that the total number of pods available at all times during the update is at
+                          least 70% of desired pods.
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  type:
+                    description: Type of deployment. Can be "Recreate" or "RollingUpdate".
+                      Default is RollingUpdate.
+                    type: string
+                type: object
               template:
                 description: |-
                   Template is the object that describes the pod that will be created if

--- a/helm/slurm/templates/loginset/loginset-cr.yaml
+++ b/helm/slurm/templates/loginset/loginset-cr.yaml
@@ -40,6 +40,10 @@ spec:
   {{ if $loginset.replicas }}
   replicas: {{ $loginset.replicas }}
   {{- end }}{{- /* if $loginset.replicas */}}
+  {{- with $loginset.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}{{- /* with $loginset.strategy */}}
   login:
     {{- $_ := set $loginset.login "imagePullPolicy" (get $loginset.login "imagePullPolicy" | default $.Values.imagePullPolicy ) -}}
     {{- include "format-container" $loginset.login | nindent 4 }}

--- a/helm/slurm/tests/loginset_test.yaml
+++ b/helm/slurm/tests/loginset_test.yaml
@@ -121,6 +121,26 @@ tests:
       - equal:
           path: spec.template.spec.topologySpreadConstraints[0].labelSelector.matchLabels.foo
           value: bar
+  - it: should set strategy
+    set:
+      loginsets:
+        slinky:
+          enabled: true
+          strategy:
+            type: RollingUpdate
+            rollingUpdate:
+              maxUnavailable: 1
+              maxSurge: 0
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: RollingUpdate
+      - equal:
+          path: spec.strategy.rollingUpdate.maxUnavailable
+          value: 1
+      - equal:
+          path: spec.strategy.rollingUpdate.maxSurge
+          value: 0
   - it: should not use priority class
     set:
       priorityClass:

--- a/helm/slurm/values.yaml
+++ b/helm/slurm/values.yaml
@@ -541,6 +541,13 @@ loginsets:
     enabled: false
     # -- Number of replicas to deploy.
     replicas: 1
+    # -- Deployment strategy configuration.
+    # Ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+    strategy: {}
+      # type: RollingUpdate
+      # rollingUpdate:
+      #   maxUnavailable: 0
+      #   maxSurge: 1
     # login container configurations.
     login:
       # -- (string \| object) The image to use.

--- a/internal/builder/loginbuilder/login_app.go
+++ b/internal/builder/loginbuilder/login_app.go
@@ -90,6 +90,7 @@ func (b *LoginBuilder) BuildLogin(loginset *slinkyv1beta1.LoginSet) (*appsv1.Dep
 		Spec: appsv1.DeploymentSpec{
 			Replicas:             loginset.Spec.Replicas,
 			RevisionHistoryLimit: ptr.To[int32](0),
+			Strategy:             loginset.Spec.Strategy,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: selectorLabels,
 			},


### PR DESCRIPTION
## Summary

Add a `strategy` field to `LoginSetSpec` to allow configuring the Kubernetes Deployment rollout strategy for Login pods.

With the default Deployment strategy, rollouts can get stuck when running one Login pod per node and cluster node capacity is fully utilized. the surge pods cannot be scheduled. This change exposes the standard `appsv1.DeploymentStrategy` on the LoginSet CRD so users can set e.g. `maxSurge: 0` / `maxUnavailable: 1` to avoid requiring extra node capacity during rollouts.

When the field is omitted, behavior is unchanged (Kubernetes applies its defaults).

## Breaking Changes

N/A

## Testing Notes

- Unit tests pass (`go test ./internal/builder/loginbuilder/...`, `go test ./internal/utils/objectutils/...`)
- Helm unit tests pass (`make helm-unittest`) including a new `should set strategy` test case
- Verified end-to-end on a local kind cluster:
  - LoginSet CR correctly stores the `strategy` field
  - Underlying Deployment reflects the configured strategy (`maxSurge: 0`, `maxUnavailable: 1`)
  - Rollout restart confirmed zero-surge behavior: old pod terminated before new pod created

## Additional Context

The implementation reuses `appsv1.DeploymentStrategy` directly rather than defining custom types, since LoginSet maps 1:1 to a Kubernetes Deployment. This gives users the full standard API (`RollingUpdate` with `maxUnavailable`/`maxSurge`, or `Recreate`).

The Deployment patch path in `objectutils.SyncObject` already copies `Strategy` from the built object, so no changes were needed there.