### PR TITLE
fix: correct sssd-conf-hash computation and reconcile on SSSD secret changes for LoginSet

### DIFF
--- a/internal/builder/loginbuilder/login_app.go
+++ b/internal/builder/loginbuilder/login_app.go
@@ -338,7 +338,7 @@ func (b *LoginBuilder) getLoginHashes(ctx context.Context, loginset *slinkyv1bet
 	hashMap := map[string]string{
 		common.AnnotationSshHostKeysHash: crypto.CheckSumFromMap(SshHostKeys.Data),
 		common.AnnotationSshdConfHash:    crypto.CheckSum([]byte(SshConfig.Data[SshdConfigFile])),
-		common.AnnotationSssdConfHash:    crypto.CheckSum([]byte(SssdSecret.StringData[loginset.SssdSecretRef().Key])),
+		common.AnnotationSssdConfHash:    crypto.CheckSum(SssdSecret.Data[loginset.SssdSecretRef().Key]),
 	}
 
 	return hashMap, nil

--- a/internal/controller/loginset/eventhandler/eventhandler_secret.go
+++ b/internal/controller/loginset/eventhandler/eventhandler_secret.go
@@ -78,6 +78,8 @@ func (e *SecretEventHandler) enqueueRequest(
 	}
 	secretKey := client.ObjectKeyFromObject(secret)
 
+	enqueued := make(map[string]bool)
+
 	controllerList := &slinkyv1beta1.ControllerList{}
 	if err := e.List(ctx, controllerList); err != nil {
 		logger.Error(err, "failed to list controller CRs")
@@ -100,7 +102,23 @@ func (e *SecretEventHandler) enqueueRequest(
 			key := client.ObjectKeyFromObject(&controller)
 			if loginset.Spec.ControllerRef.IsMatch(key) {
 				objectutils.EnqueueRequest(q, &loginset)
+				enqueued[loginset.Key().String()] = true
 			}
 		}
+	}
+
+	loginsetList := &slinkyv1beta1.LoginSetList{}
+	if err := e.List(ctx, loginsetList); err != nil {
+		logger.Error(err, "failed to list LoginSet CRs")
+		return
+	}
+	for _, loginset := range loginsetList.Items {
+		if secretKey.String() != loginset.SssdSecretKey().String() {
+			continue
+		}
+		if enqueued[loginset.Key().String()] {
+			continue
+		}
+		objectutils.EnqueueRequest(q, &loginset)
 	}
 }

--- a/internal/controller/loginset/eventhandler/eventhandler_secret_test.go
+++ b/internal/controller/loginset/eventhandler/eventhandler_secret_test.go
@@ -80,6 +80,26 @@ func Test_SecretEventHandler_Create(t *testing.T) {
 			},
 			want: 1,
 		},
+		{
+			name: "SSSD conf secret",
+			fields: fields{
+				Reader: fake.NewFakeClient(
+					slurmKeySecret,
+					jwtKeySecret,
+					sssdConfSecret,
+					controller,
+					loginset,
+				),
+			},
+			args: args{
+				ctx: context.TODO(),
+				evt: event.CreateEvent{
+					Object: sssdConfSecret,
+				},
+				q: newQueue(),
+			},
+			want: 1,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -150,6 +170,26 @@ func Test_SecretEventHandler_Delete(t *testing.T) {
 				ctx: context.TODO(),
 				evt: event.DeleteEvent{
 					Object: jwtKeySecret,
+				},
+				q: newQueue(),
+			},
+			want: 1,
+		},
+		{
+			name: "SSSD conf secret",
+			fields: fields{
+				Reader: fake.NewFakeClient(
+					slurmKeySecret,
+					jwtKeySecret,
+					sssdConfSecret,
+					controller,
+					loginset,
+				),
+			},
+			args: args{
+				ctx: context.TODO(),
+				evt: event.DeleteEvent{
+					Object: sssdConfSecret,
 				},
 				q: newQueue(),
 			},
@@ -266,6 +306,27 @@ func Test_SecretEventHandler_Update(t *testing.T) {
 				evt: event.UpdateEvent{
 					ObjectOld: jwtKeySecret,
 					ObjectNew: jwtKeySecret,
+				},
+				q: newQueue(),
+			},
+			want: 1,
+		},
+		{
+			name: "SSSD conf secret",
+			fields: fields{
+				Reader: fake.NewFakeClient(
+					slurmKeySecret,
+					jwtKeySecret,
+					sssdConfSecret,
+					controller,
+					loginset,
+				),
+			},
+			args: args{
+				ctx: context.TODO(),
+				evt: event.UpdateEvent{
+					ObjectOld: sssdConfSecret,
+					ObjectNew: sssdConfSecret,
 				},
 				q: newQueue(),
 			},


### PR DESCRIPTION
## Summary

- Fix SSSD hash computation in LoginSet builder using `Secret.Data` instead of `Secret.StringData` (`StringData` is write-only and always empty when read back from the API)
- Add SSSD secret watch to LoginSet `SecretEventHandler` so reconciliation is triggered when the referenced SSSD secret is created, updated, or deleted
- Add unit tests for the new SSSD secret event handling

## Breaking Changes

none

## Testing Notes

- [x] `go test ./internal/controller/loginset/eventhandler/...` — SSSD secret Create/Update/Delete events enqueue the LoginSet
- [x] `go build ./...` — full project compiles cleanly

## Additional Context

<!--
Provide any other additional information here.
(e.g. which commits are critical or superfluous; why this implementation)
-->
