### PR TITLE
fix(controller): include Gres= from NodeSet ExtraConf in slurm.conf N…

### DIFF
--- a/internal/builder/controllerbuilder/controller_config.go
+++ b/internal/builder/controllerbuilder/controller_config.go
@@ -347,6 +347,15 @@ func buildNodeSetConf(nodesetList *slinkyv1beta1.NodeSetList) string {
 			fmt.Sprintf("NodeSet=%v", name),
 			fmt.Sprintf("Feature=%v", name),
 		}
+		// Include Gres= from ExtraConf so that slurmctld initializes GRES
+		// correctly on the CREATE path (first-time node registration).
+		// Without this, new DYNAMIC_NORM nodes get Gres=(null) because
+		// slurmctld falls back to the NodeSet definition, which has no Gres=.
+		for _, field := range strings.Fields(nodeset.Spec.ExtraConf) {
+			if strings.HasPrefix(strings.ToLower(field), "gres=") {
+				nodesetLine = append(nodesetLine, field)
+			}
+		}
 		nodesetLineRendered := strings.Join(nodesetLine, " ")
 		conf.AddProperty(config.NewPropertyRaw(nodesetLineRendered))
 		partition := nodeset.Spec.Partition

--- a/internal/builder/controllerbuilder/controller_config_test.go
+++ b/internal/builder/controllerbuilder/controller_config_test.go
@@ -452,6 +452,26 @@ func Test_buildNodeSetConf(t *testing.T) {
 			want: "",
 		},
 		{
+			name: "gres-in-extraconf",
+			nodesetList: &slinkyv1beta1.NodeSetList{
+				Items: []slinkyv1beta1.NodeSet{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: metav1.NamespaceDefault,
+							Name:      "nodeset-gpu",
+						},
+						Spec: slinkyv1beta1.NodeSetSpec{
+							ExtraConf: "Gres=gpu:h100:8",
+							Partition: slinkyv1beta1.NodeSetPartition{
+								Enabled: false,
+							},
+						},
+					},
+				},
+			},
+			want: `NodeSet=nodeset-gpu Feature=nodeset-gpu Gres=gpu:h100:8`,
+		},
+		{
 			name: "non-empty",
 			nodesetList: &slinkyv1beta1.NodeSetList{
 				Items: []slinkyv1beta1.NodeSet{


### PR DESCRIPTION

<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->

<!--
Feature requests, code contributions, and bug reports are welcome!
GitHub issues and pull requests are handled on a best-effort basis.
The SchedMD official issue tracker is at <https://support.schedmd.com/>.
-->

## Summary

### Problem

 On GPU clusters, slurmd pods occasionally register with Gres=(null) in slurmctld, making the node unusable for GPU workloads.

###  Root cause: 

Slurm has two node registration paths:

  - CREATE path — triggered when a node registers with slurmctld for the first time (no prior record). slurmctld initializes GRES from the NodeSet= line in slurm.conf.
  - UPDATE path — triggered when a node re-registers and a record already exists. slurmctld accepts GRES directly from slurmd's NVML hardware detection.

  buildNodeSetConf generates NodeSet lines as:
  NodeSet=foo Feature=foo

  Gres= is present in NodeSet.Spec.ExtraConf (e.g. Gres=gpu:h100:8) and correctly passed to slurmd's --conf flag, but it was never included in the slurm.conf NodeSet= line. So on the CREATE path, slurmctld sees no Gres= in the NodeSet definition and initializes the node with Gres=(null).

 This only affects first-time registrations. Restarted pods (UPDATE path) report the correct GRES from NVML.

  ### Fix

  Append any Gres= fields from NodeSet.Spec.ExtraConf to the generated NodeSet= line:
  NodeSet=foo Feature=foo Gres=gpu:h100:8

  With this, slurmctld correctly initializes GRES on both the CREATE and UPDATE paths.


  
## Checklist

- [x] I have read
  [CONTRIBUTING.md](https://github.com/SlinkyProject/slurm-operator/blob/main/CONTRIBUTING.md)
  and the
  [Code of Conduct](https://github.com/SlinkyProject/slurm-operator/blob/main/CODE_OF_CONDUCT.md).
- [x] New or existing tests cover these changes (where applicable).
- [ ] Documentation is updated if user-visible behavior changes.

## Breaking Changes

<!--
Does this cause any breaking changes to users?
Explain why the breakage has to happen.
-->

No

## Testing Notes

Added a test case to Test_buildNodeSetConf covering a NodeSet with ExtraConf: "Gres=gpu:h100:8", verifying the field appears in the generated NodeSet line.


## Additional Context

<!--
Any other context for reviewers.
-->
