### PR TITLE
fix(loginset): skip reconciliation when LoginSet is being deleted

### DIFF
--- a/internal/controller/loginset/loginset_controller_test.go
+++ b/internal/controller/loginset/loginset_controller_test.go
@@ -10,6 +10,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
 	"github.com/SlinkyProject/slurm-operator/internal/utils/testutils"
@@ -47,6 +48,50 @@ var _ = Describe("LoginSet Controller", func() {
 			_ = k8sClient.Delete(ctx, sssdConfSecret)
 			_ = k8sClient.Delete(ctx, loginset)
 		})
+
+		It("Should skip sync when LoginSet is being deleted", func(ctx SpecContext) {
+			By("Waiting for LoginSet children to be created")
+			deploymentKey := loginset.Key()
+			deployment := &appsv1.Deployment{}
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, deploymentKey, deployment)).To(Succeed())
+			}, testutils.Timeout, testutils.Interval).Should(Succeed())
+
+			By("Deleting LoginSet with foreground propagation")
+			loginsetKey := client.ObjectKeyFromObject(loginset)
+			Expect(k8sClient.Delete(ctx, loginset,
+				client.PropagationPolicy(metav1.DeletePropagationForeground),
+			)).To(Succeed())
+
+			By("Verifying LoginSet has deletionTimestamp set")
+			Eventually(func(g Gomega) {
+				ls := &slinkyv1beta1.LoginSet{}
+				g.Expect(k8sClient.Get(ctx, loginsetKey, ls)).To(Succeed())
+				g.Expect(ls.DeletionTimestamp.IsZero()).To(BeFalse())
+			}, testutils.Timeout, testutils.Interval).Should(Succeed())
+
+			By("Deleting Deployment child while LoginSet is terminating")
+			Expect(k8sClient.Get(ctx, deploymentKey, deployment)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, deployment)).To(Succeed())
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, deploymentKey, deployment)
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(client.IgnoreNotFound(err)).To(Succeed())
+			}, testutils.Timeout, testutils.Interval).Should(Succeed())
+
+			By("Verifying Deployment child is NOT recreated")
+			Consistently(func(g Gomega) {
+				err := k8sClient.Get(ctx, deploymentKey, deployment)
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(client.IgnoreNotFound(err)).To(Succeed())
+			}, 5*testutils.Interval, testutils.Interval).Should(Succeed())
+
+			By("Cleaning up: removing foregroundDeletion finalizer")
+			ls := &slinkyv1beta1.LoginSet{}
+			Expect(k8sClient.Get(ctx, loginsetKey, ls)).To(Succeed())
+			ls.Finalizers = nil
+			Expect(k8sClient.Update(ctx, ls)).To(Succeed())
+		}, SpecTimeout(testutils.Timeout))
 
 		It("Should successfully create create an loginset", func(ctx SpecContext) {
 			By("Creating LoginSet CR")

--- a/internal/controller/loginset/loginset_sync.go
+++ b/internal/controller/loginset/loginset_sync.go
@@ -40,6 +40,17 @@ func (r *LoginSetReconciler) Sync(ctx context.Context, req reconcile.Request) er
 	loginset = loginset.DeepCopy()
 	defaults.SetLoginSetDefaults(loginset)
 
+	// Skip reconciliation if the LoginSet is being deleted.
+	// Child resources (Deployment, Service, ConfigMap, Secret) have
+	// blockOwnerDeletion=true, so the Kubernetes garbage collector will
+	// delete them before the LoginSet. If we continue to reconcile, we
+	// would recreate children that the GC is trying to delete, causing
+	// the LoginSet to be stuck in Terminating state.
+	if !loginset.DeletionTimestamp.IsZero() {
+		logger.Info("LoginSet is being deleted, skipping sync", "request", req)
+		return nil
+	}
+
 	controller := &slinkyv1beta1.Controller{}
 	controllerKey := client.ObjectKey(loginset.Spec.ControllerRef.NamespacedName())
 	if err := r.Get(ctx, controllerKey, controller); err != nil {


### PR DESCRIPTION
## Summary

- Skip `Sync()` when the `LoginSet` has a non-zero `DeletionTimestamp`, preventing the controller from reconciling child resources during foreground deletion
- Without this check, a foreground delete can leave the `LoginSet` stuck in `Terminating`: garbage collection removes children, `Sync()` recreates them, and the `foregroundDeletion` finalizer never clears

## Breaking Changes

none

## Testing Notes

- [x] Verify `go build ./...` compiles cleanly
- [x] Verify existing unit tests pass
- [x] Reproduce the stuck deletion on `main` using foreground cascading (`kubectl delete --cascade=foreground`)
- [x] Verify the fix stops reconciliation for deleting `LoginSet` objects and allows garbage collection to complete
- [ ] Add integration test verifying `LoginSet` deletion completes (included in this PR, requires kubebuilder test env)

## Context

All four `LoginSet` child resources (`Deployment`, `Service`, `ConfigMap`, `Secret`) have `blockOwnerDeletion=true` in their `ownerReferences`, set by `controllerutil.SetControllerReference()`.

The issue reproduces on the foreground deletion path used by ArgoCD:

1. The `LoginSet` is deleted with foreground cascading
2. Kubernetes sets `metadata.deletionTimestamp` and adds the `foregroundDeletion` finalizer
3. Garbage collection starts removing child resources before deleting the parent
4. `LoginSet.Sync()` runs again while deletion is already in progress
5. Missing children are reconciled back into existence
6. Deletion does not converge, because the parent stays in foreground deletion while children keep reappearing

This matches the existing `DeletionTimestamp` guards already present in:
- `internal/controller/nodeset/nodeset_sync.go:78`
- `internal/controller/token/token_sync.go:53`

## Reproduction (kind cluster, `main`)

```bash
# Fresh kind cluster with operator v1.1.0 and LoginSets enabled
kind create cluster --name slinky-repro
helm repo add jetstack https://charts.jetstack.io
helm repo update
helm install cert-manager jetstack/cert-manager   --set crds.enabled=true --namespace cert-manager --create-namespace
helm install slurm-operator-crds oci://ghcr.io/slinkyproject/charts/slurm-operator-crds
helm install slurm-operator oci://ghcr.io/slinkyproject/charts/slurm-operator   --namespace=slinky --create-namespace
helm install slurm oci://ghcr.io/slinkyproject/charts/slurm   --namespace=slurm --create-namespace --set loginsets.slinky.enabled=true

# Wait for pods to be ready
kubectl get pods -n slurm --watch

# Confirm children have blockOwnerDeletion
kubectl get deployment slurm-login-slinky -n slurm   -o jsonpath='{.metadata.ownerReferences}' | jq

# Delete the LoginSet with foreground cascading
kubectl delete loginset slurm-login-slinky -n slurm --cascade=foreground --wait=false
```

Observed on a clean kind cluster (`main`, operator `v1.1.0`):

```bash
$ kubectl get loginset -n slurm slurm-login-slinky   -o jsonpath='deletionTimestamp={.metadata.deletionTimestamp} finalizers={.metadata.finalizers}'
deletionTimestamp=2026-04-06T18:05:27Z finalizers=["foregroundDeletion"]
```

Polling the parent and child resource count once per second:

```bash
for i in $(seq 1 30); do
  LS=$(kubectl get loginset -n slurm slurm-login-slinky     -o jsonpath='ts={.metadata.deletionTimestamp} fin={.metadata.finalizers}' 2>&1)
  CHILDREN=$(kubectl get deployment,service,configmap,secret -n slurm 2>&1 | grep -c login || echo 0)
  echo "$(date -u +%H:%M:%S) loginset=[$LS] children=$CHILDREN"
  sleep 1
done
```

Example output:

```text
18:05:27 loginset=[ts=2026-04-06T18:05:27Z fin=["foregroundDeletion"]] children=4
...
18:05:36 loginset=[ts=2026-04-06T18:05:27Z fin=["foregroundDeletion"]] children=3
18:05:37 loginset=[ts=2026-04-06T18:05:27Z fin=["foregroundDeletion"]] children=4
...
18:05:42 loginset=[ts=2026-04-06T18:05:27Z fin=["foregroundDeletion"]] children=3
18:05:43 loginset=[ts=2026-04-06T18:05:27Z fin=["foregroundDeletion"]] children=4
```

So while the `LoginSet` is already in foreground deletion, the child count drops and then returns to 4 instead of converging to 0, and the parent remains stuck in `Terminating`.

Operator logs also show the controller continuing to sync the deleting `LoginSet` during that period:

```bash
$ kubectl logs -n slinky deployment/slurm-operator --since=60s | grep -c "Started syncing LoginSet"
732
```

## Fix

Return early from `LoginSet.Sync()` when `metadata.deletionTimestamp` is set. This prevents reconciliation from reintroducing child resources while Kubernetes garbage collection is trying to remove them.
