### PR TITLE
fix(login): raise RSA SSH host key default to 4096 bits

### DIFF
--- a/internal/builder/loginbuilder/login_secret.go
+++ b/internal/builder/loginbuilder/login_secret.go
@@ -16,7 +16,10 @@ import (
 )
 
 func (b *LoginBuilder) BuildLoginSshHostKeys(loginset *slinkyv1beta1.LoginSet) (*corev1.Secret, error) {
-	keyPairRsa, err := crypto.NewKeyPair(crypto.WithType(crypto.KeyPairRsa))
+	keyPairRsa, err := crypto.NewKeyPair(
+		crypto.WithType(crypto.KeyPairRsa),
+		crypto.WithRsaLength(crypto.DefaultRsaBitLength),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create RSA key pair: %w", err)
 	}

--- a/internal/utils/crypto/keypair.go
+++ b/internal/utils/crypto/keypair.go
@@ -67,9 +67,14 @@ type KeyPair struct {
 	ellipticCurve elliptic.Curve
 }
 
+// DefaultRsaBitLength is the default RSA key length used when callers do
+// not pass WithRsaLength. 4096 bits provides a comfortable security
+// margin for SSH host keys well beyond NIST SP 800-57's 2030 horizon.
+const DefaultRsaBitLength = 4096
+
 func NewKeyPair(opts ...Option) (*KeyPair, error) {
 	o := &KeyPair{
-		bitLength:     1024,
+		bitLength:     DefaultRsaBitLength,
 		ellipticCurve: elliptic.P256(),
 		keyType:       KeyPairEd25519,
 	}


### PR DESCRIPTION
## Summary

- `crypto.NewKeyPair` defaulted RSA keys to 1024 bits, and `BuildLoginSshHostKeys` was relying on that default to generate the login pod's RSA SSH host key. 1024-bit RSA is below modern security baselines (NIST SP 800-57 recommends 3072 bits for keys remaining secure past 2030).
- Introduces `crypto.DefaultRsaBitLength = 4096` and uses it as the new default in `NewKeyPair`.
- Pins the length explicitly at the login-secret call site (`crypto.WithRsaLength(crypto.DefaultRsaBitLength)`) so the secure length is documented at both layers and won't silently regress if the default ever changes.

## Test plan

- [x] `go test ./internal/utils/crypto/... ./internal/builder/loginbuilder/...` passes locally (existing `TestNewKeyPair` cases cover RSA default, `WithRsaLength(4096)`, and the rejected `WithRsaLength(256)` insecure-length case).
- [ ] CI green.
- [x] Manual verification: deploy a `LoginSet`, exec into the resulting Secret, and confirm `ssh-keygen -lf ssh_host_rsa_key` reports 4096 bits.