### PR TITLE
fix(nodeset): prevent duplicate SlurmNodeState pod conditions

### DIFF
--- a/internal/controller/nodeset/nodeset_sync_status.go
+++ b/internal/controller/nodeset/nodeset_sync_status.go
@@ -244,20 +244,12 @@ func (r *NodeSetReconciler) updateNodeSetPodConditions(
 
 		podConditions := nodeStatus.NodeStates[nodesetutils.GetSlurmNodeName(toUpdate)]
 
-		// Filter previous SlurmNodeStates that are no longer present
+		// Strip all existing SlurmNodeState conditions; they are re-applied
+		// from the current Slurm state by the UpdatePodCondition loop below.
 		var filteredConditions []corev1.PodCondition
 		for _, condition := range toUpdate.Status.Conditions {
-			// Keep any conditions that is not a SlurmNodeState
 			if !strings.HasPrefix(string(condition.Type), slurmconditions.StatePrefix) {
 				filteredConditions = append(filteredConditions, condition)
-			} else {
-				// Keep SlurmNodeStates that are still present
-				for _, cond := range podConditions {
-					_, c := podutil.GetPodCondition(&pod.Status, cond.Type)
-					if c != nil {
-						filteredConditions = append(filteredConditions, *c)
-					}
-				}
 			}
 		}
 		toUpdate.Status.Conditions = filteredConditions

--- a/internal/controller/nodeset/nodeset_sync_status_test.go
+++ b/internal/controller/nodeset/nodeset_sync_status_test.go
@@ -561,6 +561,16 @@ func TestNodeSetReconciler_updateNodeSetPodConditions(t *testing.T) {
 		Status:  corev1.ConditionTrue,
 		Message: "",
 	}
+	downCondition := corev1.PodCondition{
+		Type:    slurmconditions.PodConditionDown,
+		Status:  corev1.ConditionTrue,
+		Message: "",
+	}
+	notRespondingCondition := corev1.PodCondition{
+		Type:    slurmconditions.PodConditionNotResponding,
+		Status:  corev1.ConditionTrue,
+		Message: "",
+	}
 
 	controller := &slinkyv1beta1.Controller{
 		ObjectMeta: metav1.ObjectMeta{
@@ -654,6 +664,76 @@ func TestNodeSetReconciler_updateNodeSetPodConditions(t *testing.T) {
 				wantErr: nil,
 			}
 		}(),
+		func() testCaseFields {
+			nodeset := newNodeSet("foo", controller.Name, 2)
+			pods := make([]*corev1.Pod, 0)
+			for i := range 2 {
+				pod := nodesetutils.NewNodeSetStatefulSetPod(fake.NewFakeClient(), nodeset, controller, i, hash)
+				pod = makePodHealthy(pod)
+				pod.Status.Conditions = append(pod.Status.Conditions, downCondition, drainCondition, notRespondingCondition)
+				pods = append(pods, pod)
+			}
+			podList := &corev1.PodList{
+				Items: structutils.DereferenceList(pods),
+			}
+			c := fake.NewClientBuilder().WithRuntimeObjects(nodeset, podList).WithStatusSubresource(nodeset).Build()
+
+			return testCaseFields{
+				name: "Slurm States remain Down+Drain+NotResponding (second reconcile)",
+				fields: fields{
+					Client: c,
+				},
+				args: args{
+					ctx:  context.TODO(),
+					pods: pods,
+					nodeStatus: &slurmcontrol.SlurmNodeStatus{
+						NodeStates: func(pods []*corev1.Pod) map[string][]corev1.PodCondition {
+							ns := make(map[string][]corev1.PodCondition)
+							for _, pod := range pods {
+								ns[pod.Name] = append(ns[pod.Name], downCondition, drainCondition, notRespondingCondition)
+							}
+							return ns
+						}(pods),
+					},
+				},
+				wantErr: nil,
+			}
+		}(),
+		func() testCaseFields {
+			nodeset := newNodeSet("foo", controller.Name, 2)
+			pods := make([]*corev1.Pod, 0)
+			for i := range 2 {
+				pod := nodesetutils.NewNodeSetStatefulSetPod(fake.NewFakeClient(), nodeset, controller, i, hash)
+				pod = makePodHealthy(pod)
+				pod.Status.Conditions = append(pod.Status.Conditions, downCondition, drainCondition, notRespondingCondition)
+				pods = append(pods, pod)
+			}
+			podList := &corev1.PodList{
+				Items: structutils.DereferenceList(pods),
+			}
+			c := fake.NewClientBuilder().WithRuntimeObjects(nodeset, podList).WithStatusSubresource(nodeset).Build()
+
+			return testCaseFields{
+				name: "Slurm States transition from Down+Drain+NotResponding to Idle",
+				fields: fields{
+					Client: c,
+				},
+				args: args{
+					ctx:  context.TODO(),
+					pods: pods,
+					nodeStatus: &slurmcontrol.SlurmNodeStatus{
+						NodeStates: func(pods []*corev1.Pod) map[string][]corev1.PodCondition {
+							ns := make(map[string][]corev1.PodCondition)
+							for _, pod := range pods {
+								ns[pod.Name] = append(ns[pod.Name], idleCondition)
+							}
+							return ns
+						}(pods),
+					},
+				},
+				wantErr: nil,
+			}
+		}(),
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -672,8 +752,10 @@ func TestNodeSetReconciler_updateNodeSetPodConditions(t *testing.T) {
 					t.Errorf("NodeSetReconciler.updateNodeSetPodConditions() error = %v", err)
 					return
 				}
+				var slurmCondCount int
 				for _, condition := range pod.Status.Conditions {
 					if strings.HasPrefix(string(condition.Type), slurmconditions.StatePrefix) {
+						slurmCondCount++
 						var found bool
 						for _, nodeCondition := range ns {
 							if condition.Type == nodeCondition.Type &&
@@ -686,6 +768,10 @@ func TestNodeSetReconciler_updateNodeSetPodConditions(t *testing.T) {
 							as a Slurm node state (%v)`, condition, ns)
 						}
 					}
+				}
+				if slurmCondCount != len(ns) {
+					t.Errorf("NodeSetReconciler.updateNodeSetPodConditions() SlurmNodeState condition count = %d, want %d",
+						slurmCondCount, len(ns))
 				}
 			}
 		})


### PR DESCRIPTION
<!--
Feature requests, code contributions, and bug reports are welcome!
Github/Gitlab submitted issues and PRs/MRs are handled on a best effort basis.
The SchedMD official issue tracker is at <https://support.schedmd.com/>.
-->

## Summary

Fix N×M duplicate `SlurmNodeState` pod conditions generated by `updateNodeSetPodConditions` when a Slurm node has multiple simultaneous states (e.g. `DOWN+DRAIN+NOT_RESPONDING`). The nested filter loop appended M conditions N times, producing duplicates that the Kubernetes API server rejects in the strategic merge patch (`"order in patch list doesn't match $setElementOrder list"`), permanently halting the NodeSet controller with no recovery path.

Remove the else branch so that all existing SlurmNodeState conditions are stripped during filtering. The UpdatePodCondition loop immediately below unconditionally re-applies current Slurm state, making the selective retention logic redundant.

Fixes https://github.com/SlinkyProject/slurm-operator/issues/144

## Breaking Changes

N/A

## Testing Notes

**Unit tests (go test ./internal/controller/nodeset/... -v):**

- Added "Slurm States remain Down+Drain+NotResponding (second reconcile)" — the exact N×M=9 scenario from the bug report
- Added "Slurm States transition from Down+Drain+NotResponding to Idle" — stale condition removal

**Local Kind cluster deployment:**

- Deployed fix to existing Kind cluster via skaffold run
- Set worker node to `DOWN+DRAIN`: `scontrol update nodename=slinky-1 state=down reason=testing-issue-144` followed by `state=drain`
- Verified pod conditions transitioned to `SlurmNodeStateDown` + `SlurmNodeStateDrain`
- Observed 10+ consecutive successful reconcile cycles with the multi-state condition: no `"Reconciler error"`, no exponential backoff
- Resumed node via `scontrol update nodename=slinky-1 state=resume`: conditions cleanly reverted to `SlurmNodeStateIdle`

## Additional Context

The bug was masked during normal operation because healthy nodes have M=1 (single base state), and 1×1=1 produces no duplication. It only surfaced when M>1 (base state + flag states), typically during error/failure scenarios, precisely when monitoring and remediation tools (e.g. NVSentinel) need accurate pod conditions the most.
