### PR TITLE
feat(helm): expose topologySpreadConstraints on operator and webhook

### DIFF
--- a/helm/slurm-operator/README.md
+++ b/helm/slurm-operator/README.md
@@ -63,6 +63,7 @@ Kubernetes: `>= 1.29.0-0`
 | operator.slurmclientWorkers | int | `2` | Set the max concurrent workers for the SlurmClient controller. |
 | operator.tokenWorkers | int | `4` | Set the max concurrent workers for the Token controller. |
 | operator.tolerations | list | `[]` | Tolerations for pod assignment. Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |
+| operator.topologySpreadConstraints | list | `[]` | Topology spread constraints for pod assignment. Prefer scheduling replicas across failure domains (nodes, zones, ...) when running in HA. Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/ |
 | priorityClassName | string | `""` | Set the priority class to use. Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass |
 | propagatedNodeConditions | list | `[]` | List of Kubernetes Node Conditions, by type, to propagate to the Slurm node drain reason. Ref: https://kubernetes.io/docs/reference/node/node-status/#condition |
 | webhook.affinity | object | `{}` | Affinity for pod assignment. Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity |
@@ -83,4 +84,5 @@ Kubernetes: `>= 1.29.0-0`
 | webhook.serviceAccount.name | string | `""` | Set the service account to use (and create). |
 | webhook.timeoutSeconds | int | `10` | Set the timeout period for calls. |
 | webhook.tolerations | list | `[]` | Tolerations for pod assignment. Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |
+| webhook.topologySpreadConstraints | list | `[]` | Topology spread constraints for pod assignment. Prefer scheduling replicas across failure domains (nodes, zones, ...) when running in HA. Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/ |
 

--- a/helm/slurm-operator/templates/operator/deployment.yaml
+++ b/helm/slurm-operator/templates/operator/deployment.yaml
@@ -104,4 +104,8 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}{{- /* with .Values.operator.tolerations */}}
+      {{- with .Values.operator.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}{{- /* with .Values.operator.topologySpreadConstraints */}}
 {{- end }}{{- /* if .Values.operator.enabled */}}

--- a/helm/slurm-operator/templates/webhook/deployment.yaml
+++ b/helm/slurm-operator/templates/webhook/deployment.yaml
@@ -82,6 +82,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}{{- /* with .Values.webhook.tolerations */}}
+      {{- with .Values.webhook.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}{{- /* with .Values.webhook.topologySpreadConstraints */}}
       volumes:
         - name: certificates
           secret:

--- a/helm/slurm-operator/tests/operator_deployment_test.yaml
+++ b/helm/slurm-operator/tests/operator_deployment_test.yaml
@@ -41,6 +41,27 @@ tests:
       - equal:
           path: spec.template.spec.tolerations[0].key
           value: test
+  - it: should add topologySpreadConstraints
+    set:
+      operator:
+        topologySpreadConstraints:
+          - maxSkew: 1
+            topologyKey: topology.kubernetes.io/zone
+            whenUnsatisfiable: ScheduleAnyway
+            labelSelector:
+              matchLabels:
+                foo: bar
+    asserts:
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].topologyKey
+          value: topology.kubernetes.io/zone
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].labelSelector.matchLabels.foo
+          value: bar
+  - it: should omit topologySpreadConstraints by default
+    asserts:
+      - notExists:
+          path: spec.template.spec.topologySpreadConstraints
   - it: should set imagePullSecrets
     set:
       imagePullSecrets:

--- a/helm/slurm-operator/tests/webhook_deployment_test.yaml
+++ b/helm/slurm-operator/tests/webhook_deployment_test.yaml
@@ -40,6 +40,27 @@ tests:
       - equal:
           path: spec.template.spec.tolerations[0].key
           value: test
+  - it: should add topologySpreadConstraints
+    set:
+      webhook:
+        topologySpreadConstraints:
+          - maxSkew: 1
+            topologyKey: topology.kubernetes.io/zone
+            whenUnsatisfiable: ScheduleAnyway
+            labelSelector:
+              matchLabels:
+                foo: bar
+    asserts:
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].topologyKey
+          value: topology.kubernetes.io/zone
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].labelSelector.matchLabels.foo
+          value: bar
+  - it: should omit topologySpreadConstraints by default
+    asserts:
+      - notExists:
+          path: spec.template.spec.topologySpreadConstraints
   - it: should set imagePullSecrets
     set:
       imagePullSecrets:

--- a/helm/slurm-operator/values.yaml
+++ b/helm/slurm-operator/values.yaml
@@ -54,6 +54,16 @@ operator:
     # - key: key1
     #   operator: Exists
     #   effect: NoSchedule
+  # -- Topology spread constraints for pod assignment. Prefer scheduling replicas
+  # across failure domains (nodes, zones, ...) when running in HA.
+  # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
+  topologySpreadConstraints: []
+    # - maxSkew: 1
+    #   topologyKey: topology.kubernetes.io/zone
+    #   whenUnsatisfiable: ScheduleAnyway
+    #   labelSelector:
+    #     matchLabels:
+    #       app.kubernetes.io/name: slurm-operator
   # -- The container resource limits and requests.
   # Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container
   resources: {}
@@ -126,6 +136,16 @@ webhook:
     # - key: key1
     #   operator: Exists
     #   effect: NoSchedule
+  # -- Topology spread constraints for pod assignment. Prefer scheduling replicas
+  # across failure domains (nodes, zones, ...) when running in HA.
+  # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
+  topologySpreadConstraints: []
+    # - maxSkew: 1
+    #   topologyKey: topology.kubernetes.io/zone
+    #   whenUnsatisfiable: ScheduleAnyway
+    #   labelSelector:
+    #     matchLabels:
+    #       app.kubernetes.io/name: slurm-operator-webhook
   # -- The container resource limits and requests.
   # Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container
   resources: {}


### PR DESCRIPTION
## Summary

The `slurm-operator` chart surfaced `affinity` and `tolerations` on both the operator and webhook Deployments, but not `topologySpreadConstraints`. With `replicas > 1` and leader election enabled, Kubernetes was free to schedule every replica onto the same node or zone, which undermines the HA story the chart otherwise enables.

The sibling `slurm` chart already plumbs `topologySpreadConstraints` through its component pod specs (controller, login, accounting, etc.), so this brings the `slurm-operator` chart to feature parity.

Changes:

- `helm/slurm-operator/values.yaml`: add opt-in `operator.topologySpreadConstraints` and `webhook.topologySpreadConstraints` keys (default `[]`) with inline commentary and an example zone-spread block.
- `helm/slurm-operator/templates/operator/deployment.yaml` and `helm/slurm-operator/templates/webhook/deployment.yaml`: render a `topologySpreadConstraints:` block via `{{- with ... }}` right after the existing `tolerations` block, so output is byte-identical when the value is left at its default.
- `helm/slurm-operator/tests/operator_deployment_test.yaml` and `helm/slurm-operator/tests/webhook_deployment_test.yaml`: add a positive rendering case and a `notExists` default-off case per suite.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/SlinkyProject/slurm-operator/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/SlinkyProject/slurm-operator/blob/main/CODE_OF_CONDUCT.md).
- [x] New or existing tests cover these changes (where applicable).
- [x] Documentation is updated if user-visible behavior changes. (Values docs updated inline; no user-facing README changes needed since the new keys are opt-in and documented where all other scheduling hints live.)

## Breaking Changes

None. Both new keys default to `[]`, which keeps the rendered YAML byte-identical for existing installs. All pre-existing `helm-unittest` snapshot tests still match without updates.

## Testing Notes

```
helm lint helm/slurm-operator
helm unittest helm/slurm-operator
helm template helm/slurm-operator \
  --set operator.topologySpreadConstraints[0].maxSkew=1 \
  --set operator.topologySpreadConstraints[0].topologyKey=topology.kubernetes.io/zone \
  --set operator.topologySpreadConstraints[0].whenUnsatisfiable=ScheduleAnyway \
  --set operator.topologySpreadConstraints[0].labelSelector.matchLabels."app\.kubernetes\.io/name"=slurm-operator
```

All three commands succeed, snapshots are unchanged, and the `topologySpreadConstraints` block appears on the rendered Deployment only when the new value is set.

## Additional Context

The chart already exposes `nodeSelector`, `affinity`, and `tolerations` on the same Deployments, so `topologySpreadConstraints` was the only scheduling primitive missing. This is intentionally a minimal, additive change; no defaults are altered.