### PR TITLE
Remove dead `condChanged` variable

### DIFF
--- a/internal/controller/nodeset/nodeset_sync_status.go
+++ b/internal/controller/nodeset/nodeset_sync_status.go
@@ -263,11 +263,8 @@ func (r *NodeSetReconciler) updateNodeSetPodConditions(
 		toUpdate.Status.Conditions = filteredConditions
 
 		// Add current Slurm node base and flag states
-		var condChanged bool
 		for _, cond := range podConditions {
-			if podutil.UpdatePodCondition(&toUpdate.Status, &cond) && !condChanged {
-				condChanged = true
-			}
+			podutil.UpdatePodCondition(&toUpdate.Status, &cond)
 		}
 		err := r.Status().Patch(ctx, toUpdate, client.StrategicMergeFrom(pod))
 		if err != nil {


### PR DESCRIPTION
## Summary

Remove the dead `condChanged` variable in `updateNodeSetPodConditions`. The variable was assigned but never read after the loop — the `!condChanged` guard only prevented redundant re-assignment of the bool itself, with no downstream effect. `UpdatePodCondition` is still called for its side effect of mutating `toUpdate.Status`.

## Breaking Changes

N/A

## Testing Notes

Existing unit tests pass (`TestNodeSetReconciler_updateNodeSetPodConditions`)
