### PR TITLE
fix: show controller/restapi connection info

### DIFF
--- a/helm/slurm/templates/NOTES.txt
+++ b/helm/slurm/templates/NOTES.txt
@@ -63,7 +63,7 @@ ssh via the Slurm login ({{ $name }}) service:
 {{- end }}{{- /* $loginset.enabled */}}
 {{- end }}{{- /* range $key, $loginset := $.Values.loginsets */}}
 
-{{- if ne (.Values.controller | dig "service" "spec" "type" "None" | lower) ("None" | lower) }}
+{{- if ne (.Values.controller | dig "service" "spec" "type" "" | lower) ("None" | lower) }}
 
 The Slurm controller service:
   {{- if eq (.Values.controller | dig "service" "spec" "type" "" | lower) ("LoadBalancer" | lower) }}
@@ -78,9 +78,9 @@ The Slurm controller service:
 Learn more about slurmctld:
   - Overview: https://slurm.schedmd.com/slurmctld.html
   - Configless: https://slurm.schedmd.com/configless_slurm.html
-{{- end }}{{- /* if ne (.Values.controller | dig "service" "spec" "type" "None" | lower) ("None" | lower) */}}
+{{- end }}{{- /* if ne (.Values.controller | dig "service" "spec" "type" "" | lower) ("None" | lower) */}}
 
-{{- if ne (.Values.restapi | dig "service" "spec" "type" "None" | lower) ("None" | lower) }}
+{{- if ne (.Values.restapi | dig "service" "spec" "type" "" | lower) ("None" | lower) }}
 
 curl the Slurm restapi service:
   {{- if eq (.Values.restapi | dig "service" "spec" "type" "" | lower) ("LoadBalancer" | lower) }}
@@ -96,7 +96,7 @@ Learn more about slurmrestd:
   - Overview: https://slurm.schedmd.com/rest.html
   - Quickstart: https://slurm.schedmd.com/rest_quickstart.html
   - Documentation: https://slurm.schedmd.com/rest_api.html
-{{- end }}{{- /* if ne (.Values.restapi | dig "service" "spec" "type" "None" | lower) ("None" | lower) */}}
+{{- end }}{{- /* if ne (.Values.restapi | dig "service" "spec" "type" "" | lower) ("None" | lower) */}}
 
 Learn more about Slurm:
   - Overview: https://slurm.schedmd.com/overview.html


### PR DESCRIPTION
## Summary

Fix a templating bug in `helm/slurm/templates/NOTES.txt` where the post-install connection instructions for `slurmctld` and `slurmrestd` were silently hidden on a default install.

The outer `{{- if ne ... }}` guards used `"None"` as the `dig` default for `service.spec.type`. With the values.yaml default of `spec: {}`, `dig` returned the sentinel and skipped both blocks even though Kubernetes still creates a ClusterIP service that users need to know how to reach.
Switch the outer guards to `dig ... ""` to match the pattern already used by the inner `LoadBalancer` / `ExternalName` / `clusterIP` branches in the same file. Default installs now render the connection instructions; explicitly setting `service.spec.type: None` still opts out.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/SlinkyProject/slurm-operator/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/SlinkyProject/slurm-operator/blob/main/CODE_OF_CONDUCT.md).
- [ ] New or existing tests cover these changes (where applicable).
- [ ] Documentation is updated if user-visible behavior changes.

## Breaking Changes

N/A

## Testing Notes

Rendered NOTES with `helm install --dry-run` against the chart:
- **Defaults** (`spec: {}`): controller and restapi sections now appear with `jsonpath='{.spec.clusterIP}'`, as expected.
- **Explicit opt-out** (`--set controller.service.spec.type=None --set restapi.service.spec.type=None`): both sections suppressed.
- **LoadBalancer / ExternalName**: inner branches unchanged; renders the matching jsonpath.