### PR TITLE
test(token): fill empty sync status test stubs

### DIFF
--- a/internal/controller/token/token_sync_status_test.go
+++ b/internal/controller/token/token_sync_status_test.go
@@ -7,12 +7,61 @@ import (
 	"context"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	"github.com/SlinkyProject/slurm-operator/internal/controller/token/slurmjwt"
+	"github.com/SlinkyProject/slurm-operator/internal/utils/crypto"
 )
 
 func TestTokenReconciler_syncStatus(t *testing.T) {
+	signingKey := crypto.NewSigningKey()
+	signedToken, err := slurmjwt.NewToken(signingKey).NewSignedToken()
+	if err != nil {
+		t.Fatalf("failed to create signed token: %v", err)
+	}
+
+	jwtKeySecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-jwtkey",
+			Namespace: corev1.NamespaceDefault,
+		},
+		Data: map[string][]byte{
+			"jwt.key": signingKey,
+		},
+	}
+
+	token := &slinkyv1beta1.Token{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: corev1.NamespaceDefault,
+		},
+		Spec: slinkyv1beta1.TokenSpec{
+			Username: "slurm",
+			JwtKeyRef: &slinkyv1beta1.JwtSecretKeySelector{
+				SecretKeySelector: corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: jwtKeySecret.Name,
+					},
+					Key: "jwt.key",
+				},
+			},
+		},
+	}
+
+	authSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      token.SecretKey().Name,
+			Namespace: corev1.NamespaceDefault,
+		},
+		Data: map[string][]byte{
+			"SLURM_JWT": []byte(signedToken),
+		},
+	}
+
 	type fields struct {
 		Client client.Client
 	}
@@ -26,7 +75,66 @@ func TestTokenReconciler_syncStatus(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-		// TODO: Add test cases.
+		{
+			name: "Succeeds with valid JWT and updates status",
+			fields: fields{
+				Client: fake.NewClientBuilder().
+					WithRuntimeObjects(token.DeepCopy(), jwtKeySecret.DeepCopy(), authSecret.DeepCopy()).
+					WithStatusSubresource(&slinkyv1beta1.Token{}).
+					Build(),
+			},
+			args: args{
+				ctx:   context.TODO(),
+				token: token.DeepCopy(),
+			},
+			wantErr: false,
+		},
+		{
+			name: "Fails when auth secret is missing",
+			fields: fields{
+				Client: fake.NewClientBuilder().
+					WithRuntimeObjects(token.DeepCopy(), jwtKeySecret.DeepCopy()).
+					WithStatusSubresource(&slinkyv1beta1.Token{}).
+					Build(),
+			},
+			args: args{
+				ctx:   context.TODO(),
+				token: token.DeepCopy(),
+			},
+			wantErr: true,
+		},
+		{
+			name: "Fails when JWT signing key secret is missing",
+			fields: fields{
+				Client: fake.NewClientBuilder().
+					WithRuntimeObjects(token.DeepCopy(), authSecret.DeepCopy()).
+					WithStatusSubresource(&slinkyv1beta1.Token{}).
+					Build(),
+			},
+			args: args{
+				ctx:   context.TODO(),
+				token: token.DeepCopy(),
+			},
+			wantErr: true,
+		},
+		{
+			name: "Fails when JWT is signed with wrong key",
+			fields: fields{
+				Client: func() client.Client {
+					wrongKeySecret := jwtKeySecret.DeepCopy()
+					wrongKeySecret.Data["jwt.key"] = crypto.NewSigningKey()
+					return fake.NewClientBuilder().
+						WithRuntimeObjects(token.DeepCopy(), wrongKeySecret, authSecret.DeepCopy()).
+						WithStatusSubresource(&slinkyv1beta1.Token{}).
+						Build()
+				}(),
+			},
+			args: args{
+				ctx:   context.TODO(),
+				token: token.DeepCopy(),
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -39,6 +147,13 @@ func TestTokenReconciler_syncStatus(t *testing.T) {
 }
 
 func TestTokenReconciler_updateStatus(t *testing.T) {
+	token := &slinkyv1beta1.Token{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: corev1.NamespaceDefault,
+		},
+	}
+
 	type fields struct {
 		Client client.Client
 	}
@@ -53,7 +168,37 @@ func TestTokenReconciler_updateStatus(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-		// TODO: Add test cases.
+		{
+			name: "Succeeds updating status",
+			fields: fields{
+				Client: fake.NewClientBuilder().
+					WithRuntimeObjects(token.DeepCopy()).
+					WithStatusSubresource(&slinkyv1beta1.Token{}).
+					Build(),
+			},
+			args: args{
+				ctx:   context.TODO(),
+				token: token.DeepCopy(),
+				newStatus: &slinkyv1beta1.TokenStatus{
+					IssuedAt: &metav1.Time{Time: metav1.Now().Time},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "No-op when token is not found",
+			fields: fields{
+				Client: fake.NewFakeClient(),
+			},
+			args: args{
+				ctx:   context.TODO(),
+				token: token.DeepCopy(),
+				newStatus: &slinkyv1beta1.TokenStatus{
+					IssuedAt: &metav1.Time{Time: metav1.Now().Time},
+				},
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Fill two previously empty table-driven test functions in `internal/controller/token/token_sync_status_test.go` that had only `// TODO: Add test cases.` placeholders.

**Tests added (6 cases total):**

- `TestTokenReconciler_syncStatus` (4 cases): valid JWT with status update, missing auth secret, missing signing key secret, wrong signing key verification failure
- `TestTokenReconciler_updateStatus` (2 cases): successful status subresource update, no-op when token CR is not found

These cover the Token controller's status synchronization pipeline: secret resolution for auth tokens and signing keys, JWT parsing and validation, status comparison and update, and the `updateStatus` retry-on-conflict path including the intentional no-op for deleted tokens.

## Breaking Changes

N/A

## Testing Notes

All 6 new cases pass. Full package suite (`go test ./internal/controller/token/...`) and `go vet` also pass with no regressions.

## Additional Context

Test fixtures follow existing patterns in the repository:
- `fake.NewClientBuilder().WithRuntimeObjects(...).WithStatusSubresource(...).Build()` for cases reaching status updates (matching `nodeset_sync_status_test.go`)
- `fake.NewFakeClient()` for the NotFound case (matching same file)
- Scheme registration via `suite_test.go` `init()` — no custom scheme needed
- `crypto.NewSigningKey()` + `slurmjwt.NewToken().NewSignedToken()` for realistic JWT fixtures (matching `slurmjwt/token_test.go`)
