### PR TITLE
fix(chart): dcgm.enabled=false now disables dcgm

### DIFF
--- a/helm/slurm/templates/vendor/nvidia/dcgm/_helpers.tpl
+++ b/helm/slurm/templates/vendor/nvidia/dcgm/_helpers.tpl
@@ -8,7 +8,7 @@ SPDX-License-Identifier: Apache-2.0
 Check if DCGM integration is enabled
 */}}
 {{- define "vendor.dcgm.enabled" -}}
-{{- .Values.vendor.nvidia.dcgm.enabled -}}
+{{- .Values.vendor.nvidia.dcgm.enabled | ternary "true" "" -}}
 {{- end }}
 
 {{/*

--- a/helm/slurm/tests/__snapshot__/controller_test.yaml.snap
+++ b/helm/slurm/tests/__snapshot__/controller_test.yaml.snap
@@ -11,8 +11,7 @@ manifest should match snapshot:
       name: test-release-slurm
       namespace: test-namespace
     spec:
-      epilogScriptRefs:
-        - name: test-release-slurm-epilog-dcgm
+      epilogScriptRefs: null
       epilogSlurmctldScriptRefs: null
       extraConf: PartitionName=all Nodes=ALL Default=YES MaxTime=UNLIMITED State=UP
       jwtKeyRef:
@@ -43,8 +42,7 @@ manifest should match snapshot:
         resources:
           requests:
             storage: 4Gi
-      prologScriptRefs:
-        - name: test-release-slurm-prolog-dcgm
+      prologScriptRefs: null
       prologSlurmctldScriptRefs: null
       reconfigure:
         image: ghcr.io/slinkyproject/slurmctld:v1.2.3

--- a/helm/slurm/tests/vendor_dcgm_test.yaml
+++ b/helm/slurm/tests/vendor_dcgm_test.yaml
@@ -1,8 +1,10 @@
 ---
-suite: test vendor nvidia dcgm configmaps
+suite: test vendor nvidia dcgm
 templates:
   - vendor/nvidia/dcgm/prolog-configmap.yaml
   - vendor/nvidia/dcgm/epilog-configmap.yaml
+  - controller/controller-cr.yaml
+  - nodeset/nodeset-cr.yaml
 release:
   name: test-release
   namespace: test-namespace
@@ -10,6 +12,7 @@ chart:
   version: 1.2.3
   appVersion: 1.2.3
 tests:
+# prolog-configmap
   - it: should render dcgm prolog configmap with correct metadata when enabled
     template: vendor/nvidia/dcgm/prolog-configmap.yaml
     set:
@@ -35,6 +38,7 @@ tests:
           path: metadata.labels["app.kubernetes.io/part-of"]
           value: slurm
 
+# epilog-configmap
   - it: should render dcgm epilog configmap with correct metadata when enabled
     template: vendor/nvidia/dcgm/epilog-configmap.yaml
     set:
@@ -74,3 +78,143 @@ tests:
       - equal:
           path: metadata.namespace
           value: custom-namespace
+
+  - it: should not render dcgm prolog configmap when disabled
+    template: vendor/nvidia/dcgm/prolog-configmap.yaml
+    set:
+      vendor:
+        nvidia:
+          dcgm:
+            enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render dcgm epilog configmap when disabled
+    template: vendor/nvidia/dcgm/epilog-configmap.yaml
+    set:
+      vendor:
+        nvidia:
+          dcgm:
+            enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+# controller-cr
+  - it: should not reference dcgm prolog/epilog scripts on controller when disabled
+    template: controller/controller-cr.yaml
+    set:
+      controller:
+        slurmctld:
+          image:
+            tag: v1.2.3
+        reconfigure:
+          image:
+            tag: v1.2.3
+      vendor:
+        nvidia:
+          dcgm:
+            enabled: false
+    asserts:
+      - isNullOrEmpty:
+          path: spec.prologScriptRefs
+      - isNullOrEmpty:
+          path: spec.epilogScriptRefs
+
+  - it: should reference dcgm prolog/epilog scripts on controller when enabled
+    template: controller/controller-cr.yaml
+    set:
+      controller:
+        slurmctld:
+          image:
+            tag: v1.2.3
+        reconfigure:
+          image:
+            tag: v1.2.3
+      vendor:
+        nvidia:
+          dcgm:
+            enabled: true
+    asserts:
+      - contains:
+          path: spec.prologScriptRefs
+          content:
+            name: test-release-slurm-prolog-dcgm
+      - contains:
+          path: spec.epilogScriptRefs
+          content:
+            name: test-release-slurm-epilog-dcgm
+
+# nodeset-cr
+  - it: should not mount dcgm job-mapping volume on nodeset when disabled
+    template: nodeset/nodeset-cr.yaml
+    set:
+      vendor:
+        nvidia:
+          dcgm:
+            enabled: false
+      nodesets:
+        slinky:
+          enabled: true
+          slurmd:
+            image:
+              tag: v1.2.3
+            resources:
+              limits:
+                nvidia.com/gpu: "8"
+    asserts:
+      - isNullOrEmpty:
+          path: spec.template.spec.volumes
+      - isNullOrEmpty:
+          path: spec.slurmd.volumeMounts
+
+  - it: should mount dcgm job-mapping volume on nodeset when enabled and GPUs are allocated
+    template: nodeset/nodeset-cr.yaml
+    set:
+      vendor:
+        nvidia:
+          dcgm:
+            enabled: true
+            jobMappingDir: /var/lib/dcgm-exporter/job-mapping
+      nodesets:
+        slinky:
+          enabled: true
+          slurmd:
+            image:
+              tag: v1.2.3
+            resources:
+              limits:
+                nvidia.com/gpu: "8"
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: dcgm-job-mapping
+            hostPath:
+              path: /var/lib/dcgm-exporter/job-mapping
+              type: DirectoryOrCreate
+      - contains:
+          path: spec.slurmd.volumeMounts
+          content:
+            name: dcgm-job-mapping
+            mountPath: /var/lib/dcgm-exporter/job-mapping
+
+  - it: should not mount dcgm job-mapping volume on nodeset when enabled but no GPUs allocated
+    template: nodeset/nodeset-cr.yaml
+    set:
+      vendor:
+        nvidia:
+          dcgm:
+            enabled: true
+      nodesets:
+        slinky:
+          enabled: true
+          slurmd:
+            image:
+              tag: v1.2.3
+    asserts:
+      - isNullOrEmpty:
+          path: spec.template.spec.volumes
+      - isNullOrEmpty:
+          path: spec.slurmd.volumeMounts


### PR DESCRIPTION
## Summary

Restore the `vendor.dcgm.enabled` helper so `dcgm.enabled: false` actually disables the DCGM integration.

Since [6f6668d](https://github.com/SlinkyProject/slurm-operator/commit/6f6668db87db59d4cbcbaf41876b6294137c5fb6) (`refactor(chart): use raw bool, not redundant ternary`) the helper emits the raw bool value of `.Values.vendor.nvidia.dcgm.enabled`. Because `include` always returns a string, a disabled value renders as the literal string `"false"` — which is truthy in Go templates. Every `{{- if (include "vendor.dcgm.enabled" .) }}` gate therefore evaluates true regardless of configuration, and DCGM resources are injected even when users set `dcgm.enabled: false`:

- `prologScriptRefs` / `epilogScriptRefs` on the Controller CR gain the DCGM prolog/epilog configmap references.
- Every GPU-requesting NodeSet gets the `dcgm-job-mapping` hostPath volume and its volumeMount appended.

The "redundant" ternary was actually doing essential string coercion (`"true"` / `""`), so this PR reverts the helper to that form and adds negative-path coverage for every `include "vendor.dcgm.enabled"` call site so the regression can't come back silently.

Closes: user reports of DCGM volume mounts appearing despite `dcgm.enabled: false`.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/SlinkyProject/slurm-operator/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/SlinkyProject/slurm-operator/blob/main/CODE_OF_CONDUCT.md).
- [x] New or existing tests cover these changes (where applicable).
- [x] Documentation is updated if user-visible behavior changes. (No user-facing docs change; values schema and defaults are unchanged.)

## Breaking Changes

N/A

## Testing Notes

Ran `helm unittest --strict ./helm/slurm` — **113/113 tests pass, 5/5 snapshots pass**.

Added 7 regression tests in `helm/slurm/tests/vendor_dcgm_test.yaml` covering every `include "vendor.dcgm.enabled"` consumer:

- prolog/epilog configmaps are not rendered when disabled
- controller `spec.prologScriptRefs` / `spec.epilogScriptRefs` are empty when disabled and populated when enabled
- nodeset `spec.template.spec.volumes` and `spec.slurmd.volumeMounts` do not contain `dcgm-job-mapping` when disabled
- nodeset correctly injects the volume + mount when enabled AND the nodeset requests `nvidia.com/gpu`
- nodeset does NOT inject the volume + mount when enabled but no GPUs are allocated (guards the `nodesetHasGPU` path)

Confirmed the new tests fail against the broken helper (4 assertions fail, reproducing the exact user-reported symptoms) and pass with the fix.

## Additional Context

The controller_test.yaml snapshot was captured after 6f6668d landed, so it had baked in the bug (DCGM script refs appearing in a manifest rendered with the default dcgm.enabled: false). Regenerating the snapshot as part of this PR removes those lines — which is itself a nice confirmation of the regression.