### PR TITLE
Add LoginSet validating webhook

### DIFF
--- a/internal/webhook/loginset_webhook.go
+++ b/internal/webhook/loginset_webhook.go
@@ -5,7 +5,10 @@ package webhook
 
 import (
 	"context"
+	"errors"
 
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -13,8 +16,6 @@ import (
 
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
 )
-
-// TODO(user): EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
 type LoginSetWebhook struct{}
 
@@ -39,14 +40,22 @@ var _ admission.Validator[*slinkyv1beta1.LoginSet] = &LoginSetWebhook{}
 func (r *LoginSetWebhook) ValidateCreate(ctx context.Context, loginset *slinkyv1beta1.LoginSet) (admission.Warnings, error) {
 	loginsetlog.Info("validate create", "loginset", klog.KObj(loginset))
 
-	return nil, nil
+	warns, errs := r.validateLoginSet(loginset)
+
+	return warns, utilerrors.NewAggregate(errs)
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *LoginSetWebhook) ValidateUpdate(ctx context.Context, oldLoginset, newLoginset *slinkyv1beta1.LoginSet) (admission.Warnings, error) {
 	loginsetlog.Info("validate update", "newLoginset", klog.KObj(newLoginset))
 
-	return nil, nil
+	warns, errs := r.validateLoginSet(newLoginset)
+
+	if !apiequality.Semantic.DeepEqual(newLoginset.Spec.ControllerRef, oldLoginset.Spec.ControllerRef) {
+		errs = append(errs, errors.New("cannot change controllerRef after deployment"))
+	}
+
+	return warns, utilerrors.NewAggregate(errs)
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
@@ -54,4 +63,19 @@ func (r *LoginSetWebhook) ValidateDelete(ctx context.Context, loginset *slinkyv1
 	loginsetlog.Info("validate delete", "loginset", klog.KObj(loginset))
 
 	return nil, nil
+}
+
+func (r *LoginSetWebhook) validateLoginSet(loginset *slinkyv1beta1.LoginSet) (admission.Warnings, []error) {
+	var warns admission.Warnings
+	var errs []error
+
+	if loginset.Spec.ControllerRef.Name == "" {
+		errs = append(errs, errors.New("controllerRef.name must not be empty"))
+	}
+
+	if loginset.Spec.SssdConfRef.Name == "" {
+		errs = append(errs, errors.New("sssdConfRef.name must not be empty"))
+	}
+
+	return warns, errs
 }

--- a/internal/webhook/loginset_webhook_test.go
+++ b/internal/webhook/loginset_webhook_test.go
@@ -5,16 +5,69 @@ package webhook
 
 import (
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+
+	"github.com/SlinkyProject/slurm-operator/internal/utils/testutils"
 )
 
 var _ = Describe("LoginSet Webhook", func() {
-	Context("When creating LoginSet under Validating Webhook", func() {
-		It("Should deny if a required field is empty", func() {
-			// TODO(user): Add your logic here
+	Context("When Creating a LoginSet with Validating Webhook", func() {
+		It("Should deny if controllerRef.name is empty", func(ctx SpecContext) {
+			loginset := testutils.NewLoginset("test-loginset", nil, testutils.NewSssdConfRef("test"))
+
+			_, err := loginSetWebhook.ValidateCreate(ctx, loginset)
+			Expect(err).To(HaveOccurred())
 		})
 
-		It("Should admit if all required fields are provided", func() {
-			// TODO(user): Add your logic here
+		It("Should deny if sssdConfRef.name is empty", func(ctx SpecContext) {
+			controller := testutils.NewController("some-controller", corev1.SecretKeySelector{}, corev1.SecretKeySelector{}, nil)
+			loginset := testutils.NewLoginset("test-loginset", controller, corev1.SecretKeySelector{})
+
+			_, err := loginSetWebhook.ValidateCreate(ctx, loginset)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("Should admit if all required fields are provided", func(ctx SpecContext) {
+			controller := testutils.NewController("valid-controller", corev1.SecretKeySelector{}, corev1.SecretKeySelector{}, nil)
+			loginset := testutils.NewLoginset("test-loginset", controller, testutils.NewSssdConfRef("test"))
+
+			_, err := loginSetWebhook.ValidateCreate(ctx, loginset)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("When Updating a LoginSet with Validating Webhook", func() {
+		It("Should reject changes to controllerRef", func(ctx SpecContext) {
+			oldController := testutils.NewController("old-controller", corev1.SecretKeySelector{}, corev1.SecretKeySelector{}, nil)
+			oldLoginSet := testutils.NewLoginset("test-loginset", oldController, testutils.NewSssdConfRef("test"))
+
+			newController := testutils.NewController("new-controller", corev1.SecretKeySelector{}, corev1.SecretKeySelector{}, nil)
+			newLoginSet := testutils.NewLoginset("test-loginset", newController, testutils.NewSssdConfRef("test"))
+
+			_, err := loginSetWebhook.ValidateUpdate(ctx, oldLoginSet, newLoginSet)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("Should admit if no immutable fields change", func(ctx SpecContext) {
+			controller := testutils.NewController("valid-controller", corev1.SecretKeySelector{}, corev1.SecretKeySelector{}, nil)
+			oldLoginSet := testutils.NewLoginset("test-loginset", controller, testutils.NewSssdConfRef("test"))
+			newLoginSet := testutils.NewLoginset("test-loginset", controller, testutils.NewSssdConfRef("test"))
+			newLoginSet.Spec.Replicas = ptr.To(int32(2))
+
+			_, err := loginSetWebhook.ValidateUpdate(ctx, oldLoginSet, newLoginSet)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("When Deleting a LoginSet with Validating Webhook", func() {
+		It("Should admit a Delete", func(ctx SpecContext) {
+			loginset := testutils.NewLoginset("test-loginset", nil, corev1.SecretKeySelector{})
+
+			_, err := loginSetWebhook.ValidateDelete(ctx, loginset)
+			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 })


### PR DESCRIPTION
## Summary

Implement validation for LoginSet admission, replacing the scaffold no-op. Mirrors the NodeSet webhook pattern.

Create & Update validation (`validateLoginSet`):

- Reject empty `controllerRef.name`: CRD requires the field but not a non-empty `.name`; empty name causes cryptic reconciler failures
- Reject empty `sssdConfRef.name`: CRD requires the field but allows empty `.name`; the builder generates a volume referencing an empty secret name, causing pod creation failures

Update-only immutability:

- `controllerRef` — changing the owning Controller post-deploy is not supported

No `client.Client` needed — all checks are pure struct validation. LoginSet is simpler than NodeSet (no `scalingMode`, `volumeClaimTemplates`, or `maxUnavailable`) because it uses Deployments, not StatefulSets.

## Breaking Changes

N/A

## Testing Notes

Unit tests via `go test ./internal/webhook/` against envtest (27/27 specs pass). 6 new LoginSet tests cover every validation rule, immutability check, and happy path for create/update/delete.

## Additional Context

Companion to #156 (NodeSet webhook). Same pattern: only validate what the CRD schema cannot express, no cross-object existence checks.

If the webhook checked that the Controller CR exists via client.Get, it could reject a valid LoginSet during a concurrent deploy where the Controller hasn't been created yet. The reconciler already surfaces ControllerRefFailed events (`loginset_sync.go`) when the reference is missing at runtime.