### PR TITLE
fix: helm multiple LoginSets

### DIFF
--- a/helm/slurm/templates/loginset/loginset-cr.yaml
+++ b/helm/slurm/templates/loginset/loginset-cr.yaml
@@ -12,7 +12,7 @@ SPDX-License-Identifier: Apache-2.0
 {{- $_ := set $podSpec "imagePullSecrets" $imagePullSecrets -}}
 {{- $priorityClassName := $podSpec.priorityClassName | default (include "slurm.priorityClassName" $) -}}
 {{- $_ := set $podSpec "priorityClassName" $priorityClassName -}}
-{{- $podTemplate := dict "metadata" $metadata "spec" $podSpec -}}
+{{- $podTemplate := dict "metadata" $metadata "spec" $podSpec }}
 ---
 apiVersion: slinky.slurm.net/v1beta1
 kind: LoginSet

--- a/helm/slurm/tests/loginset_test.yaml
+++ b/helm/slurm/tests/loginset_test.yaml
@@ -159,3 +159,23 @@ tests:
       - equal:
           path: spec.template.spec.priorityClassName
           value: foo-priorityclass
+  - it: should deploy multiple loginsets
+    set:
+      loginsets:
+        slinky:
+          enabled: true
+        slinky2:
+          enabled: true
+          initconf:
+            image:
+              repository: docker.io/library/alpine
+              tag: v1.2.3
+          login:
+            image:
+              repository: ghcr.io/slinkyproject/login
+              tag: v1.2.3
+    asserts:
+      - hasDocuments:
+          count: 2
+      - isKind:
+          of: LoginSet


### PR DESCRIPTION
## Summary

### Problem

When multiple LoginSets are enabled (e.g. `slinky` and `slinky2`), the Helm template produced invalid YAML. The `---` document separator was concatenated directly onto the previous document's last line:

```yaml
      type: LoadBalancer---
apiVersion: slinky.slurm.net/v1beta1
kind: LoginSet
```
### Root cause

The `{{- $podTemplate := dict "metadata" $metadata "spec" $podSpec -}}` line used `-}}`, which trims the trailing newline. That removed the newline between documents when the template loop rendered the next LoginSet.

### Solution

Remove the `-` from `-}}` so the newline after the assignment is preserved:

This breaks YAML parsing because documents must be separated by a newline before `---`.

## Breaking Changes

none

## Testing Notes

new helm unittest to cover this use case

```
helm unittest .


### Chart [ slurm ] .

 PASS  test accounting  tests/accounting_test.yaml
 PASS  test controller  tests/controller_test.yaml
 PASS  test loginset    tests/loginset_test.yaml
 PASS  test nodeset     tests/nodeset_test.yaml
 PASS  test secrets     tests/priorityclass_test.yaml
 PASS  test restapi     tests/restapi_test.yaml
 PASS  test secrets     tests/secrets_test.yaml

Charts:      1 passed, 1 total
Test Suites: 7 passed, 7 total
Tests:       69 passed, 69 total
Snapshot:    5 passed, 5 total
Time:        118.6785ms

```

## Additional Context

<!--
Provide any other additional information here.
(e.g. which commits are critical or superfluous; why this implementation)
-->
