### PR TITLE
Expose nodeSelector for operator and webhook

### DIFF
--- a/helm/slurm-operator/README.md
+++ b/helm/slurm-operator/README.md
@@ -52,6 +52,7 @@ Kubernetes: `>= 1.29.0-0`
 | operator.loginsetWorkers | int | `4` | Set the max concurrent workers for the LoginSet controller. |
 | operator.metricsPort | int | `8080` | Set the port used by the metrics server. Value of "0" will disable it. |
 | operator.namespaces | string | `""` | Comma-separated list of namespaces the operator will watch. If empty, all namespaces are watched. |
+| operator.nodeSelector | object | `{}` | Node label selector for pod assignment. Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector |
 | operator.nodesetWorkers | int | `4` | Set the max concurrent workers for the NodeSet controller. |
 | operator.pdb.enabled | bool | `false` | Enable PodDisruptionBudget. |
 | operator.pdb.minAvailable | int | `1` | Minimum number of pods that must still be available after eviction. Can be an absolute number (ex: 5) or a percentage (ex: 25%). |
@@ -74,6 +75,7 @@ Kubernetes: `>= 1.29.0-0`
 | webhook.logLevel | string | `"info"` | Set the log level by string (e.g. error, info, debug) or number (e.g. 1..5). |
 | webhook.metricsPort | int | `0` | Set the port used by the metrics server. Value of "0" will disable it. |
 | webhook.namespaces | string | `""` | Comma-separated list of namespaces the webhook will watch. If empty, all namespaces are watched. |
+| webhook.nodeSelector | object | `{}` | Node label selector for pod assignment. Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector |
 | webhook.pdb.enabled | bool | `false` | Enable PodDisruptionBudget. |
 | webhook.pdb.minAvailable | int | `1` | Minimum number of pods that must still be available after eviction. Can be an absolute number (ex: 5) or a percentage (ex: 25%). |
 | webhook.replicas | int | `1` | Set the number of replicas to deploy. |

--- a/helm/slurm-operator/templates/operator/deployment.yaml
+++ b/helm/slurm-operator/templates/operator/deployment.yaml
@@ -96,6 +96,10 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+      {{- with .Values.operator.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}{{- /* with .Values.operator.nodeSelector */}}
       {{- with .Values.operator.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/helm/slurm-operator/templates/webhook/deployment.yaml
+++ b/helm/slurm-operator/templates/webhook/deployment.yaml
@@ -74,6 +74,10 @@ spec:
             - name: certificates
               mountPath: /tmp/k8s-webhook-server/serving-certs/
               readOnly: true
+      {{- with .Values.webhook.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}{{- /* with .Values.webhook.nodeSelector */}}
       {{- with .Values.webhook.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/helm/slurm-operator/tests/operator_deployment_test.yaml
+++ b/helm/slurm-operator/tests/operator_deployment_test.yaml
@@ -13,6 +13,15 @@ tests:
   - it: manifest should match snapshot
     asserts:
       - matchSnapshot: {}
+  - it: should add nodeSelector
+    set:
+      operator:
+        nodeSelector:
+          kubernetes.io/os: linux
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector["kubernetes.io/os"]
+          value: linux
   - it: should add affinity
     set:
       operator:

--- a/helm/slurm-operator/tests/webhook_deployment_test.yaml
+++ b/helm/slurm-operator/tests/webhook_deployment_test.yaml
@@ -12,6 +12,15 @@ tests:
   - it: manifest should match snapshot
     asserts:
       - matchSnapshot: {}
+  - it: should add nodeSelector
+    set:
+      webhook:
+        nodeSelector:
+          kubernetes.io/os: linux
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector["kubernetes.io/os"]
+          value: linux
   - it: should add affinity
     set:
       webhook:

--- a/helm/slurm-operator/values.yaml
+++ b/helm/slurm-operator/values.yaml
@@ -45,6 +45,10 @@ operator:
     create: true
     # -- Set the service account to use (and create).
     name: ""
+  # -- Node label selector for pod assignment.
+  # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+  nodeSelector: {}
+    # kubernetes.io/os: linux
   # -- Affinity for pod assignment.
   # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
   affinity: {}
@@ -117,6 +121,10 @@ webhook:
     name: ""
   # -- Set the timeout period for calls.
   timeoutSeconds: 10
+  # -- Node label selector for pod assignment.
+  # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+  nodeSelector: {}
+    # kubernetes.io/os: linux
   # -- Affinity for pod assignment.
   # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
   affinity: {}


### PR DESCRIPTION
## Summary

The Helm chart did not document or wire `nodeSelector` for either the operator or webhook Deployment. Helm parsed `--set operator.nodeSelector.foo=bar` (and the webhook equivalent) into `.Values` without complaint and silently dropped the value at render time, since no template referenced it and the chart has no `values.schema.json` for validation.

This PR wires `.Values.operator.nodeSelector` and `.Values.webhook.nodeSelector` through `templates/operator/deployment.yaml` and `templates/webhook/deployment.yaml` using the same `{{- with ... }}` / `toYaml | nindent 8` idiom already used for `affinity` and `tolerations`, documents the field in `values.yaml` with wording aligned to the sibling `helm/slurm` chart, regenerates the matching rows in the values table of `helm/slurm-operator/README.md`, and adds helm-unittest cases that assert the rendered field for both deployments.

### Reproduction

    helm template slinky-slurm-op helm/slurm-operator \
      --set operator.nodeSelector.foo=bar \
      --set webhook.nodeSelector.baz=qux | grep nodeSelector
    # (no output — value silently dropped)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/SlinkyProject/slurm-operator/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/SlinkyProject/slurm-operator/blob/main/CODE_OF_CONDUCT.md).
- [x] New or existing tests cover these changes (where applicable).
- [x] Documentation is updated if user-visible behavior changes.

## Breaking Changes

Not a breaking API change — `nodeSelector` was never a documented or supported field on either deployment, and default renders are unchanged (the field is omitted unless the user sets it).

There is a latent behavior change worth flagging: any operator who had been setting `operator.nodeSelector` or `webhook.nodeSelector` in their values file under the assumption it was being honored will now see the constraint take effect. They should verify their value does not pin pods to nodes that no longer match.

## Testing Notes

The new helm-unittest cases (`should add nodeSelector`) sit alongside the existing `should add affinity` / `should add tolerations` tests in both `tests/operator_deployment_test.yaml` and `tests/webhook_deployment_test.yaml`, following the same shape and depth.
