### PR TITLE
fix(webhook): replace objectSelector with namespaceSelector filtering to prevent webhook deadlock (#189)

### DIFF
--- a/helm/slurm-operator/README.md
+++ b/helm/slurm-operator/README.md
@@ -77,6 +77,7 @@ Kubernetes: `>= 1.29.0-0`
 | webhook.namespaces | string | `""` | Comma-separated list of namespaces the webhook will watch. If empty, all namespaces are watched. |
 | webhook.pdb.enabled | bool | `false` | Enable PodDisruptionBudget. |
 | webhook.pdb.minAvailable | int | `1` | Minimum number of pods that must still be available after eviction. Can be an absolute number (ex: 5) or a percentage (ex: 25%). |
+| webhook.podBinding.includedNamespaces | list | `[]` | List of namespaces to include for the pod binding webhook. When set, only pod bindings in these namespaces will be intercepted. This reduces the webhook's blast radius and prevents deadlocks during cluster reboot by limiting scope to namespaces where Slurm clusters run. Example: ["slurm", "slurm-prod"] |
 | webhook.replicas | int | `1` | Set the number of replicas to deploy. |
 | webhook.resources | object | `{}` | The container resource limits and requests. Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container |
 | webhook.serverPort | int | `9443` | Set the port used for the webhook server |

--- a/helm/slurm-operator/templates/webhook/webhook.yaml
+++ b/helm/slurm-operator/templates/webhook/webhook.yaml
@@ -263,6 +263,14 @@ webhooks:
           values:
             - kube-system
             - {{ include "slurm-operator.namespace" . }}
+        {{- with .Values.webhook.podBinding.includedNamespaces }}
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values:
+            {{- range . }}
+            - {{ . }}
+            {{- end }}
+        {{- end }}
     admissionReviewVersions:
       - v1
     clientConfig:

--- a/helm/slurm-operator/tests/webhook_webhook_test.yaml
+++ b/helm/slurm-operator/tests/webhook_webhook_test.yaml
@@ -68,6 +68,8 @@ tests:
       webhook:
         enabled: true
         timeoutSeconds: 10
+        podBinding:
+          includedNamespaces: []
       certManager:
         enabled: false
         secretName: slurm-operator-webhook-ca
@@ -87,6 +89,36 @@ tests:
       - equal:
           path: webhooks[0].rules[0].resources[0]
           value: pods/binding
+      - notExists:
+          path: webhooks[0].objectSelector
+
+  - it: should include namespaceSelector with In operator when includedNamespaces is set
+    documentSelector:
+      path: kind
+      value: MutatingWebhookConfiguration
+    set:
+      webhook:
+        enabled: true
+        podBinding:
+          includedNamespaces:
+            - slurm
+            - slurm-prod
+      certManager:
+        enabled: false
+        secretName: slurm-operator-webhook-ca
+    asserts:
+      - equal:
+          path: webhooks[0].namespaceSelector.matchExpressions[1].key
+          value: kubernetes.io/metadata.name
+      - equal:
+          path: webhooks[0].namespaceSelector.matchExpressions[1].operator
+          value: In
+      - contains:
+          path: webhooks[0].namespaceSelector.matchExpressions[1].values
+          content: slurm
+      - contains:
+          path: webhooks[0].namespaceSelector.matchExpressions[1].values
+          content: slurm-prod
 
   - it: should include cert-manager annotations when certManager is enabled
     documentSelector:

--- a/helm/slurm-operator/values.yaml
+++ b/helm/slurm-operator/values.yaml
@@ -109,6 +109,14 @@ operator:
 webhook:
   # -- Enable the webhook.
   enabled: true
+  # Pod binding webhook configurations.
+  podBinding:
+    # -- List of namespaces to include for the pod binding webhook.
+    # When set, only pod bindings in these namespaces will be intercepted.
+    # This reduces the webhook's blast radius and prevents deadlocks during
+    # cluster reboot by limiting scope to namespaces where Slurm clusters run.
+    # Example: ["slurm", "slurm-prod"]
+    includedNamespaces: []
   # -- Set the number of replicas to deploy.
   replicas: 1
   # -- Set the image pull policy.


### PR DESCRIPTION
## Summary

Follow-up to: [fix(webhook): limit pod binding webhook scope #188](https://github.com/SlinkyProject/slurm-operator/pull/188)

Replace the ineffective `objectSelector` with a configurable `namespaceSelector` inclusion list for the `podsbinding-v1.kb.io` webhook. This reduces the webhook's blast radius by allowing users to limit interception to only namespaces where Slurm clusters are deployed, preventing cluster-wide scheduling deadlocks during node reboots.

Addresses #189.

## Problem

The previous approach using `objectSelector` with `matchLabels: app.kubernetes.io/name: slurmd` does **not work** for `pods/binding` subresource webhooks. The Kubernetes Binding object does not inherit the parent Pod's labels, so the selector never matches — causing the webhook to become completely inactive (not just filtered).

With the webhook intercepting all `pods/binding` requests in non-excluded namespaces and `failurePolicy: Fail`, any webhook unavailability (cluster reboot, CNI recovery, rolling update) blocks all Pod scheduling cluster-wide.

## Solution

Add a configurable `webhook.podBinding.includedNamespaces` field in `values.yaml`:

```yaml
webhook:
  podBinding:
    # When set, only pod bindings in these namespaces will be intercepted.
    # Example: ["slurm", "slurm-prod"]
    includedNamespaces: []
```

When configured, this adds a `kubernetes.io/metadata.name: In [...]` expression to the existing `namespaceSelector`, restricting the webhook to only the specified namespaces. The existing `NotIn` exclusion for `kube-system` and operator namespace is preserved.

## Changes

- **`helm/slurm-operator/values.yaml`**: Add `webhook.podBinding.includedNamespaces` configuration (default: `[]`)
- **`helm/slurm-operator/templates/webhook/webhook.yaml`**: Remove ineffective `objectSelector`; add conditional `namespaceSelector` In expression
- **`helm/slurm-operator/tests/webhook_webhook_test.yaml`**: Remove objectSelector test; add test for includedNamespaces rendering

## Why `namespaceSelector` instead of `objectSelector`

| Approach | Works for `pods/binding`? | Reason |
|----------|--------------------------|--------|
| `objectSelector` (labels) | ❌ | Binding object has no Pod labels |
| `matchConditions` (CEL) | ⚠️ Partial | Cannot access Pod labels; pod name prefix depends on Helm release name |
| `namespaceSelector` | ✅ | Namespace metadata is always available at admission time |

## Behavior

| Configuration | Behavior |
|---------------|----------|
| `includedNamespaces: []` (default) | Backwards compatible — excludes only `kube-system` + operator namespace |
| `includedNamespaces: ["slurm"]` | Webhook only intercepts pod bindings in `slurm` namespace |


## Checklist

- [x] I have read CONTRIBUTING.md and the Code of Conduct.
- [x] New or existing tests cover these changes.
- [x] Documentation is updated (values.yaml comments).
- [x] `failurePolicy` remains `Fail` (per maintainer feedback in #188).
- [x] Existing Go-level filtering preserved as defense-in-depth.

## Breaking Changes

None. Default behavior is unchanged (`includedNamespaces: []`).

	
This PR does not change the webhook `failurePolicy`; it remains `Fail`.
## Testing Notes
1. **Generate manifests:**
   ```bash
   make manifests
   ```
2. **Generate Helm docs:**
   ```bash
   make helm-docs
   ```
3. **Validate Helm chart:**
   ```bash
   make helm-validate
   ```
4. **Run Helm unit tests:**
   ```bash
   make helm-unittest
   ```
5. **Run Go tests:**
   ```bash
   make test
   ```
   Result:
   ```text
   total: (statements) 75.7%
   go tool cover -html cover.out -o cover.html
   ```
6. **Run pre-commit checks:**
   ```bash
   pre-commit run --all-files
   ```
   <img width="810" height="647" alt="image" src="https://github.com/user-attachments/assets/47fc78d3-d37d-4ef9-9a27-3df29c69aac3" />

## Additional Context
The related issue describes a cluster or node reboot scenario where the webhook Service can become temporarily unreachable while the cluster networking stack is recovering. With the previous configuration, the `pods/binding` webhook could be invoked for Pods outside of Slurm worker Pods, increasing the blast radius of that temporary webhook unavailability.
The Go handler at `internal/webhook/pod_binding_webhook.go` already filters non-worker Pods with an early `return nil`. This PR moves that filtering boundary earlier, from webhook handler logic to Kubernetes admission selection.
The Go-level check is preserved as a safety net.
Related discussion and full deadlock analysis: #189