### PR TITLE
fix: jwt annotation

### DIFF
--- a/internal/builder/common/const.go
+++ b/internal/builder/common/const.go
@@ -80,7 +80,7 @@ const (
 
 const (
 	AnnotationAuthSlurmKeyHash = slinkyv1beta1.SlinkyPrefix + "slurm-key-hash"
-	AnnotationAuthJwtKeyHash   = slinkyv1beta1.SlinkyPrefix + "jwt--key-hash"
+	AnnotationAuthJwtKeyHash   = slinkyv1beta1.SlinkyPrefix + "jwt-key-hash"
 )
 
 const (


### PR DESCRIPTION
## Summary

Fix typo in AnnotationAuthJwtKeyHash (`jwt--key-hash` -> `jwt-key-hash`) introduced in https://github.com/SlinkyProject/slurm-operator/commit/1ab485cbbd2d99b8be9d9a4c3e4081cffd1a41e7

## Breaking Changes

none

## Testing Notes

local kind and unittest

## Additional Context

<!--
Provide any other additional information here.
(e.g. which commits are critical or superfluous; why this implementation)
-->
