### PR TITLE
fix(builder): honor service.nodePort for restapi, controller, accounting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in version specific
 files.
 
+- [CHANGELOG-1.2.md](./CHANGELOG/CHANGELOG-1.2.md)
 - [CHANGELOG-1.1.md](./CHANGELOG/CHANGELOG-1.1.md)
 - [CHANGELOG-1.0.md](./CHANGELOG/CHANGELOG-1.0.md)
 - [CHANGELOG-0.4.md](./CHANGELOG/CHANGELOG-0.4.md)

--- a/CHANGELOG/CHANGELOG-1.2.md
+++ b/CHANGELOG/CHANGELOG-1.2.md
@@ -1,0 +1,5 @@
+## v1.2.0
+
+### Fixed
+
+- Honor `service.nodePort` on RestApi, Controller, and Accounting CRs.

--- a/internal/builder/accountingbuilder/accounting_service.go
+++ b/internal/builder/accountingbuilder/accounting_service.go
@@ -32,6 +32,7 @@ func (b *AccountingBuilder) BuildAccountingService(accounting *slinkyv1beta1.Acc
 		Protocol:   corev1.ProtocolTCP,
 		Port:       common.DefaultPort(int32(spec.Port), common.SlurmdbdPort),
 		TargetPort: intstr.FromString(labels.AccountingApp),
+		NodePort:   int32(spec.NodePort),
 	}
 	opts.Ports = append(opts.Ports, port)
 

--- a/internal/builder/accountingbuilder/accounting_service_test.go
+++ b/internal/builder/accountingbuilder/accounting_service_test.go
@@ -14,6 +14,38 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+func TestBuilder_BuildAccountingService_NodePort(t *testing.T) {
+	const want int32 = 30819
+	c := fake.NewClientBuilder().
+		WithObjects(&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "mariadb"},
+			Data:       map[string][]byte{"password": []byte("mariadb-password")},
+		}).
+		Build()
+	accounting := &slinkyv1beta1.Accounting{
+		ObjectMeta: metav1.ObjectMeta{Name: "slurm"},
+		Spec: slinkyv1beta1.AccountingSpec{
+			JwtKeyRef: &corev1.SecretKeySelector{},
+			StorageConfig: slinkyv1beta1.StorageConfig{
+				PasswordKeyRef: corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: "mariadb"},
+					Key:                  "password",
+				},
+			},
+			Service: slinkyv1beta1.ServiceSpec{
+				NodePort: int(want),
+			},
+		},
+	}
+	got, err := New(c).BuildAccountingService(accounting)
+	if err != nil {
+		t.Fatalf("BuildAccountingService() error = %v", err)
+	}
+	if got.Spec.Ports[0].NodePort != want {
+		t.Errorf("Ports[0].NodePort = %d, want %d", got.Spec.Ports[0].NodePort, want)
+	}
+}
+
 func TestBuilder_BuildAccountingService(t *testing.T) {
 	type fields struct {
 		client client.Client

--- a/internal/builder/controllerbuilder/controller_service.go
+++ b/internal/builder/controllerbuilder/controller_service.go
@@ -34,6 +34,7 @@ func (b *ControllerBuilder) BuildControllerService(controller *slinkyv1beta1.Con
 		Protocol:   corev1.ProtocolTCP,
 		Port:       common.DefaultPort(int32(spec.Port), common.SlurmctldPort),
 		TargetPort: intstr.FromString(labels.ControllerApp),
+		NodePort:   int32(spec.NodePort),
 	}
 	opts.Ports = append(opts.Ports, port)
 

--- a/internal/builder/controllerbuilder/controller_service_test.go
+++ b/internal/builder/controllerbuilder/controller_service_test.go
@@ -14,6 +14,26 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+func TestBuilder_BuildControllerService_NodePort(t *testing.T) {
+	const want int32 = 30817
+	controller := &slinkyv1beta1.Controller{
+		ObjectMeta: metav1.ObjectMeta{Name: "slurm"},
+		Spec: slinkyv1beta1.ControllerSpec{
+			JwtKeyRef: &corev1.SecretKeySelector{},
+			Service: slinkyv1beta1.ServiceSpec{
+				NodePort: int(want),
+			},
+		},
+	}
+	got, err := New(fake.NewFakeClient()).BuildControllerService(controller)
+	if err != nil {
+		t.Fatalf("BuildControllerService() error = %v", err)
+	}
+	if got.Spec.Ports[0].NodePort != want {
+		t.Errorf("Ports[0].NodePort = %d, want %d", got.Spec.Ports[0].NodePort, want)
+	}
+}
+
 func TestBuilder_BuildControllerService(t *testing.T) {
 	type fields struct {
 		client client.Client

--- a/internal/builder/restapibuilder/restapi_service.go
+++ b/internal/builder/restapibuilder/restapi_service.go
@@ -31,6 +31,7 @@ func (b *RestapiBuilder) BuildRestapiService(restapi *slinkyv1beta1.RestApi) (*c
 		Protocol:   corev1.ProtocolTCP,
 		Port:       common.DefaultPort(int32(spec.Port), SlurmrestdPort),
 		TargetPort: intstr.FromString(labels.RestapiApp),
+		NodePort:   int32(spec.NodePort),
 	}
 	opts.Ports = append(opts.Ports, port)
 

--- a/internal/builder/restapibuilder/restapi_service_test.go
+++ b/internal/builder/restapibuilder/restapi_service_test.go
@@ -14,6 +14,31 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+func TestBuilder_BuildRestapiService_NodePort(t *testing.T) {
+	const want int32 = 30820
+	c := fake.NewClientBuilder().
+		WithObjects(&slinkyv1beta1.Controller{
+			ObjectMeta: metav1.ObjectMeta{Name: "slurm"},
+		}).
+		Build()
+	restapi := &slinkyv1beta1.RestApi{
+		ObjectMeta: metav1.ObjectMeta{Name: "slurm"},
+		Spec: slinkyv1beta1.RestApiSpec{
+			ControllerRef: slinkyv1beta1.ObjectReference{Name: "slurm"},
+			Service: slinkyv1beta1.ServiceSpec{
+				NodePort: int(want),
+			},
+		},
+	}
+	got, err := New(c).BuildRestapiService(restapi)
+	if err != nil {
+		t.Fatalf("BuildRestapiService() error = %v", err)
+	}
+	if got.Spec.Ports[0].NodePort != want {
+		t.Errorf("Ports[0].NodePort = %d, want %d", got.Spec.Ports[0].NodePort, want)
+	}
+}
+
 func TestBuilder_BuildRestapiService(t *testing.T) {
 	type fields struct {
 		client client.Client


### PR DESCRIPTION
The chart documents `restapi.service.nodePort`, `controller.service.nodePort`, and `accounting.service.nodePort` (helm/slurm/values.yaml lines 297, 397, 509), but the corresponding ServicePort builders never set NodePort. Setting the field in helm values made it through to the CR's spec.service.nodePort, but the operator silently dropped it when building the Service — kube-apiserver then auto-allocated a random port, and the field was effectively a no-op.

Mirror the pattern already used by loginbuilder/login_service.go: pass spec.NodePort through to the corev1.ServicePort. Add a focused unit test per builder that asserts the propagation.

loginbuilder/login_service.go already has this; loginsets.slinky.service.nodePort in helm values has always worked.

<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->

<!--
Feature requests, code contributions, and bug reports are welcome!
GitHub issues and pull requests are handled on a best-effort basis.
The SchedMD official issue tracker is at <https://support.schedmd.com/>.
-->

## Summary

<!--
Describe what this is for and why it is needed.
Link relevant issues which this addresses (e.g. closes #123).
-->

## Checklist

- [x] I have read
  [CONTRIBUTING.md](https://github.com/SlinkyProject/slurm-operator/blob/main/CONTRIBUTING.md)
  and the
  [Code of Conduct](https://github.com/SlinkyProject/slurm-operator/blob/main/CODE_OF_CONDUCT.md).
- [x] New or existing tests cover these changes (where applicable).
- [ ] Documentation is updated if user-visible behavior changes.

## Breaking Changes

<!--
Does this cause any breaking changes to users?
Explain why the breakage has to happen.
-->

## Testing Notes

<!--
How to test this change.
-->

## Additional Context

<!--
Any other context for reviewers.
-->
