### PR TITLE
fix(nodeset): use bare node name as DaemonSet pod hostname

### DIFF
--- a/internal/controller/nodeset/utils/utils.go
+++ b/internal/controller/nodeset/utils/utils.go
@@ -67,7 +67,7 @@ func NewNodeSetDaemonSetPod(
 	pod, _ := k8scontroller.GetPodFromTemplate(&podTemplate, nodeset, controllerRef)
 
 	// Ensure the hostname is RFC 1178 compliant
-	safeHostname := getDaemonSetPodHostname(nodeset, nodeName)
+	safeHostname := getDaemonSetPodHostname(nodeName)
 	pod.Spec.Hostname = safeHostname
 	if pod.Labels == nil {
 		pod.Labels = make(map[string]string)
@@ -95,17 +95,12 @@ func NewNodeSetDaemonSetPod(
 	return pod
 }
 
-func getDaemonSetPodHostname(nodeset *slinkyv1beta1.NodeSet, nodeName string) string {
+func getDaemonSetPodHostname(nodeName string) string {
 	name := nodeName
 	if before, _, ok := strings.Cut(nodeName, "."); ok {
 		name = before
 	}
-	name = strings.TrimSuffix(name, "-")
-	if nodeset.Spec.Template.PodSpecWrapper.Hostname != "" {
-		prefix := strings.TrimSuffix(nodeset.Spec.Template.PodSpecWrapper.Hostname, "-")
-		return fmt.Sprintf("%s-%s", prefix, name)
-	}
-	return fmt.Sprintf("%s-%s", nodeset.Name, name)
+	return strings.TrimSuffix(name, "-")
 }
 
 func initIdentity(nodeset *slinkyv1beta1.NodeSet, pod *corev1.Pod) {

--- a/internal/controller/nodeset/utils/utils_test.go
+++ b/internal/controller/nodeset/utils/utils_test.go
@@ -497,7 +497,7 @@ func TestNewNodeSetDaemonSetPod(t *testing.T) {
 				t.Fatal("NewNodeSetDaemonSetPod() returned nil")
 			}
 			if tt.checkIdentity {
-				wantHostname := getDaemonSetPodHostname(nodeset, tt.args.nodeName)
+				wantHostname := getDaemonSetPodHostname(tt.args.nodeName)
 				if pod.GenerateName != nodeset.Name+"-" {
 					t.Errorf("GenerateName = %q, want %q", pod.GenerateName, nodeset.Name+"-")
 				}
@@ -551,80 +551,53 @@ func TestNewNodeSetDaemonSetPod(t *testing.T) {
 func TestGetDaemonSetPodHostname(t *testing.T) {
 	tests := []struct {
 		name     string
-		nodeset  *slinkyv1beta1.NodeSet
 		nodeName string
 		want     string
 	}{
 		{
-			name:     "Nodeset name and node name combined",
-			nodeset:  newNodeSetDaemonset("foo", ""),
+			name:     "Simple node name",
 			nodeName: "node-1",
-			want:     "foo-node-1",
+			want:     "node-1",
 		},
 		{
 			name:     "Trailing dash on node name is trimmed",
-			nodeset:  newNodeSetDaemonset("foo", ""),
 			nodeName: "node-1-",
-			want:     "foo-node-1",
+			want:     "node-1",
 		},
 		{
 			name:     "Empty node name",
-			nodeset:  newNodeSetDaemonset("foo", ""),
 			nodeName: "",
-			want:     "foo-",
+			want:     "",
 		},
 		{
-			name:     "Different nodeset name",
-			nodeset:  newNodeSetDaemonset("my-nodeset", ""),
-			nodeName: "worker-0",
-			want:     "my-nodeset-worker-0",
-		},
-		{
-			name:     "Node name with multiple trailing dashes",
-			nodeset:  newNodeSetDaemonset("foo", ""),
+			name:     "Node name with multiple trailing dashes trimmed once",
 			nodeName: "node-1---",
-			want:     "foo-node-1--",
+			want:     "node-1--",
 		},
 		{
 			name:     "Single character node name",
-			nodeset:  newNodeSetDaemonset("ns", ""),
 			nodeName: "a",
-			want:     "ns-a",
+			want:     "a",
 		},
 		{
 			name:     "AWS-style FQDN node name uses first label only",
-			nodeset:  newNodeSetDaemonset("foo", ""),
 			nodeName: "node1.us-west-2.compute.internal",
-			want:     "foo-node1",
+			want:     "node1",
 		},
 		{
 			name:     "GCP-style internal DNS node name uses first label only",
-			nodeset:  newNodeSetDaemonset("worker", ""),
 			nodeName: "node-2.my-project.us-central1-a.c.gcp-project.internal",
-			want:     "worker-node-2",
+			want:     "node-2",
 		},
 		{
 			name:     "Azure-style node name uses first label only, trailing dash trimmed",
-			nodeset:  newNodeSetDaemonset("slurm", ""),
 			nodeName: "node-0.abc123.region.azure.internal-",
-			want:     "slurm-node-0",
-		},
-		{
-			name:     "Custom template hostname prefix is used without separator",
-			nodeset:  newNodeSetDaemonset("foo", "slurm-"),
-			nodeName: "node-1",
-			want:     "slurm-node-1",
-		},
-		{
-			name:     "Custom template hostname with FQDN node name uses first label",
-			nodeset:  newNodeSetDaemonset("foo", "worker-"),
-			nodeName: "node-2.my-project.us-central1-a.c.gcp-project.internal",
-			want:     "worker-node-2",
+			want:     "node-0",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := getDaemonSetPodHostname(tt.nodeset, tt.nodeName); got != tt.want {
+			if got := getDaemonSetPodHostname(tt.nodeName); got != tt.want {
 				t.Errorf("getDaemonSetPodHostname() = %q, want %q", got, tt.want)
 			}
 		})


### PR DESCRIPTION

## Summary
- DaemonSet-mode NodeSet pods now use the Kubernetes node name directly as the pod hostname instead of prepending a prefix.
- This avoids duplicated names (e.g. `cpu-cpu-zzzz-xxxx`) when the node name is `cpu-zzzz-xxxx`.


## Breaking Changes

none

## Testing Notes

- [x] Updated `TestGetDaemonSetPodHostname` expectations for no-prefix cases
- [x] Verified custom hostname prefix tests still pass unchanged
- [x] Deploy a DaemonSet-mode NodeSet and confirm pods use bare node names as hostnames

## Additional Context

<!--
Provide any other additional information here.
(e.g. which commits are critical or superfluous; why this implementation)
-->
