### PR TITLE
fix(nodeset): handle NotFound in SlurmDeadline and SlurmTopology sync steps

### DIFF
--- a/internal/controller/nodeset/nodeset_sync.go
+++ b/internal/controller/nodeset/nodeset_sync.go
@@ -578,6 +578,9 @@ func (r *NodeSetReconciler) syncSlurmDeadline(
 			toUpdate.Annotations[slinkyv1beta1.AnnotationPodDeadline] = deadline.Format(time.RFC3339)
 		}
 		if err := r.Patch(ctx, toUpdate, client.StrategicMergeFrom(pod)); err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
 			return err
 		}
 
@@ -620,6 +623,9 @@ func (r *NodeSetReconciler) syncSlurmTopology(
 		toUpdate := pod.DeepCopy()
 		toUpdate.Annotations[slinkyv1beta1.AnnotationNodeTopologySpec] = topologyLine
 		if err := r.Patch(ctx, toUpdate, client.StrategicMergeFrom(pod)); err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
 			logger.Error(err, "failed to patch pod annotations", "pod", klog.KObj(pod))
 			return err
 		}


### PR DESCRIPTION
## Summary

- Handle `apierrors.IsNotFound` in `syncSlurmDeadline` and `syncSlurmTopology` so that pods deleted by a prior sync step (`syncSlurmNodes`) are silently skipped instead of failing the reconciliation
- Aligns error handling with how `syncSlurmNodes` already handles this case

Fixes #149

## Breaking Changes

none

## Testing Notes

- [x] Verify `go build ./internal/controller/nodeset/...` compiles cleanly
- [x] Verify existing unit tests pass (`go test ./internal/controller/nodeset/...`)
- [x] Deploy and confirm the `Failed "SlurmDeadline" step: pods ... not found` error no longer appears when a pod is deleted mid-reconciliation