### PR TITLE
fix: clear mutually exclusive probe handlers during container merge

### DIFF
--- a/internal/builder/common/container.go
+++ b/internal/builder/common/container.go
@@ -19,14 +19,34 @@ func (b *CommonBuilder) BuildContainer(opts ContainerOpts) corev1.Container {
 	// Handle non `patchStrategy=merge` fields as if they were.
 	opts.Base.Args = structutils.MergeList(opts.Base.Args, opts.Merge.Args)
 	opts.Merge.Args = []string{}
+	// Clear mutually exclusive probe handlers during container merge.
+	// When the user provides a probe with a different handler type (e.g., exec)
+	// than the base (e.g., tcpSocket), the base handler must be cleared first.
+	// StrategicMergePatch merges both handlers into the same probe, producing
+	// an invalid spec with multiple handler types:
+	//   "may not specify more than 1 handler type"
+	// Replacing just the ProbeHandler preserves the base probe's settings
+	// (periodSeconds, failureThreshold, etc.) while swapping the handler.
 	if opts.Merge.LivenessProbe != nil {
-		opts.Base.LivenessProbe.ProbeHandler = opts.Merge.LivenessProbe.ProbeHandler
+		if opts.Base.LivenessProbe != nil {
+			opts.Base.LivenessProbe.ProbeHandler = opts.Merge.LivenessProbe.ProbeHandler
+		} else {
+			opts.Base.LivenessProbe = opts.Merge.LivenessProbe
+		}
 	}
 	if opts.Merge.ReadinessProbe != nil {
-		opts.Base.ReadinessProbe.ProbeHandler = opts.Merge.ReadinessProbe.ProbeHandler
+		if opts.Base.ReadinessProbe != nil {
+			opts.Base.ReadinessProbe.ProbeHandler = opts.Merge.ReadinessProbe.ProbeHandler
+		} else {
+			opts.Base.ReadinessProbe = opts.Merge.ReadinessProbe
+		}
 	}
 	if opts.Merge.StartupProbe != nil {
-		opts.Base.StartupProbe.ProbeHandler = opts.Merge.StartupProbe.ProbeHandler
+		if opts.Base.StartupProbe != nil {
+			opts.Base.StartupProbe.ProbeHandler = opts.Merge.StartupProbe.ProbeHandler
+		} else {
+			opts.Base.StartupProbe = opts.Merge.StartupProbe
+		}
 	}
 
 	out := structutils.StrategicMergePatch(&opts.Base, &opts.Merge)

--- a/internal/builder/common/container_test.go
+++ b/internal/builder/common/container_test.go
@@ -267,6 +267,52 @@ func TestBuilder_BuildContainer(t *testing.T) {
 			},
 		},
 		{
+			name:   "merge probe when base has no probe",
+			client: fake.NewFakeClient(),
+			opts: ContainerOpts{
+				Base: corev1.Container{
+					Name: "slurmctld",
+				},
+				Merge: corev1.Container{
+					ReadinessProbe: &corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							Exec: &corev1.ExecAction{
+								Command: []string{"test", "-f", "/var/run/slurmctld.pid"},
+							},
+						},
+						PeriodSeconds:    5,
+						FailureThreshold: 3,
+					},
+					LivenessProbe: &corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							Exec: &corev1.ExecAction{
+								Command: []string{"true"},
+							},
+						},
+					},
+				},
+			},
+			want: corev1.Container{
+				Name: "slurmctld",
+				ReadinessProbe: &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						Exec: &corev1.ExecAction{
+							Command: []string{"test", "-f", "/var/run/slurmctld.pid"},
+						},
+					},
+					PeriodSeconds:    5,
+					FailureThreshold: 3,
+				},
+				LivenessProbe: &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						Exec: &corev1.ExecAction{
+							Command: []string{"true"},
+						},
+					},
+				},
+			},
+		},
+		{
 			name:   "no merge probe leaves base untouched",
 			client: fake.NewFakeClient(),
 			opts: ContainerOpts{


### PR DESCRIPTION
## Summary

Fix nil pointer dereference in `BuildContainer` when the base container has no probe defined but the merge container does.

The existing code at lines 22-30 replaces `opts.Base.{Liveness,Readiness,Startup}Probe.ProbeHandler` with the merge probe's handler. This works when both base and merge have probes defined, but **panics** when `opts.Base.*Probe` is nil:

```
panic: runtime error: invalid memory address or nil pointer dereference
```

This happens when:
- The base container template has no probes (e.g., a minimal container spec)
- The user provides probes via Helm values or CR overrides

### Fix

Guard each `ProbeHandler` replacement with a nil check. If the base probe is nil, assign the entire merge probe instead of accessing `.ProbeHandler` on nil.

```go
if opts.Merge.ReadinessProbe != nil {
    if opts.Base.ReadinessProbe != nil {
        opts.Base.ReadinessProbe.ProbeHandler = opts.Merge.ReadinessProbe.ProbeHandler
    } else {
        opts.Base.ReadinessProbe = opts.Merge.ReadinessProbe
    }
}
```

## Breaking Changes

None. Existing behavior is preserved when both base and merge probes are non-nil.

## Testing Notes

- Added test case `merge_probe_when_base_has_no_probe` covering the nil base probe scenario
- All existing tests pass unchanged
- `go test ./internal/builder/common/ -run TestBuilder_BuildContainer -v` — 8/8 PASS