### PR TITLE
Remove duplicate Patch call in updateNodeSetPodPDBLabels

### DIFF
--- a/internal/controller/nodeset/nodeset_sync_status.go
+++ b/internal/controller/nodeset/nodeset_sync_status.go
@@ -334,7 +334,7 @@ func (r *NodeSetReconciler) updateNodeSetPodPDBLabels(
 			logger.Error(err, "failed to patch pod labels for PDB", "pod", klog.KObj(toUpdate))
 			return err
 		}
-		return r.Patch(ctx, toUpdate, client.StrategicMergeFrom(pod))
+		return nil
 	}
 	if _, err := utils.SlowStartBatch(len(pods), utils.SlowStartInitialBatchSize, syncPodPDBLabelsFn); err != nil {
 		return err


### PR DESCRIPTION
## Summary

Remove a duplicate `r.Patch()` call in `updateNodeSetPodPDBLabels` that sent the same strategic-merge patch to the API server twice per pod on every reconcile cycle.

## Breaking Changes

N/A

## Testing Notes

Existing unit tests pass. No other Patch call site in the repo follows a double-patch pattern; every other site patches once and returns.

## Additional Context

The second patch was a redundant API call: after the first patch succeeds, calling `Patch` again with the same `toUpdate` and `StrategicMergeFrom(pod)` computes and sends the same diff a second time. Removing it halves the number of API calls made by `updateNodeSetPodPDBLabels`.