### PR TITLE
fix(webhook): limit pod binding webhook scope

### DIFF
--- a/helm/slurm-operator/templates/webhook/webhook.yaml
+++ b/helm/slurm-operator/templates/webhook/webhook.yaml
@@ -263,6 +263,9 @@ webhooks:
           values:
             - kube-system
             - {{ include "slurm-operator.namespace" . }}
+    objectSelector:
+      matchLabels:
+        app.kubernetes.io/name: slurmd
     admissionReviewVersions:
       - v1
     clientConfig:

--- a/helm/slurm-operator/tests/webhook_webhook_test.yaml
+++ b/helm/slurm-operator/tests/webhook_webhook_test.yaml
@@ -87,6 +87,9 @@ tests:
       - equal:
           path: webhooks[0].rules[0].resources[0]
           value: pods/binding
+      - equal:
+          path: webhooks[0].objectSelector.matchLabels["app.kubernetes.io/name"]
+          value: slurmd
 
   - it: should include cert-manager annotations when certManager is enabled
     documentSelector:

--- a/internal/webhook/pod_binding_webhook.go
+++ b/internal/webhook/pod_binding_webhook.go
@@ -37,6 +37,8 @@ func (r *PodBindingWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;update;patch;watch
 // +kubebuilder:rbac:groups="",resources=pods/binding,verbs=get;list;watch
 // +kubebuilder:webhook:path=/mutate--v1-binding,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,sideEffects=None,groups="",resources=pods/binding,verbs=create,versions=v1,name=podsbinding-v1.kb.io,admissionReviewVersions=v1
+// NOTE: objectSelector (matchLabels: app.kubernetes.io/name=slurmd) is manually
+// maintained in config/webhook/manifests.yaml and helm template.
 
 var _ admission.Defaulter[*corev1.Binding] = &PodBindingWebhook{}
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->

<!--
Feature requests, code contributions, and bug reports are welcome!
GitHub issues and pull requests are handled on a best-effort basis.
The SchedMD official issue tracker is at <https://support.schedmd.com/>.
-->

## Summary

Limit the scope of the `podsbinding-v1.kb.io` mutating webhook by adding an `objectSelector` that matches only Slurm worker Pods labeled with `app.kubernetes.io/name: slurmd`.

This prevents the webhook from being invoked for unrelated Pods during Pod binding admission.

Addresses #189.

**Changes:**

1. Add `objectSelector` to the `podsbinding-v1.kb.io` webhook in the Helm template:

   ```yaml
   objectSelector:
     matchLabels:
       app.kubernetes.io/name: slurmd
   ```

2. Add a Helm unit test to verify the `objectSelector` is rendered for the Pod binding webhook.

3. Keep the existing Go-level filtering as a defensive fallback.

**Why this is needed:**

The current webhook is registered for `pods/binding`, so Pod binding requests can reach the webhook before the Go handler filters out non-worker Pods.

Although the Go handler already returns early for non-worker Pods, the request still has to reach the webhook service first. If the webhook service is temporarily unreachable during cluster or node reboot scenarios, unrelated Pod scheduling can be affected.

Adding an admission-level `objectSelector` prevents non-Slurm Pods from invoking the webhook in the first place, reducing the webhook's blast radius while preserving the existing `failurePolicy: Fail` behavior.

## Checklist

* [x] I have read
  [CONTRIBUTING.md](https://github.com/SlinkyProject/slurm-operator/blob/main/CONTRIBUTING.md)
  and the
  [Code of Conduct](https://github.com/SlinkyProject/slurm-operator/blob/main/CODE_OF_CONDUCT.md).
* [x] New or existing tests cover these changes (where applicable).
* [x] Documentation is updated if user-visible behavior changes.

## Breaking Changes

None.

This PR does not change the webhook `failurePolicy`; it remains `Fail`.

## Testing Notes

1. **Generate manifests:**

   ```bash
   make manifests
   ```

2. **Generate Helm docs:**

   ```bash
   make helm-docs
   ```

3. **Validate Helm chart:**

   ```bash
   make helm-validate
   ```

4. **Run Helm unit tests:**

   ```bash
   make helm-unittest
   ```

5. **Run Go tests:**

   ```bash
   make test
   ```

   Result:

   ```text
   total: (statements) 75.6%
   go tool cover -html cover.out -o cover.html
   ```

6. **Run pre-commit checks:**

   ```bash
   pre-commit run --all-files
   ```

7. **Verify Helm template rendering:**

   ```bash
   helm template slurm-operator ./helm/slurm-operator | grep -A5 "objectSelector"
   ```

   Expected output includes:

   ```yaml
   objectSelector:
     matchLabels:
       app.kubernetes.io/name: slurmd
   ```

## Additional Context

The related issue describes a cluster or node reboot scenario where the webhook Service can become temporarily unreachable while the cluster networking stack is recovering. With the previous configuration, the `pods/binding` webhook could be invoked for Pods outside of Slurm worker Pods, increasing the blast radius of that temporary webhook unavailability.

The Go handler at `internal/webhook/pod_binding_webhook.go` already filters non-worker Pods with an early `return nil`. This PR moves that filtering boundary earlier, from webhook handler logic to Kubernetes admission selection.

The Go-level check is preserved as a safety net.

Related discussion and full deadlock analysis: #189
