### PR TITLE
fix(slurmclient): handle missing RestApi gracefully

### DIFF
--- a/internal/controller/slurmclient/slurmclient_controller_test.go
+++ b/internal/controller/slurmclient/slurmclient_controller_test.go
@@ -76,5 +76,43 @@ var _ = Describe("SlurmClient Controller", func() {
 				g.Expect(slurmClient).Should(BeNil())
 			}, testutils.Timeout, testutils.Interval).Should(Succeed())
 		}, SpecTimeout(testutils.Timeout))
+
+		It("Should remove the Slurm Client when its RestApi is deleted but Controller remains", func(ctx SpecContext) {
+			controllerKey := client.ObjectKeyFromObject(controller)
+
+			By("Simulating RestApi Deployment Ready Status")
+			restapiDeploymentKey := restapi.Key()
+			createdDeployment := &appsv1.Deployment{}
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, restapiDeploymentKey, createdDeployment)).To(Succeed())
+				createdDeployment.Status.Replicas = 1
+				createdDeployment.Status.ReadyReplicas = 1
+				g.Expect(k8sClient.Status().Update(ctx, createdDeployment)).To(Succeed())
+			}, testutils.Timeout, testutils.Interval).Should(Succeed())
+
+			By("Creating Slurm Client")
+			Eventually(func(g Gomega) {
+				g.Expect(clientMap.Get(controllerKey)).ShouldNot(BeNil())
+			}, testutils.Timeout, testutils.Interval).Should(Succeed())
+
+			By("Deleting RestApi but leaving Controller in place")
+			Expect(k8sClient.Delete(ctx, restapi.DeepCopy())).To(Succeed())
+
+			By("Touching Controller to trigger a reconcile")
+			Eventually(func(g Gomega) {
+				fresh := &slinkyv1beta1.Controller{}
+				g.Expect(k8sClient.Get(ctx, controllerKey, fresh)).To(Succeed())
+				if fresh.Annotations == nil {
+					fresh.Annotations = map[string]string{}
+				}
+				fresh.Annotations["test.slinky.slurm.net/touch"] = "1"
+				g.Expect(k8sClient.Update(ctx, fresh)).To(Succeed())
+			}, testutils.Timeout, testutils.Interval).Should(Succeed())
+
+			By("Removing Slurm Client")
+			Eventually(func(g Gomega) {
+				g.Expect(clientMap.Get(controllerKey)).Should(BeNil())
+			}, testutils.Timeout, testutils.Interval).Should(Succeed())
+		}, SpecTimeout(testutils.Timeout))
 	})
 })

--- a/internal/controller/slurmclient/slurmclient_sync.go
+++ b/internal/controller/slurmclient/slurmclient_sync.go
@@ -5,9 +5,7 @@ package slurmclient
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"net/http"
 	"os"
 	"time"
 
@@ -40,15 +38,17 @@ func (r *SlurmClientReconciler) Sync(ctx context.Context, req reconcile.Request)
 	}
 	controllerKey := client.ObjectKeyFromObject(controller)
 
-	server, err := r.getRestApiServer(ctx, controller)
+	restapiList, err := r.refResolver.GetRestapisForController(ctx, controller)
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			_ = r.ClientMap.Remove(controllerKey)
-			durationStore.Push(controllerKey.String(), 10*time.Second)
-			return nil
-		}
 		return err
 	}
+	if len(restapiList.Items) == 0 {
+		logger.Info("No RestApi bound to Controller, removing slurm client", "controller", controllerKey)
+		_ = r.ClientMap.Remove(controllerKey)
+		durationStore.Push(controllerKey.String(), 10*time.Second)
+		return nil
+	}
+	server := r.getRestApiServer(ctx, &restapiList.Items[0])
 
 	signingKey, err := r.refResolver.GetSecretKeyRef(ctx, controller.AuthJwtRef(), controller.Namespace)
 	if err != nil {
@@ -106,22 +106,11 @@ func (r *SlurmClientReconciler) Sync(ctx context.Context, req reconcile.Request)
 	return nil
 }
 
-func (r *SlurmClientReconciler) getRestApiServer(ctx context.Context, controller *slinkyv1beta1.Controller) (string, error) {
-	logger := log.FromContext(ctx)
-
-	restapiList, err := r.refResolver.GetRestapisForController(ctx, controller)
-	if err != nil {
-		return "", err
-	}
-	if len(restapiList.Items) == 0 {
-		return "", errors.New(http.StatusText(http.StatusNotFound))
-	}
-
-	server := fmt.Sprintf("http://%s:%d", restapiList.Items[0].ServiceFQDNShort(), builder.SlurmrestdPort)
+func (r *SlurmClientReconciler) getRestApiServer(ctx context.Context, restapi *slinkyv1beta1.RestApi) string {
+	server := fmt.Sprintf("http://%s:%d", restapi.ServiceFQDNShort(), builder.SlurmrestdPort)
 	if val := os.Getenv("DEBUG"); val == "1" {
-		logger.Info("overriding restapi URL with localhost")
+		log.FromContext(ctx).Info("overriding restapi URL with localhost")
 		server = fmt.Sprintf("http://localhost:%d", builder.SlurmrestdPort)
 	}
-
-	return server, nil
+	return server
 }


### PR DESCRIPTION
## Summary

Fixes a dead `apierrors.IsNotFound` branch in `SlurmClientReconciler.Sync` that was unreachable because the producer (`getRestApiServer`) returned a plain `errors.New(http.StatusText(http.StatusNotFound))`. `apierrors.IsNotFound` only recognises errors that implement (or wrap, via `errors.As`) `apimachinery`'s `APIStatus` interface; a plain `errors.New(...)` does not.

When a `Controller` exists but no `RestApi` is bound to it, the intended graceful path — drop the cached slurm client + requeue in 10 s — never ran. The reconcile errored out and went to controller-runtime's exponential backoff instead, leaving the cached `slurm.Client` (and its background goroutine started by `ClientMap.add`) alive against a server that no longer exists.

The fix moves the empty-list check into `Sync` and treats "no RestApi bound" as a normal business state rather than an error to be unwrapped. `getRestApiServer` collapses into a small URL builder taking `*RestApi`. This shape mirrors the rest of the codebase: `RefResolver` already returns `&XList{}, nil` rather than synthesising a not-found error, and the existing graceful-exit pattern across `accounting_sync.go`, `token_sync.go`, `nodeset_sync.go` only uses `apierrors.IsNotFound` against real `*StatusError`s from `r.Get`. (Option A — typed sentinel + `errors.Is` — was considered and rejected: zero precedent in production code.)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/SlinkyProject/slurm-operator/blob/main/CONTRIBUTING.md).
- [x] I have read the [Code of Conduct](https://github.com/SlinkyProject/slurm-operator/blob/main/CODE_OF_CONDUCT.md).
- [x] New or existing tests cover these changes (where applicable).
- [x] Documentation is updated if user-visible behavior changes.

## Breaking Changes

N/A

## Testing Notes

```sh
go test ./internal/controller/slurmclient/... -count=1
make golangci-lint
```

The new test (`Should remove the Slurm Client when its RestApi is deleted but Controller remains`) exercises the previously-dead "empty list" path end-to-end:

1. Bring up Controller + RestApi, wait for the slurm client to land in `ClientMap`.
2. Delete the RestApi, leaving the Controller in place.
3. Touch the Controller (annotation update) to force a reconcile — see "Additional Context" for why this is needed.
4. Assert the slurm client is removed from `ClientMap`.

## Additional Context

While writing the regression test I noticed `SlurmClientReconciler.SetupWithManager` only watches `&slinkyv1beta1.Controller{}`. Deleting a `RestApi` with the `Controller` still alive does not trigger a reconcile on its own — the graceful path now works but only fires when something else nudges the reconciler (the 12-min token-refresh requeue, in practice). This is **pre-existing** and out of scope here, but it does mean the fix takes up to 12 minutes to be visible in production today. Suggested follow-up: add `.Watches(&slinkyv1beta1.RestApi{}, handler.EnqueueRequestsFromMapFunc(...))` so RestApi deletion enqueues the owning Controller promptly. Happy to open a sibling PR for that.

A second pre-existing observation, also for a follow-up: `restapiList.Items[0]` silently picks the first match if multiple `RestApi`s point at the same `Controller`. Not introduced here; same behaviour as the original code. A `len(...) > 1` warning log would be a nice belt-and-suspenders addition.
