### PR TITLE
feat(helm): add extraObjects to deploy extra Kubernetes manifests

### DIFF
--- a/helm/slurm-operator/templates/extra.yaml
+++ b/helm/slurm-operator/templates/extra.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{- end }}

--- a/helm/slurm-operator/tests/extra_test.yaml
+++ b/helm/slurm-operator/tests/extra_test.yaml
@@ -1,0 +1,116 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: test extra manifests
+templates:
+  - extra.yaml
+release:
+  name: test-release
+  namespace: test-namespace
+tests:
+  - it: should not render anything when extraManifests is empty
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should render a single extra manifest
+    set:
+      extraObjects:
+        - apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: my-extra-config
+          data:
+            key: value
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: apiVersion
+          value: v1
+      - equal:
+          path: kind
+          value: ConfigMap
+      - equal:
+          path: metadata.name
+          value: my-extra-config
+      - equal:
+          path: data.key
+          value: value
+  - it: should render multiple extra manifests
+    set:
+      extraObjects:
+        - apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: config-one
+          data:
+            foo: bar
+        - apiVersion: v1
+          kind: Secret
+          metadata:
+            name: secret-one
+          stringData:
+            password: s3cr3t
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: kind
+          value: ConfigMap
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: config-one
+        documentIndex: 0
+      - equal:
+          path: kind
+          value: Secret
+        documentIndex: 1
+      - equal:
+          path: metadata.name
+          value: secret-one
+        documentIndex: 1
+  - it: should support Helm templating in extra manifests
+    set:
+      extraObjects:
+        - apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: "{{ .Release.Name }}-dynamic"
+            namespace: "{{ .Release.Namespace }}"
+          data:
+            release: "{{ .Release.Name }}"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: test-release-dynamic
+      - equal:
+          path: metadata.namespace
+          value: test-namespace
+      - equal:
+          path: data.release
+          value: test-release
+  - it: should render non-namespaced resources
+    set:
+      extraObjects:
+        - apiVersion: rbac.authorization.k8s.io/v1
+          kind: ClusterRole
+          metadata:
+            name: extra-cluster-role
+          rules:
+            - apiGroups: [""]
+              resources: ["pods"]
+              verbs: ["get", "list"]
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: kind
+          value: ClusterRole
+      - equal:
+          path: metadata.name
+          value: extra-cluster-role
+      - equal:
+          path: rules[0].resources[0]
+          value: pods

--- a/helm/slurm-operator/values.yaml
+++ b/helm/slurm-operator/values.yaml
@@ -148,6 +148,23 @@ webhook:
   # -- Enable leader election for slurm-operator-webhook
   leaderElection: true
 
+# -- Extra Kubernetes objects to deploy alongside the chart.
+# Each entry is rendered as a standalone Kubernetes object.
+# Supports Helm templating (e.g. {{ .Release.Namespace }}).
+extraObjects: []
+  # - apiVersion: v1
+  #   kind: ConfigMap
+  #   metadata:
+  #     name: extra-config
+  #   data:
+  #     key: value
+  # - apiVersion: v1
+  #   kind: Secret
+  #   metadata:
+  #     name: extra-secret
+  #   stringData:
+  #     password: "s3cr3t"
+
 #
 # Cert-Manager certificate configurations.
 certManager:

--- a/helm/slurm/templates/extra.yaml
+++ b/helm/slurm/templates/extra.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{- end }}

--- a/helm/slurm/tests/extra_test.yaml
+++ b/helm/slurm/tests/extra_test.yaml
@@ -1,0 +1,116 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: test extra manifests
+templates:
+  - extra.yaml
+release:
+  name: test-release
+  namespace: test-namespace
+tests:
+  - it: should not render anything when extraManifests is empty
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should render a single extra manifest
+    set:
+      extraObjects:
+        - apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: my-extra-config
+          data:
+            key: value
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: apiVersion
+          value: v1
+      - equal:
+          path: kind
+          value: ConfigMap
+      - equal:
+          path: metadata.name
+          value: my-extra-config
+      - equal:
+          path: data.key
+          value: value
+  - it: should render multiple extra manifests
+    set:
+      extraObjects:
+        - apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: config-one
+          data:
+            foo: bar
+        - apiVersion: v1
+          kind: Secret
+          metadata:
+            name: secret-one
+          stringData:
+            password: s3cr3t
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: kind
+          value: ConfigMap
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: config-one
+        documentIndex: 0
+      - equal:
+          path: kind
+          value: Secret
+        documentIndex: 1
+      - equal:
+          path: metadata.name
+          value: secret-one
+        documentIndex: 1
+  - it: should support Helm templating in extra manifests
+    set:
+      extraObjects:
+        - apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: "{{ .Release.Name }}-dynamic"
+            namespace: "{{ .Release.Namespace }}"
+          data:
+            release: "{{ .Release.Name }}"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: test-release-dynamic
+      - equal:
+          path: metadata.namespace
+          value: test-namespace
+      - equal:
+          path: data.release
+          value: test-release
+  - it: should render non-namespaced resources
+    set:
+      extraObjects:
+        - apiVersion: rbac.authorization.k8s.io/v1
+          kind: ClusterRole
+          metadata:
+            name: extra-cluster-role
+          rules:
+            - apiGroups: [""]
+              resources: ["pods"]
+              verbs: ["get", "list"]
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: kind
+          value: ClusterRole
+      - equal:
+          path: metadata.name
+          value: extra-cluster-role
+      - equal:
+          path: rules[0].resources[0]
+          value: pods

--- a/helm/slurm/values.yaml
+++ b/helm/slurm/values.yaml
@@ -819,3 +819,20 @@ vendor:
       jobMappingDir: "/var/lib/dcgm-exporter/job-mapping"
       # -- Script execution priority (lower numbers run first)
       scriptPriority: "90"
+
+# -- Extra Kubernetes objects to deploy alongside the chart.
+# Each entry is rendered as a standalone Kubernetes object.
+# Supports Helm templating (e.g. {{ .Release.Namespace }}).
+extraObjects: []
+  # - apiVersion: v1
+  #   kind: ConfigMap
+  #   metadata:
+  #     name: extra-config
+  #   data:
+  #     key: value
+  # - apiVersion: v1
+  #   kind: Secret
+  #   metadata:
+  #     name: extra-secret
+  #   stringData:
+  #     password: "s3cr3t"


### PR DESCRIPTION
## Summary

- Adds `extraManifests` field to both `slurm` and `slurm-operator` Helm charts, allowing users to deploy arbitrary Kubernetes resources (ConfigMaps, Secrets, NetworkPolicies, RBAC, etc.) alongside the chart
- Each entry is rendered as a standalone Kubernetes object with full Helm templating support (e.g. `{{ .Release.Namespace }}`)
- Includes helm-unittest tests for both charts covering: empty list, single/multiple manifests, Helm templating resolution, and non-namespaced resources

## Breaking Changes

none

## Testing Notes

- [x] `helm unittest helm/slurm -f tests/extra_test.yaml` — 5/5 passing
- [x] `helm unittest helm/slurm-operator -f tests/extra_test.yaml` — 5/5 passing
- [x] `helm template` verified with inline `--set` values and piped values files


## Additional Context

<!--
Provide any other additional information here.
(e.g. which commits are critical or superfluous; why this implementation)
-->
