### PR TITLE
fix: clear mutually exclusive probe handlers during container merge

### DIFF
--- a/helm/slurm/tests/controller_test.yaml
+++ b/helm/slurm/tests/controller_test.yaml
@@ -149,3 +149,31 @@ tests:
       - equal:
           path: spec.template.spec.priorityClassName
           value: foo-priorityclass
+  - it: should set slurmctld livenessProbe exec
+    set:
+      controller:
+        slurmctld:
+          livenessProbe:
+            exec:
+              command:
+                - /usr/bin/scontrol
+                - ping
+            initialDelaySeconds: 60
+            periodSeconds: 20
+            failureThreshold: 3
+    asserts:
+      - equal:
+          path: spec.slurmctld.livenessProbe.exec.command[0]
+          value: /usr/bin/scontrol
+      - equal:
+          path: spec.slurmctld.livenessProbe.exec.command[1]
+          value: ping
+      - equal:
+          path: spec.slurmctld.livenessProbe.initialDelaySeconds
+          value: 60
+      - equal:
+          path: spec.slurmctld.livenessProbe.periodSeconds
+          value: 20
+      - equal:
+          path: spec.slurmctld.livenessProbe.failureThreshold
+          value: 3

--- a/internal/builder/common/container.go
+++ b/internal/builder/common/container.go
@@ -21,6 +21,29 @@ func (b *CommonBuilder) BuildContainer(opts ContainerOpts) corev1.Container {
 	opts.Base.Args = structutils.MergeList(opts.Base.Args, opts.Merge.Args)
 	opts.Merge.Args = []string{}
 
+	clearBaseProbeHandler(opts.Base.LivenessProbe, opts.Merge.LivenessProbe)
+	clearBaseProbeHandler(opts.Base.ReadinessProbe, opts.Merge.ReadinessProbe)
+	clearBaseProbeHandler(opts.Base.StartupProbe, opts.Merge.StartupProbe)
+
 	out := structutils.StrategicMergePatch(&opts.Base, &opts.Merge)
 	return ptr.Deref(out, corev1.Container{})
+}
+
+// clearBaseProbeHandler clears the base probe's handler fields when the merge
+// probe specifies a handler. ProbeHandler fields (Exec, HTTPGet, TCPSocket,
+// GRPC) are mutually exclusive but strategic merge patch treats them as
+// independent struct fields, so the base handler must be cleared to prevent
+// both from appearing in the result.
+func clearBaseProbeHandler(base, merge *corev1.Probe) {
+	if !hasProbeHandler(base) || !hasProbeHandler(merge) {
+		return
+	}
+	base.Exec = nil
+	base.HTTPGet = nil
+	base.TCPSocket = nil
+	base.GRPC = nil
+}
+
+func hasProbeHandler(p *corev1.Probe) bool {
+	return p != nil && (p.Exec != nil || p.HTTPGet != nil || p.TCPSocket != nil || p.GRPC != nil)
 }

--- a/internal/builder/common/container_test.go
+++ b/internal/builder/common/container_test.go
@@ -9,6 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -65,13 +66,246 @@ func TestBuilder_BuildContainer(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:   "livenessProbe exec replaces httpGet",
+			client: fake.NewFakeClient(),
+			opts: ContainerOpts{
+				Base: corev1.Container{
+					Name: "slurmctld",
+					LivenessProbe: &corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Path: "/livez",
+								Port: intstr.FromString("slurmctld"),
+							},
+						},
+						FailureThreshold: 6,
+						PeriodSeconds:    10,
+					},
+				},
+				Merge: corev1.Container{
+					LivenessProbe: &corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							Exec: &corev1.ExecAction{
+								Command: []string{"true"},
+							},
+						},
+					},
+				},
+			},
+			want: corev1.Container{
+				Name: "slurmctld",
+				LivenessProbe: &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						Exec: &corev1.ExecAction{
+							Command: []string{"true"},
+						},
+					},
+					FailureThreshold: 6,
+					PeriodSeconds:    10,
+				},
+			},
+		},
+		{
+			name:   "livenessProbe exec with custom thresholds",
+			client: fake.NewFakeClient(),
+			opts: ContainerOpts{
+				Base: corev1.Container{
+					Name: "slurmctld",
+					LivenessProbe: &corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Path: "/livez",
+								Port: intstr.FromString("slurmctld"),
+							},
+						},
+						FailureThreshold: 6,
+						PeriodSeconds:    10,
+					},
+				},
+				Merge: corev1.Container{
+					LivenessProbe: &corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							Exec: &corev1.ExecAction{
+								Command: []string{"true"},
+							},
+						},
+						FailureThreshold: 3,
+						PeriodSeconds:    5,
+					},
+				},
+			},
+			want: corev1.Container{
+				Name: "slurmctld",
+				LivenessProbe: &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						Exec: &corev1.ExecAction{
+							Command: []string{"true"},
+						},
+					},
+					FailureThreshold: 3,
+					PeriodSeconds:    5,
+				},
+			},
+		},
+		{
+			name:   "livenessProbe exec preserves other probes",
+			client: fake.NewFakeClient(),
+			opts: ContainerOpts{
+				Base: corev1.Container{
+					Name: "slurmctld",
+					StartupProbe: &corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Path: "/livez",
+								Port: intstr.FromString("slurmctld"),
+							},
+						},
+						FailureThreshold: 6,
+						PeriodSeconds:    10,
+					},
+					ReadinessProbe: &corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Path: "/readyz",
+								Port: intstr.FromString("slurmctld"),
+							},
+						},
+					},
+					LivenessProbe: &corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Path: "/livez",
+								Port: intstr.FromString("slurmctld"),
+							},
+						},
+						FailureThreshold: 6,
+						PeriodSeconds:    10,
+					},
+				},
+				Merge: corev1.Container{
+					LivenessProbe: &corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							Exec: &corev1.ExecAction{
+								Command: []string{"true"},
+							},
+						},
+					},
+				},
+			},
+			want: corev1.Container{
+				Name: "slurmctld",
+				StartupProbe: &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path: "/livez",
+							Port: intstr.FromString("slurmctld"),
+						},
+					},
+					FailureThreshold: 6,
+					PeriodSeconds:    10,
+				},
+				ReadinessProbe: &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path: "/readyz",
+							Port: intstr.FromString("slurmctld"),
+						},
+					},
+				},
+				LivenessProbe: &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						Exec: &corev1.ExecAction{
+							Command: []string{"true"},
+						},
+					},
+					FailureThreshold: 6,
+					PeriodSeconds:    10,
+				},
+			},
+		},
+		{
+			name:   "livenessProbe httpGet override preserves handler type",
+			client: fake.NewFakeClient(),
+			opts: ContainerOpts{
+				Base: corev1.Container{
+					Name: "slurmctld",
+					LivenessProbe: &corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Path: "/livez",
+								Port: intstr.FromString("slurmctld"),
+							},
+						},
+						FailureThreshold: 6,
+						PeriodSeconds:    10,
+					},
+				},
+				Merge: corev1.Container{
+					LivenessProbe: &corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Path: "/healthz",
+								Port: intstr.FromString("slurmctld"),
+							},
+						},
+					},
+				},
+			},
+			want: corev1.Container{
+				Name: "slurmctld",
+				LivenessProbe: &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path: "/healthz",
+							Port: intstr.FromString("slurmctld"),
+						},
+					},
+					FailureThreshold: 6,
+					PeriodSeconds:    10,
+				},
+			},
+		},
+		{
+			name:   "no merge probe leaves base untouched",
+			client: fake.NewFakeClient(),
+			opts: ContainerOpts{
+				Base: corev1.Container{
+					Name: "slurmctld",
+					LivenessProbe: &corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Path: "/livez",
+								Port: intstr.FromString("slurmctld"),
+							},
+						},
+						FailureThreshold: 6,
+						PeriodSeconds:    10,
+					},
+				},
+				Merge: corev1.Container{},
+			},
+			want: corev1.Container{
+				Name: "slurmctld",
+				LivenessProbe: &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path: "/livez",
+							Port: intstr.FromString("slurmctld"),
+						},
+					},
+					FailureThreshold: 6,
+					PeriodSeconds:    10,
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			b := New(tt.client)
 			got := b.BuildContainer(tt.opts)
 			if !apiequality.Semantic.DeepEqual(got, tt.want) {
-				t.Errorf("Builder.BuildContainer() = %v", got)
+				t.Errorf("Builder.BuildContainer() = %v, want %v", got, tt.want)
 				return
 			}
 		})


### PR DESCRIPTION
## Summary
ProbeHandler fields (Exec, HTTPGet, TCPSocket, GRPC) are mutually exclusive, but StrategicMergePatch treats them as independent struct fields, causing the base handler to leak through when a different handler type is provided in the merge. Clear the base probe handler before patching so only the intended handler appears in the result.

## Breaking Changes

none

## Testing Notes

helm unittest and local testing

## Additional Context

<!--
Provide any other additional information here.
(e.g. which commits are critical or superfluous; why this implementation)
-->
