### PR TITLE
feat: emit Kubernetes events from all controllers

### DIFF
--- a/internal/controller/accounting/accounting_controller.go
+++ b/internal/controller/accounting/accounting_controller.go
@@ -35,6 +35,12 @@ const (
 	BackoffGCInterval = 1 * time.Minute
 )
 
+// Reasons for Accounting events
+const (
+	SyncSucceededReason = "SyncSucceeded"
+	SyncFailedReason    = "SyncFailed"
+)
+
 func init() {
 	flag.IntVar(&maxConcurrentReconciles, "accounting-workers", maxConcurrentReconciles, "Max concurrent workers for Accounting controller.")
 }
@@ -56,7 +62,7 @@ type AccountingReconciler struct {
 
 	builder       *builder.AccountingBuilder
 	refResolver   *refresolver.RefResolver
-	eventRecorder record.EventRecorderLogger
+	eventRecorder record.EventRecorder
 }
 
 // +kubebuilder:rbac:groups=slinky.slurm.net,resources=accountings,verbs=get;list;watch;create;update;patch;delete
@@ -104,7 +110,7 @@ func (r *AccountingReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 func (r *AccountingReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.builder = builder.New(r.Client)
 	r.refResolver = refresolver.New(r.Client)
-	r.eventRecorder = record.NewBroadcaster().NewRecorder(r.Scheme, corev1.EventSource{Component: ControllerName})
+	r.eventRecorder = mgr.GetEventRecorderFor(ControllerName)
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(ControllerName).
 		For(&slinkyv1beta1.Accounting{}).

--- a/internal/controller/accounting/accounting_sync.go
+++ b/internal/controller/accounting/accounting_sync.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
@@ -91,6 +92,8 @@ func (r *AccountingReconciler) Sync(ctx context.Context, req reconcile.Request) 
 
 	for _, s := range syncSteps {
 		if err := s.Sync(ctx, cluster); err != nil {
+			msg := fmt.Sprintf("Failed to sync %s: %v", s.Name, err)
+			r.eventRecorder.Event(cluster, corev1.EventTypeWarning, SyncFailedReason, msg)
 			e := fmt.Errorf("[%s]: %w", s.Name, err)
 			errors := []error{e}
 			if err := r.syncStatus(ctx, cluster); err != nil {
@@ -101,5 +104,6 @@ func (r *AccountingReconciler) Sync(ctx context.Context, req reconcile.Request) 
 		}
 	}
 
+	r.eventRecorder.Event(cluster, corev1.EventTypeNormal, SyncSucceededReason, "All sync steps completed successfully")
 	return r.syncStatus(ctx, cluster)
 }

--- a/internal/controller/controller/controller_controller.go
+++ b/internal/controller/controller/controller_controller.go
@@ -36,6 +36,12 @@ const (
 	BackoffGCInterval = 1 * time.Minute
 )
 
+// Reasons for Controller events
+const (
+	SyncSucceededReason = "SyncSucceeded"
+	SyncFailedReason    = "SyncFailed"
+)
+
 func init() {
 	flag.IntVar(&maxConcurrentReconciles, "controller-workers", maxConcurrentReconciles, "Max concurrent workers for Controller controller.")
 }
@@ -59,7 +65,7 @@ type ControllerReconciler struct {
 
 	builder       *builder.ControllerBuilder
 	refResolver   *refresolver.RefResolver
-	eventRecorder record.EventRecorderLogger
+	eventRecorder record.EventRecorder
 }
 
 // +kubebuilder:rbac:groups=slinky.slurm.net,resources=controllers,verbs=get;list;watch;create;update;patch;delete
@@ -107,6 +113,7 @@ func (r *ControllerReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ControllerReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	r.eventRecorder = mgr.GetEventRecorderFor(ControllerName)
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(ControllerName).
 		For(&slinkyv1beta1.Controller{}).

--- a/internal/controller/controller/controller_sync.go
+++ b/internal/controller/controller/controller_sync.go
@@ -116,6 +116,8 @@ func (r *ControllerReconciler) Sync(ctx context.Context, req reconcile.Request) 
 
 	for _, s := range syncSteps {
 		if err := s.Sync(ctx, controller); err != nil {
+			msg := fmt.Sprintf("Failed to sync %s: %v", s.Name, err)
+			r.eventRecorder.Event(controller, corev1.EventTypeWarning, SyncFailedReason, msg)
 			e := fmt.Errorf("[%s]: %w", s.Name, err)
 			errors := []error{e}
 			if err := r.syncStatus(ctx, controller); err != nil {
@@ -126,5 +128,6 @@ func (r *ControllerReconciler) Sync(ctx context.Context, req reconcile.Request) 
 		}
 	}
 
+	r.eventRecorder.Event(controller, corev1.EventTypeNormal, SyncSucceededReason, "All sync steps completed successfully")
 	return r.syncStatus(ctx, controller)
 }

--- a/internal/controller/loginset/loginset_controller.go
+++ b/internal/controller/loginset/loginset_controller.go
@@ -35,6 +35,13 @@ const (
 	BackoffGCInterval = 1 * time.Minute
 )
 
+// Reasons for LoginSet events
+const (
+	SyncSucceededReason       = "SyncSucceeded"
+	SyncFailedReason          = "SyncFailed"
+	ControllerRefFailedReason = "ControllerRefFailed"
+)
+
 func init() {
 	flag.IntVar(&maxConcurrentReconciles, "loginset-workers", maxConcurrentReconciles, "Max concurrent workers for LoginSet controller.")
 }
@@ -56,7 +63,7 @@ type LoginSetReconciler struct {
 
 	builder       *builder.LoginBuilder
 	refResolver   *refresolver.RefResolver
-	eventRecorder record.EventRecorderLogger
+	eventRecorder record.EventRecorder
 }
 
 // +kubebuilder:rbac:groups=slinky.slurm.net,resources=loginsets,verbs=get;list;watch;create;update;patch;delete
@@ -102,6 +109,7 @@ func (r *LoginSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *LoginSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	r.eventRecorder = mgr.GetEventRecorderFor(ControllerName)
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(ControllerName).
 		For(&slinkyv1beta1.LoginSet{}).

--- a/internal/controller/loginset/loginset_sync.go
+++ b/internal/controller/loginset/loginset_sync.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
@@ -42,6 +43,8 @@ func (r *LoginSetReconciler) Sync(ctx context.Context, req reconcile.Request) er
 	controller := &slinkyv1beta1.Controller{}
 	controllerKey := client.ObjectKey(loginset.Spec.ControllerRef.NamespacedName())
 	if err := r.Get(ctx, controllerKey, controller); err != nil {
+		msg := fmt.Sprintf("Failed to get Controller (%s): %v", controllerKey, err)
+		r.eventRecorder.Event(loginset, corev1.EventTypeWarning, ControllerRefFailedReason, msg)
 		return fmt.Errorf("failed to get controller (%s): %w", controllerKey, err)
 	}
 
@@ -102,6 +105,8 @@ func (r *LoginSetReconciler) Sync(ctx context.Context, req reconcile.Request) er
 
 	for _, s := range syncSteps {
 		if err := s.Sync(ctx, loginset); err != nil {
+			msg := fmt.Sprintf("Failed to sync %s: %v", s.Name, err)
+			r.eventRecorder.Event(loginset, corev1.EventTypeWarning, SyncFailedReason, msg)
 			e := fmt.Errorf("[%s]: %w", s.Name, err)
 			errors := []error{e}
 			if err := r.syncStatus(ctx, loginset); err != nil {
@@ -112,5 +117,6 @@ func (r *LoginSetReconciler) Sync(ctx context.Context, req reconcile.Request) er
 		}
 	}
 
+	r.eventRecorder.Event(loginset, corev1.EventTypeNormal, SyncSucceededReason, "All sync steps completed successfully")
 	return r.syncStatus(ctx, loginset)
 }

--- a/internal/controller/nodeset/nodeset_controller.go
+++ b/internal/controller/nodeset/nodeset_controller.go
@@ -48,6 +48,20 @@ const (
 	FailedPlacementReason = "FailedPlacement"
 	// FailedNodeSetPodReason is added to an event when the status of a Pod of a NodeSet is 'Failed'.
 	FailedNodeSetPodReason = "FailedNodeSetPod"
+	// ScalingUpReason is added to an event when pods are being created to reach the desired replica count.
+	ScalingUpReason = "ScalingUp"
+	// ScalingDownReason is added to an event when pods are being deleted to reach the desired replica count.
+	ScalingDownReason = "ScalingDown"
+	// SyncFailedReason is added to an event when a sync sub-step fails.
+	SyncFailedReason = "SyncFailed"
+	// NodeCordonReason is added to an event when a pod is cordoned due to its Kubernetes node being cordoned.
+	NodeCordonReason = "NodeCordon"
+	// SlurmNodeNotRegisteredReason is added to an event when a pod is deleted because its Slurm node is not registered.
+	SlurmNodeNotRegisteredReason = "SlurmNodeNotRegistered"
+	// RollingUpdateReason is added to an event when pods are being replaced during a rolling update.
+	RollingUpdateReason = "RollingUpdate"
+	// ControllerRefFailedReason is added to an event when the referenced Controller CR cannot be fetched.
+	ControllerRefFailedReason = "ControllerRefFailed"
 )
 
 func init() {
@@ -76,7 +90,7 @@ type NodeSetReconciler struct {
 	podControl     podcontrol.PodControlInterface
 	slurmControl   slurmcontrol.SlurmControlInterface
 	historyControl historycontrol.HistoryControlInterface
-	eventRecorder  record.EventRecorderLogger
+	eventRecorder  record.EventRecorder
 	expectations   *kubecontroller.UIDTrackingControllerExpectations
 }
 
@@ -131,7 +145,7 @@ func (r *NodeSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *NodeSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	r.eventRecorder = record.NewBroadcaster().NewRecorder(r.Scheme, corev1.EventSource{Component: ControllerName})
+	r.eventRecorder = mgr.GetEventRecorderFor(ControllerName)
 	r.builder = builder.New(r.Client)
 	r.refResolver = refresolver.New(r.Client)
 	r.historyControl = historycontrol.NewHistoryControl(r.Client)

--- a/internal/controller/nodeset/nodeset_sync.go
+++ b/internal/controller/nodeset/nodeset_sync.go
@@ -238,42 +238,52 @@ func (r *NodeSetReconciler) sync(
 	hash string,
 ) error {
 	if err := r.slurmControl.RefreshNodeCache(ctx, nodeset); err != nil {
+		r.eventRecorder.Eventf(nodeset, corev1.EventTypeWarning, SyncFailedReason, "Failed to refresh Slurm node cache: %v", err)
 		return err
 	}
 
 	if err := r.syncClusterWorkerService(ctx, nodeset); err != nil {
+		r.eventRecorder.Eventf(nodeset, corev1.EventTypeWarning, SyncFailedReason, "Failed to sync cluster worker service: %v", err)
 		return err
 	}
 
 	if err := r.syncClusterWorkerPDB(ctx, nodeset); err != nil {
+		r.eventRecorder.Eventf(nodeset, corev1.EventTypeWarning, SyncFailedReason, "Failed to sync PodDisruptionBudget: %v", err)
 		return err
 	}
 
 	if err := r.syncSshConfig(ctx, nodeset); err != nil {
+		r.eventRecorder.Eventf(nodeset, corev1.EventTypeWarning, SyncFailedReason, "Failed to sync SSH config: %v", err)
 		return err
 	}
 
 	if err := r.syncSlurmNodes(ctx, nodeset, pods); err != nil {
+		r.eventRecorder.Eventf(nodeset, corev1.EventTypeWarning, SyncFailedReason, "Failed to sync Slurm nodes: %v", err)
 		return err
 	}
 
 	if err := r.syncSlurmDeadline(ctx, nodeset, pods); err != nil {
+		r.eventRecorder.Eventf(nodeset, corev1.EventTypeWarning, SyncFailedReason, "Failed to sync Slurm deadline: %v", err)
 		return err
 	}
 
 	if err := r.syncSlurmTopology(ctx, nodeset, pods); err != nil {
+		r.eventRecorder.Eventf(nodeset, corev1.EventTypeWarning, SyncFailedReason, "Failed to sync Slurm topology: %v", err)
 		return err
 	}
 
 	if err := r.syncCordon(ctx, nodeset, pods); err != nil {
+		r.eventRecorder.Eventf(nodeset, corev1.EventTypeWarning, SyncFailedReason, "Failed to sync cordon state: %v", err)
 		return err
 	}
 
 	if err := r.syncTaint(ctx); err != nil {
+		r.eventRecorder.Eventf(nodeset, corev1.EventTypeWarning, SyncFailedReason, "Failed to sync node taints: %v", err)
 		return err
 	}
 
 	if err := r.syncNodeSet(ctx, nodeset, pods, hash); err != nil {
+		r.eventRecorder.Eventf(nodeset, corev1.EventTypeWarning, SyncFailedReason, "Failed to sync NodeSet pods: %v", err)
 		return err
 	}
 
@@ -367,6 +377,9 @@ func (r *NodeSetReconciler) syncCordon(
 					"reason", value)
 				reason = value
 			}
+
+			r.eventRecorder.Eventf(nodeset, corev1.EventTypeNormal, NodeCordonReason,
+				"Cordoning Pod %s: Kubernetes node %s was cordoned", klog.KObj(pod), name)
 
 			if err := r.makePodCordonAndDrain(ctx, nodeset, pod, reason); err != nil {
 				return err
@@ -500,6 +513,8 @@ func (r *NodeSetReconciler) syncSlurmNodes(
 		}
 		logger.Info("Deleting NodeSet pod, Slurm node is not registered but pod is healthy",
 			"pod", klog.KObj(pod))
+		r.eventRecorder.Eventf(nodeset, corev1.EventTypeWarning, SlurmNodeNotRegisteredReason,
+			"Deleting Pod %s: Slurm node is not registered but pod is healthy", klog.KObj(pod))
 		if err := r.Delete(ctx, pod); err != nil {
 			if !apierrors.IsNotFound(err) {
 				return err
@@ -821,6 +836,14 @@ func (r *NodeSetReconciler) syncNodeSet(
 			podsToCreate[i] = pod
 		}
 		if len(podsToDelete) > 0 || len(podsToCreate) > 0 {
+			if len(podsToCreate) > 0 {
+				r.eventRecorder.Eventf(nodeset, corev1.EventTypeNormal, ScalingUpReason,
+					"Scaling up: creating %d daemon pod(s)", len(podsToCreate))
+			}
+			if len(podsToDelete) > 0 {
+				r.eventRecorder.Eventf(nodeset, corev1.EventTypeNormal, ScalingDownReason,
+					"Scaling down: deleting %d daemon pod(s)", len(podsToDelete))
+			}
 			return r.doPodScale(ctx, nodeset, podsNewScaling, podsToDelete, podsToCreate)
 		}
 	} else {
@@ -851,10 +874,14 @@ func (r *NodeSetReconciler) syncNodeSet(
 				podsToCreate[i] = pod
 			}
 			logger.V(2).Info("Too few NodeSet pods", "need", replicaCount, "creating", diff)
+			r.eventRecorder.Eventf(nodeset, corev1.EventTypeNormal, ScalingUpReason,
+				"Scaling up: creating %d pod(s) to reach %d replicas", diff, replicaCount)
 			return r.doPodScale(ctx, nodeset, podsNewScaling, nil, podsToCreate)
 		}
 		if diff > 0 {
 			logger.V(2).Info("Too many NodeSet pods", "need", replicaCount, "deleting", diff)
+			r.eventRecorder.Eventf(nodeset, corev1.EventTypeNormal, ScalingDownReason,
+				"Scaling down: deleting %d pod(s) to reach %d replicas", diff, replicaCount)
 			podsToDelete, podsToKeep := nodesetutils.SplitActivePods(podsNewScaling, diff)
 			return r.doPodScale(ctx, nodeset, podsToKeep, podsToDelete, nil)
 		}
@@ -988,6 +1015,8 @@ func (r *NodeSetReconciler) newNodeSetPodDaemon(
 	controller := &slinkyv1beta1.Controller{}
 	key := nodeset.Spec.ControllerRef.NamespacedName()
 	if err := r.Get(ctx, key, controller); err != nil {
+		r.eventRecorder.Eventf(nodeset, corev1.EventTypeWarning, ControllerRefFailedReason,
+			"Failed to get Controller (%s): %v", key, err)
 		return nil, err
 	}
 	if nodeName == "" {
@@ -1008,6 +1037,8 @@ func (r *NodeSetReconciler) newNodeSetPodOrdinal(
 	controller := &slinkyv1beta1.Controller{}
 	key := nodeset.Spec.ControllerRef.NamespacedName()
 	if err := r.Get(ctx, key, controller); err != nil {
+		r.eventRecorder.Eventf(nodeset, corev1.EventTypeWarning, ControllerRefFailedReason,
+			"Failed to get Controller (%s): %v", key, err)
 		return nil, err
 	}
 
@@ -1366,6 +1397,8 @@ func (r *NodeSetReconciler) syncRollingUpdate(
 	if len(unhealthyPods) > 0 {
 		logger.Info("Delete unhealthy pods for Rolling Update",
 			"unhealthyPods", len(unhealthyPods))
+		r.eventRecorder.Eventf(nodeset, corev1.EventTypeNormal, RollingUpdateReason,
+			"Rolling update: deleting %d unhealthy old pod(s)", len(unhealthyPods))
 		if err := r.doPodScale(ctx, nodeset, nil, unhealthyPods, nil); err != nil {
 			return err
 		}
@@ -1375,6 +1408,8 @@ func (r *NodeSetReconciler) syncRollingUpdate(
 	if len(podsToDelete) > 0 {
 		logger.Info("Scale-in pods for Rolling Update",
 			"delete", len(podsToDelete))
+		r.eventRecorder.Eventf(nodeset, corev1.EventTypeNormal, RollingUpdateReason,
+			"Rolling update: replacing %d old pod(s) with updated revision", len(podsToDelete))
 		if err := r.doPodScale(ctx, nodeset, nil, podsToDelete, nil); err != nil {
 			return err
 		}

--- a/internal/controller/restapi/restapi_controller.go
+++ b/internal/controller/restapi/restapi_controller.go
@@ -35,6 +35,12 @@ const (
 	BackoffGCInterval = 1 * time.Minute
 )
 
+// Reasons for RestAPI events
+const (
+	SyncSucceededReason = "SyncSucceeded"
+	SyncFailedReason    = "SyncFailed"
+)
+
 func init() {
 	flag.IntVar(&maxConcurrentReconciles, "restapi-workers", maxConcurrentReconciles, "Max concurrent workers for Restapi controller.")
 }
@@ -56,7 +62,7 @@ type RestapiReconciler struct {
 
 	builder       *builder.RestapiBuilder
 	refResolver   *refresolver.RefResolver
-	eventRecorder record.EventRecorderLogger
+	eventRecorder record.EventRecorder
 }
 
 // +kubebuilder:rbac:groups=slinky.slurm.net,resources=restapis,verbs=get;list;watch;create;update;patch;delete
@@ -102,6 +108,7 @@ func (r *RestapiReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *RestapiReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	r.eventRecorder = mgr.GetEventRecorderFor(ControllerName)
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(ControllerName).
 		For(&slinkyv1beta1.RestApi{}).

--- a/internal/controller/restapi/restapi_sync.go
+++ b/internal/controller/restapi/restapi_sync.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
@@ -69,6 +70,8 @@ func (r *RestapiReconciler) Sync(ctx context.Context, req reconcile.Request) err
 
 	for _, s := range syncSteps {
 		if err := s.Sync(ctx, restapi); err != nil {
+			msg := fmt.Sprintf("Failed to sync %s: %v", s.Name, err)
+			r.eventRecorder.Event(restapi, corev1.EventTypeWarning, SyncFailedReason, msg)
 			e := fmt.Errorf("[%s]: %w", s.Name, err)
 			errors := []error{e}
 			if err := r.syncStatus(ctx, restapi); err != nil {
@@ -79,5 +82,6 @@ func (r *RestapiReconciler) Sync(ctx context.Context, req reconcile.Request) err
 		}
 	}
 
+	r.eventRecorder.Event(restapi, corev1.EventTypeNormal, SyncSucceededReason, "All sync steps completed successfully")
 	return r.syncStatus(ctx, restapi)
 }

--- a/internal/utils/podcontrol/podcontrol.go
+++ b/internal/utils/podcontrol/podcontrol.go
@@ -74,7 +74,6 @@ func (r realPodControl) createPods(ctx context.Context, pod *corev1.Pod, object 
 		return nil
 	}
 	logger.V(4).Info("Controller created pod", "controller", accessor.GetName(), "pod", klog.KObj(pod))
-	r.recorder.Eventf(object, corev1.EventTypeNormal, kubecontroller.SuccessfulCreatePodReason, "Created pod: %v", pod.GetName())
 
 	return nil
 }
@@ -109,7 +108,6 @@ func (r *realPodControl) DeletePod(ctx context.Context, namespace string, podNam
 		r.recorder.Eventf(object, corev1.EventTypeWarning, kubecontroller.FailedDeletePodReason, "Error deleting: %v", err)
 		return fmt.Errorf("unable to delete pods: %w", err)
 	}
-	r.recorder.Eventf(object, corev1.EventTypeNormal, kubecontroller.SuccessfulDeletePodReason, "Deleted pod: %v", podName)
 
 	return nil
 }


### PR DESCRIPTION
## Summary
- Add event recording to controllers that had an `eventRecorder` field but never used it: **Controller**, **RestAPI**, **Accounting**, and **LoginSet**
- Enhance existing **NodeSet** events with scaling, sync failure, cordon, rolling update, and controller-ref error events
- Wire all event recorders to the manager via `mgr.GetEventRecorderFor()` so events are actually delivered to the Kubernetes API, replacing standalone `record.NewBroadcaster()` instances that were not connected to any sink

### Background

All five reconciler controllers defined an `eventRecorder` field initialized with a standalone `record.NewBroadcaster()`. However, this broadcaster was never started with `StartRecordingToSink()`, so events were silently dropped and never reached the Kubernetes API.

The fix replaces the disconnected broadcaster with the manager's properly-wired recorder

### Events added

| Controller | Reason | Type | When |
|---|---|---|---|
| Controller | `SyncSucceeded` | Normal | All sync steps completed |
| Controller | `SyncFailed` | Warning | A sync step failed |
| RestAPI | `SyncSucceeded` | Normal | All sync steps completed |
| RestAPI | `SyncFailed` | Warning | A sync step failed |
| Accounting | `SyncSucceeded` | Normal | All sync steps completed |
| Accounting | `SyncFailed` | Warning | A sync step failed |
| LoginSet | `SyncSucceeded` | Normal | All sync steps completed |
| LoginSet | `SyncFailed` | Warning | A sync step failed |
| LoginSet | `ControllerRefFailed` | Warning | Controller CR not found |
| NodeSet | `ScalingUp` | Normal | Creating pods to reach desired count |
| NodeSet | `ScalingDown` | Normal | Deleting pods to reach desired count |
| NodeSet | `SyncFailed` | Warning | A sync sub-step failed |
| NodeSet | `NodeCordon` | Normal | Pod cordoned due to K8s node cordon |
| NodeSet | `SlurmNodeNotRegistered` | Warning | Pod deleted — Slurm node unregistered |
| NodeSet | `RollingUpdate` | Normal | Pods being replaced for update |
| NodeSet | `ControllerRefFailed` | Warning | Controller CR not found |

## Breaking Changes

none

## Testing Notes

```
~ kubectl  get nodesets -n slurm slurm-worker-slinky
NAME                  DESIRED   REPLICAS   UPDATED   READY   AGE
slurm-worker-slinky   5         5          5         5       4m40s

~ kubectl describe nodesets -n slurm slurm-worker-slinky
Name:         slurm-worker-slinky
Namespace:    slurm
....
Events:
  Type     Reason            Age                    From                Message
  ----     ------            ----                   ----                -------
  Warning  SyncFailed        2m13s (x8 over 2m34s)  nodeset-controller  Failed to refresh Slurm node cache: Get "http://slurm-restapi.slurm:6820/slurm/v0.0.44/nodes/": dial tcp 10.96.70.4:6820: connect: connection refused
  Normal   ScalingUp         85s                    nodeset-controller  Scaling up: creating 5 daemon pod(s)
  Normal   SuccessfulCreate  85s                    nodeset-controller  create Pod slurm-worker-slinky-l88nm in NodeSet slurm-worker-slinky successful
  Normal   SuccessfulCreate  85s                    nodeset-controller  create Pod slurm-worker-slinky-wzdn2 in NodeSet slurm-worker-slinky successful
  Normal   SuccessfulCreate  85s                    nodeset-controller  create Pod slurm-worker-slinky-rp4qv in NodeSet slurm-worker-slinky successful
  Normal   SuccessfulCreate  85s                    nodeset-controller  create Pod slurm-worker-slinky-279cd in NodeSet slurm-worker-slinky successful
  Normal   SuccessfulCreate  85s                    nodeset-controller  create Pod slurm-worker-slinky-6fnjn in NodeSet slurm-worker-slinky successful
  Normal   SuccessfulUpdate  83s                    nodeset-controller  update Pod slurm-worker-slinky-wzdn2 in NodeSet slurm-worker-slinky successful
  Normal   SuccessfulUpdate  83s                    nodeset-controller  update Pod slurm-worker-slinky-6fnjn in NodeSet slurm-worker-slinky successful
  Normal   SuccessfulUpdate  83s                    nodeset-controller  update Pod slurm-worker-slinky-279cd in NodeSet slurm-worker-slinky successful
  Normal   SuccessfulUpdate  83s                    nodeset-controller  update Pod slurm-worker-slinky-rp4qv in NodeSet slurm-worker-slinky successful
  Normal   SuccessfulUpdate  83s                    nodeset-controller  update Pod slurm-worker-slinky-l88nm in NodeSet slurm-worker-slinky successful
  Normal   NodeCordon        17s (x3 over 23s)      nodeset-controller  Cordoning Pod slurm/slurm-worker-slinky-279cd: Kubernetes node kind-worker2 was cordoned
```

## Additional Context

<!--
Provide any other additional information here.
(e.g. which commits are critical or superfluous; why this implementation)
-->
