### PR TITLE
fix: allow hyphens in ClusterName webhook validation

### DIFF
--- a/internal/webhook/controller_webhook.go
+++ b/internal/webhook/controller_webhook.go
@@ -44,7 +44,7 @@ func (r *ControllerWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 var _ admission.Validator[*slinkyv1beta1.Controller] = &ControllerWebhook{}
 
-const validTableNameRegex = `^[0-9a-zA-Z$_]+$`
+const validTableNameRegex = `^[0-9a-zA-Z$_-]+$`
 const warnTableNameRegex = `[A-Z]+`
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type

--- a/internal/webhook/controller_webhook_test.go
+++ b/internal/webhook/controller_webhook_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Controller Webhook", func() {
 
 		It("Should deny if ClusterName does not match regex", func(ctx SpecContext) {
 			controller := testutils.NewController("test", corev1.SecretKeySelector{}, corev1.SecretKeySelector{}, nil)
-			controller.Spec.ClusterName = "invalid-cluster" // hyphen is not allowed by [0-9a-zA-Z$_]+
+			controller.Spec.ClusterName = "invalid cluster!" // spaces and special chars are not allowed
 
 			_, err := controllerWebhook.ValidateCreate(ctx, controller)
 			Expect(err).To(HaveOccurred())
@@ -43,6 +43,14 @@ var _ = Describe("Controller Webhook", func() {
 			_, err := controllerWebhook.ValidateCreate(ctx, controller)
 			Expect(err).NotTo(HaveOccurred())
 		})
+
+		It("Should admit if ClusterName contains hyphens", func(ctx SpecContext) {
+			controller := testutils.NewController("slinky-dev", corev1.SecretKeySelector{}, corev1.SecretKeySelector{}, nil)
+
+			_, err := controllerWebhook.ValidateCreate(ctx, controller)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
 	})
 
 	Context("When Updating a Controller with Validating Webhook", func() {


### PR DESCRIPTION
## Summary
- Update the `ClusterName` validation regex to accept hyphen (`-`) characters, allowing names like `slinky-dev`
- Update existing test to use an invalid name (spaces/special chars) instead of a hyphenated name
- Add new test case validating that hyphenated cluster names are admitted

## Breaking Changes

none

## Testing Notes

- [x] Verify `slinky-dev` and similar hyphenated names are accepted by the webhook
- [x] Verify names with spaces or special characters (e.g. `invalid cluster!`) are still rejected
- [x] Run webhook unit tests (`go test ./internal/webhook/`)

## Additional Context

<!--
Provide any other additional information here.
(e.g. which commits are critical or superfluous; why this implementation)
-->
