### PR TITLE
feat(helm): gate operator/webhook PDBs on HA and expose maxUnavailable

### DIFF
--- a/helm/slurm-operator/README.md
+++ b/helm/slurm-operator/README.md
@@ -54,7 +54,7 @@ Kubernetes: `>= 1.29.0-0`
 | operator.namespaces | string | `""` | Comma-separated list of namespaces the operator will watch. If empty, all namespaces are watched. |
 | operator.nodesetWorkers | int | `4` | Set the max concurrent workers for the NodeSet controller. |
 | operator.pdb.enabled | bool | `false` | Enable PodDisruptionBudget. |
-| operator.pdb.minAvailable | int | `1` | Minimum number of pods that must still be available after eviction. Can be an absolute number (ex: 5) or a percentage (ex: 25%). |
+| operator.pdb.minAvailable | int | `1` | Minimum pods that must remain available after eviction (int or quoted percent). |
 | operator.replicas | int | `1` | Set the number of replicas to deploy. |
 | operator.resources | object | `{}` | The container resource limits and requests. Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container |
 | operator.restapiWorkers | int | `4` | Set the max concurrent workers for the Restapi controller. |
@@ -75,7 +75,7 @@ Kubernetes: `>= 1.29.0-0`
 | webhook.metricsPort | int | `0` | Set the port used by the metrics server. Value of "0" will disable it. |
 | webhook.namespaces | string | `""` | Comma-separated list of namespaces the webhook will watch. If empty, all namespaces are watched. |
 | webhook.pdb.enabled | bool | `false` | Enable PodDisruptionBudget. |
-| webhook.pdb.minAvailable | int | `1` | Minimum number of pods that must still be available after eviction. Can be an absolute number (ex: 5) or a percentage (ex: 25%). |
+| webhook.pdb.minAvailable | int | `1` | Minimum pods that must remain available after eviction (int or quoted percent). |
 | webhook.replicas | int | `1` | Set the number of replicas to deploy. |
 | webhook.resources | object | `{}` | The container resource limits and requests. Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container |
 | webhook.serverPort | int | `9443` | Set the port used for the webhook server |

--- a/helm/slurm-operator/templates/operator/poddisruptionbudget.yaml
+++ b/helm/slurm-operator/templates/operator/poddisruptionbudget.yaml
@@ -4,18 +4,21 @@ SPDX-License-Identifier: Apache-2.0
 */}}
 
 {{- if .Values.operator.enabled }}
-{{- if .Values.operator.pdb }}
-{{- if .Values.operator.pdb.enabled }}
+{{- if and .Values.operator.pdb .Values.operator.pdb.enabled (gt (int .Values.operator.replicas) 1) }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "slurm-operator.name" . }}
   namespace: {{ include "slurm-operator.namespace" . }}
 spec:
-  minAvailable: {{ .Values.operator.pdb.minAvailable}}
+  {{- if .Values.operator.pdb.minAvailable }}
+  minAvailable: {{ .Values.operator.pdb.minAvailable }}
+  {{- end }}
+  {{- if or .Values.operator.pdb.maxUnavailable (not .Values.operator.pdb.minAvailable) }}
+  maxUnavailable: {{ .Values.operator.pdb.maxUnavailable | default 1 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "slurm-operator.operator.selectorLabels" . | nindent 6 }}
-{{- end }}{{- /* if .Values.operator.pdb.enabled */}}
-{{- end }}{{- /* if .Values.operator.pdb */}}
+{{- end }}{{- /* if operator.pdb.enabled */}}
 {{- end }}{{- /* if .Values.operator.enabled */}}

--- a/helm/slurm-operator/templates/webhook/poddisruptionbudget.yaml
+++ b/helm/slurm-operator/templates/webhook/poddisruptionbudget.yaml
@@ -4,18 +4,21 @@ SPDX-License-Identifier: Apache-2.0
 */}}
 
 {{- if .Values.webhook.enabled }}
-{{- if .Values.webhook.pdb }}
-{{- if .Values.webhook.pdb.enabled }}
+{{- if and .Values.webhook.pdb .Values.webhook.pdb.enabled (gt (int .Values.webhook.replicas) 1) }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "slurm-operator.webhook.name" . }}
   namespace: {{ include "slurm-operator.namespace" . }}
 spec:
-  minAvailable: {{ .Values.webhook.pdb.minAvailable}}
+  {{- if .Values.webhook.pdb.minAvailable }}
+  minAvailable: {{ .Values.webhook.pdb.minAvailable }}
+  {{- end }}
+  {{- if or .Values.webhook.pdb.maxUnavailable (not .Values.webhook.pdb.minAvailable) }}
+  maxUnavailable: {{ .Values.webhook.pdb.maxUnavailable | default 1 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "slurm-operator.webhook.selectorLabels" . | nindent 6 }}
 {{- end }}{{- /* if .Values.webhook.pdb.enabled */}}
-{{- end }}{{- /* if .Values.webhook.pdb */}}
 {{- end }}{{- /* if .Values.webhook.enabled */}}

--- a/helm/slurm-operator/tests/operator_pdb_test.yaml
+++ b/helm/slurm-operator/tests/operator_pdb_test.yaml
@@ -27,10 +27,22 @@ tests:
       - hasDocuments:
           count: 0
 
+  - it: should not render when replicas is 1
+    set:
+      operator:
+        enabled: true
+        pdb:
+          enabled: true
+          minAvailable: 1
+    asserts:
+      - hasDocuments:
+          count: 0
+
   - it: should render with correct metadata and spec when pdb is enabled
     set:
       operator:
         enabled: true
+        replicas: 2
         pdb:
           enabled: true
           minAvailable: 1
@@ -59,6 +71,7 @@ tests:
     set:
       operator:
         enabled: true
+        replicas: 3
         pdb:
           enabled: true
           minAvailable: 2
@@ -72,6 +85,7 @@ tests:
       namespaceOverride: custom-namespace
       operator:
         enabled: true
+        replicas: 2
         pdb:
           enabled: true
           minAvailable: 1
@@ -79,3 +93,53 @@ tests:
       - equal:
           path: metadata.namespace
           value: custom-namespace
+
+  - it: should render both minAvailable and maxUnavailable when both are set
+    set:
+      operator:
+        enabled: true
+        replicas: 3
+        pdb:
+          enabled: true
+          minAvailable: 2
+          maxUnavailable: 1
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 2
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+
+  - it: should default maxUnavailable to 1 when neither is set
+    set:
+      operator:
+        enabled: true
+        replicas: 2
+        pdb:
+          enabled: true
+          minAvailable: null
+    asserts:
+      - exists:
+          path: spec.minAvailable
+        not: true
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+
+  - it: should render only maxUnavailable when minAvailable is unset and maxUnavailable is set
+    set:
+      operator:
+        enabled: true
+        replicas: 2
+        pdb:
+          enabled: true
+          minAvailable: null
+          maxUnavailable: "25%"
+    asserts:
+      - exists:
+          path: spec.minAvailable
+        not: true
+      - equal:
+          path: spec.maxUnavailable
+          value: "25%"

--- a/helm/slurm-operator/tests/webhook_pdb_test.yaml
+++ b/helm/slurm-operator/tests/webhook_pdb_test.yaml
@@ -27,10 +27,22 @@ tests:
       - hasDocuments:
           count: 0
 
+  - it: should not render when replicas is 1
+    set:
+      webhook:
+        enabled: true
+        pdb:
+          enabled: true
+          minAvailable: 1
+    asserts:
+      - hasDocuments:
+          count: 0
+
   - it: should render with correct metadata and spec when pdb is enabled
     set:
       webhook:
         enabled: true
+        replicas: 2
         pdb:
           enabled: true
           minAvailable: 1
@@ -59,6 +71,7 @@ tests:
     set:
       webhook:
         enabled: true
+        replicas: 4
         pdb:
           enabled: true
           minAvailable: 3
@@ -72,6 +85,7 @@ tests:
       namespaceOverride: custom-namespace
       webhook:
         enabled: true
+        replicas: 2
         pdb:
           enabled: true
           minAvailable: 1
@@ -79,3 +93,53 @@ tests:
       - equal:
           path: metadata.namespace
           value: custom-namespace
+
+  - it: should render both minAvailable and maxUnavailable when both are set
+    set:
+      webhook:
+        enabled: true
+        replicas: 3
+        pdb:
+          enabled: true
+          minAvailable: 2
+          maxUnavailable: 1
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 2
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+
+  - it: should default maxUnavailable to 1 when neither is set
+    set:
+      webhook:
+        enabled: true
+        replicas: 2
+        pdb:
+          enabled: true
+          minAvailable: null
+    asserts:
+      - exists:
+          path: spec.minAvailable
+        not: true
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+
+  - it: should render only maxUnavailable when minAvailable is unset and maxUnavailable is set
+    set:
+      webhook:
+        enabled: true
+        replicas: 2
+        pdb:
+          enabled: true
+          minAvailable: null
+          maxUnavailable: "25%"
+    asserts:
+      - exists:
+          path: spec.minAvailable
+        not: true
+      - equal:
+          path: spec.maxUnavailable
+          value: "25%"

--- a/helm/slurm-operator/values.yaml
+++ b/helm/slurm-operator/values.yaml
@@ -60,14 +60,15 @@ operator:
     # requests:
     #   cpu: 1
     #   memory: 1Gi
-  # PodDisruptionBudget configuration.
+  # PodDisruptionBudget for the operator Deployment.
   # Ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
   pdb:
     # -- Enable PodDisruptionBudget.
     enabled: false
-    # -- Minimum number of pods that must still be available after eviction.
-    # Can be an absolute number (ex: 5) or a percentage (ex: 25%).
+    # -- Minimum pods that must remain available after eviction (int or quoted percent).
     minAvailable: 1
+    # -- Maximum pods that may be unavailable (int or quoted percent). Rendered when set, or when `minAvailable` is unset (defaulting to 1).
+    # maxUnavailable: "25%"
   # -- Set the max concurrent workers for the Accounting controller.
   accountingWorkers: 4
   # -- Set the max concurrent workers for the Controller controller.
@@ -132,14 +133,15 @@ webhook:
     # requests:
     #   cpu: 1
     #   memory: 1Gi
-  # PodDisruptionBudget configuration.
+  # PodDisruptionBudget for the webhook Deployment.
   # Ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
   pdb:
     # -- Enable PodDisruptionBudget.
     enabled: false
-    # -- Minimum number of pods that must still be available after eviction.
-    # Can be an absolute number (ex: 5) or a percentage (ex: 25%).
+    # -- Minimum pods that must remain available after eviction (int or quoted percent).
     minAvailable: 1
+    # -- Maximum pods that may be unavailable (int or quoted percent). Rendered when set, or when `minAvailable` is unset (defaulting to 1).
+    # maxUnavailable: "25%"
   # -- Set the log level by string (e.g. error, info, debug) or number (e.g. 1..5).
   logLevel: info
   # -- Set the port used for the webhook server


### PR DESCRIPTION
## Summary

- Skip rendering the operator and webhook `PodDisruptionBudget` when `replicas <= 1` in `helm/slurm-operator`. A PDB in front of a single-replica Deployment would block voluntary evictions (drains, node upgrades) without providing any availability benefit.
- Expose `maxUnavailable` alongside `minAvailable` in `values.yaml` for both `operator.pdb` and `webhook.pdb`. When neither is explicitly set, templates default to `maxUnavailable: 1`. When both are set, both are rendered. When only `minAvailable` is set, only `minAvailable` is rendered.
- Drop the `unhealthyPodEvictionPolicy` knob to keep the values surface small and focused.

## Test plan

- `helm unittest helm/slurm-operator -f 'tests/operator_pdb_test.yaml' -f 'tests/webhook_pdb_test.yaml'` passes (18 tests), including new cases:
  - no PDB is rendered when `replicas: 1`
  - both `minAvailable` and `maxUnavailable` are rendered when both are set
  - `maxUnavailable` defaults to 1 when neither is set
  - only `maxUnavailable` is rendered when `minAvailable` is unset