### PR TITLE
fix: correct typos in error messages, comments, and identifiers

### DIFF
--- a/internal/builder/loginbuilder/login_config.go
+++ b/internal/builder/loginbuilder/login_config.go
@@ -41,7 +41,7 @@ func buildAuthorizedKeys(authorizedKeys string) string {
 }
 
 func buildSshdConfig(extraConf string) string {
-	conf := config.NewBuilder().WithSeperator(" ")
+	conf := config.NewBuilder().WithSeparator(" ")
 
 	conf.AddProperty(config.NewPropertyRaw("#"))
 	conf.AddProperty(config.NewPropertyRaw("### GENERAL ###"))

--- a/internal/builder/workerbuilder/worker_config.go
+++ b/internal/builder/workerbuilder/worker_config.go
@@ -31,7 +31,7 @@ func (b *WorkerBuilder) BuildWorkerSshConfig(nodeset *slinkyv1beta1.NodeSet) (*c
 
 // Ref: https://slurm.schedmd.com/pam_slurm_adopt.html#ssh_config
 func buildWorkerSshdConfig(extraConf string) string {
-	conf := config.NewBuilder().WithSeperator(" ")
+	conf := config.NewBuilder().WithSeparator(" ")
 
 	conf.AddProperty(config.NewPropertyRaw("#"))
 	conf.AddProperty(config.NewPropertyRaw("### GENERAL ###"))

--- a/internal/utils/config/config.go
+++ b/internal/utils/config/config.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	DefaultSeperator = "="
+	DefaultSeparator = "="
 	DefaultNewline   = true
 )
 
@@ -24,7 +24,7 @@ func (b *configBuilder) AddProperty(prop configProperty) *configBuilder {
 	return b
 }
 
-func (b *configBuilder) WithSeperator(sep string) *configBuilder {
+func (b *configBuilder) WithSeparator(sep string) *configBuilder {
 	b.sep = sep
 	return b
 }
@@ -51,7 +51,7 @@ func (b *configBuilder) Build() string {
 
 func NewBuilder() *configBuilder {
 	return &configBuilder{
-		sep:     DefaultSeperator,
+		sep:     DefaultSeparator,
 		newline: DefaultNewline,
 		props:   make([]configProperty, 0),
 	}

--- a/internal/utils/config/config_test.go
+++ b/internal/utils/config/config_test.go
@@ -25,7 +25,7 @@ func Test_configBuilder_Build(t *testing.T) {
 			name: "with options",
 			fields: fields{
 				builder: NewBuilder().
-					WithSeperator("=").
+					WithSeparator("=").
 					WithFinalNewline(false).
 					AddProperty(NewProperty("foo", "bar")).
 					AddProperty(NewPropertyRaw("fizz ~ buzz")),

--- a/internal/utils/objectutils/meta.go
+++ b/internal/utils/objectutils/meta.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-// KeyFunc gets the namespacedName strgin for the meta object. Can be used as the key in a map.
+// KeyFunc gets the namespacedName string for the meta object. Can be used as the key in a map.
 func KeyFunc(obj metav1.Object) string {
 	return NamespacedName(obj).String()
 }

--- a/internal/utils/podcontrol/podcontrol.go
+++ b/internal/utils/podcontrol/podcontrol.go
@@ -202,10 +202,10 @@ func validateControllerRef(controllerRef *metav1.OwnerReference) error {
 		return fmt.Errorf("controllerRef has empty Kind")
 	}
 	if controllerRef.Controller == nil || !*controllerRef.Controller {
-		return fmt.Errorf("controllerRef.Controller is not nodeset to true")
+		return fmt.Errorf("controllerRef.Controller is not set to true")
 	}
 	if controllerRef.BlockOwnerDeletion == nil || !*controllerRef.BlockOwnerDeletion {
-		return fmt.Errorf("controllerRef.BlockOwnerDeletion is not nodeset")
+		return fmt.Errorf("controllerRef.BlockOwnerDeletion is not set to true")
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- Fix incorrect error messages in `validateControllerRef` — "is not nodeset to true" → "is not set to true"
- Fix typo in `KeyFunc` godoc comment — "strgin" → "string"
- Rename misspelled `DefaultSeperator` → `DefaultSeparator` and `WithSeperator()` → `WithSeparator()` across all usages

## Test plan

- [ ] Verify `go build ./...` succeeds
- [ ] Verify `go test ./internal/utils/config/...` passes (renamed method used in test)
- [ ] Grep for any remaining references to the old names (`DefaultSeperator`, `WithSeperator`, `strgin`, `nodeset to true`)