### PR TITLE
feat(helm): parametrize webhook failurePolicy/matchPolicy and default to Ignore

### DIFF
--- a/helm/slurm-operator/README.md
+++ b/helm/slurm-operator/README.md
@@ -68,11 +68,13 @@ Kubernetes: `>= 1.29.0-0`
 | propagatedNodeConditions | list | `[]` | List of Kubernetes Node Conditions, by type, to propagate to the Slurm node drain reason. Ref: https://kubernetes.io/docs/reference/node/node-status/#condition |
 | webhook.affinity | object | `{}` | Affinity for pod assignment. Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity |
 | webhook.enabled | bool | `true` | Enable the webhook. |
+| webhook.failurePolicy | string | `"Ignore"` | Action taken when the admission webhook is unreachable or returns an error. Applied to every webhook entry in the generated ValidatingWebhookConfiguration and MutatingWebhookConfiguration. Default is "Ignore" so that an unavailable webhook (e.g. during rollout, eviction, or node drain) does not block unrelated cluster operations such as pod scheduling via the pods/binding mutating webhook. Set to "Fail" to require strict enforcement at the cost of cluster availability when the webhook is down. Ref: https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#failure-policy |
 | webhook.healthPort | int | `8081` | Set the port used for health checks. |
 | webhook.image | object | `{"repository":"ghcr.io/slinkyproject/slurm-operator-webhook","tag":""}` | The image to use, `${repository}:${tag}`. Ref: https://kubernetes.io/docs/concepts/containers/images/#image-names |
 | webhook.imagePullPolicy | string | `"IfNotPresent"` | Set the image pull policy. |
 | webhook.leaderElection | bool | `true` | Enable leader election for slurm-operator-webhook |
 | webhook.logLevel | string | `"info"` | Set the log level by string (e.g. error, info, debug) or number (e.g. 1..5). |
+| webhook.matchPolicy | string | `"Equivalent"` | How the rules listed in the webhook are matched against incoming requests. Applied to every webhook entry in the generated ValidatingWebhookConfiguration and MutatingWebhookConfiguration. Ref: https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-matchpolicy |
 | webhook.metricsPort | int | `0` | Set the port used by the metrics server. Value of "0" will disable it. |
 | webhook.namespaces | string | `""` | Comma-separated list of namespaces the webhook will watch. If empty, all namespaces are watched. |
 | webhook.pdb.enabled | bool | `false` | Enable PodDisruptionBudget. |

--- a/helm/slurm-operator/templates/webhook/webhook.yaml
+++ b/helm/slurm-operator/templates/webhook/webhook.yaml
@@ -64,8 +64,8 @@ webhooks:
         namespace: {{ include "slurm-operator.namespace" . }}
         name: {{ include "slurm-operator.webhook.name" . }}
         path: /validate-slinky-slurm-net-v1beta1-accounting
-    failurePolicy: Fail
-    matchPolicy: Equivalent
+    failurePolicy: {{ .Values.webhook.failurePolicy }}
+    matchPolicy: {{ .Values.webhook.matchPolicy }}
     {{- with .Values.webhook.timeoutSeconds }}
     timeoutSeconds: {{ . }}
     {{- end }}{{- /* with .Values.webhook.timeoutSeconds */}}
@@ -98,8 +98,8 @@ webhooks:
         namespace: {{ include "slurm-operator.namespace" . }}
         name: {{ include "slurm-operator.webhook.name" . }}
         path: /validate-slinky-slurm-net-v1beta1-controller
-    failurePolicy: Fail
-    matchPolicy: Equivalent
+    failurePolicy: {{ .Values.webhook.failurePolicy }}
+    matchPolicy: {{ .Values.webhook.matchPolicy }}
     {{- with .Values.webhook.timeoutSeconds }}
     timeoutSeconds: {{ . }}
     {{- end }}{{- /* with .Values.webhook.timeoutSeconds */}}
@@ -132,8 +132,8 @@ webhooks:
         namespace: {{ include "slurm-operator.namespace" . }}
         name: {{ include "slurm-operator.webhook.name" . }}
         path: /validate-slinky-slurm-net-v1beta1-loginset
-    failurePolicy: Fail
-    matchPolicy: Equivalent
+    failurePolicy: {{ .Values.webhook.failurePolicy }}
+    matchPolicy: {{ .Values.webhook.matchPolicy }}
     {{- with .Values.webhook.timeoutSeconds }}
     timeoutSeconds: {{ . }}
     {{- end }}{{- /* with .Values.webhook.timeoutSeconds */}}
@@ -166,8 +166,8 @@ webhooks:
         namespace: {{ include "slurm-operator.namespace" . }}
         name: {{ include "slurm-operator.webhook.name" . }}
         path: /validate-slinky-slurm-net-v1beta1-nodeset
-    failurePolicy: Fail
-    matchPolicy: Equivalent
+    failurePolicy: {{ .Values.webhook.failurePolicy }}
+    matchPolicy: {{ .Values.webhook.matchPolicy }}
     {{- with .Values.webhook.timeoutSeconds }}
     timeoutSeconds: {{ . }}
     {{- end }}{{- /* with .Values.webhook.timeoutSeconds */}}
@@ -200,8 +200,8 @@ webhooks:
         namespace: {{ include "slurm-operator.namespace" . }}
         name: {{ include "slurm-operator.webhook.name" . }}
         path: /validate-slinky-slurm-net-v1beta1-restapi
-    failurePolicy: Fail
-    matchPolicy: Equivalent
+    failurePolicy: {{ .Values.webhook.failurePolicy }}
+    matchPolicy: {{ .Values.webhook.matchPolicy }}
     {{- with .Values.webhook.timeoutSeconds }}
     timeoutSeconds: {{ . }}
     {{- end }}{{- /* with .Values.webhook.timeoutSeconds */}}
@@ -234,8 +234,8 @@ webhooks:
         namespace: {{ include "slurm-operator.namespace" . }}
         name: {{ include "slurm-operator.webhook.name" . }}
         path: /validate-slinky-slurm-net-v1beta1-token
-    failurePolicy: Fail
-    matchPolicy: Equivalent
+    failurePolicy: {{ .Values.webhook.failurePolicy }}
+    matchPolicy: {{ .Values.webhook.matchPolicy }}
     {{- with .Values.webhook.timeoutSeconds }}
     timeoutSeconds: {{ . }}
     {{- end }}{{- /* with .Values.webhook.timeoutSeconds */}}
@@ -273,8 +273,8 @@ webhooks:
         namespace: {{ include "slurm-operator.namespace" . }}
         name: {{ include "slurm-operator.webhook.name" . }}
         path: /mutate--v1-binding
-    failurePolicy: Fail
-    matchPolicy: Equivalent
+    failurePolicy: {{ .Values.webhook.failurePolicy }}
+    matchPolicy: {{ .Values.webhook.matchPolicy }}
     rules:
       - apiGroups:
           - ""

--- a/helm/slurm-operator/tests/__snapshot__/webhook_webhook_test.yaml.snap
+++ b/helm/slurm-operator/tests/__snapshot__/webhook_webhook_test.yaml.snap
@@ -1,0 +1,235 @@
+default manifest should match snapshot:
+  1: |
+    apiVersion: admissionregistration.k8s.io/v1
+    kind: ValidatingWebhookConfiguration
+    metadata:
+      annotations:
+        cert-manager.io/inject-ca-from: test-namespace/slurm-operator-webhook-ca
+        certmanager.k8s.io/inject-ca-from: test-namespace/slurm-operator-webhook-ca
+      labels:
+        app.kubernetes.io/instance: test-release
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: slurm-operator-webhook
+        app.kubernetes.io/part-of: slurm-operator
+        app.kubernetes.io/version: 1.2.3
+        helm.sh/chart: slurm-operator-1.2.3
+      name: slurm-operator-webhook
+    webhooks:
+      - admissionReviewVersions:
+          - v1beta1
+        clientConfig:
+          service:
+            name: slurm-operator-webhook
+            namespace: test-namespace
+            path: /validate-slinky-slurm-net-v1beta1-accounting
+        failurePolicy: Ignore
+        matchPolicy: Equivalent
+        name: accounting-v1beta1.kb.io
+        namespaceSelector:
+          matchExpressions:
+            - key: kubernetes.io/metadata.name
+              operator: NotIn
+              values:
+                - kube-system
+        rules:
+          - apiGroups:
+              - slinky.slurm.net
+            apiVersions:
+              - v1beta1
+            operations:
+              - CREATE
+              - UPDATE
+            resources:
+              - accountings
+            scope: Namespaced
+        sideEffects: None
+        timeoutSeconds: 10
+      - admissionReviewVersions:
+          - v1beta1
+        clientConfig:
+          service:
+            name: slurm-operator-webhook
+            namespace: test-namespace
+            path: /validate-slinky-slurm-net-v1beta1-controller
+        failurePolicy: Ignore
+        matchPolicy: Equivalent
+        name: controller-v1beta1.kb.io
+        namespaceSelector:
+          matchExpressions:
+            - key: kubernetes.io/metadata.name
+              operator: NotIn
+              values:
+                - kube-system
+        rules:
+          - apiGroups:
+              - slinky.slurm.net
+            apiVersions:
+              - v1beta1
+            operations:
+              - CREATE
+              - UPDATE
+            resources:
+              - controllers
+            scope: Namespaced
+        sideEffects: None
+        timeoutSeconds: 10
+      - admissionReviewVersions:
+          - v1beta1
+        clientConfig:
+          service:
+            name: slurm-operator-webhook
+            namespace: test-namespace
+            path: /validate-slinky-slurm-net-v1beta1-loginset
+        failurePolicy: Ignore
+        matchPolicy: Equivalent
+        name: loginset-v1beta1.kb.io
+        namespaceSelector:
+          matchExpressions:
+            - key: kubernetes.io/metadata.name
+              operator: NotIn
+              values:
+                - kube-system
+        rules:
+          - apiGroups:
+              - slinky.slurm.net
+            apiVersions:
+              - v1beta1
+            operations:
+              - CREATE
+              - UPDATE
+            resources:
+              - loginsets
+            scope: Namespaced
+        sideEffects: None
+        timeoutSeconds: 10
+      - admissionReviewVersions:
+          - v1beta1
+        clientConfig:
+          service:
+            name: slurm-operator-webhook
+            namespace: test-namespace
+            path: /validate-slinky-slurm-net-v1beta1-nodeset
+        failurePolicy: Ignore
+        matchPolicy: Equivalent
+        name: nodeset-v1beta1.kb.io
+        namespaceSelector:
+          matchExpressions:
+            - key: kubernetes.io/metadata.name
+              operator: NotIn
+              values:
+                - kube-system
+        rules:
+          - apiGroups:
+              - slinky.slurm.net
+            apiVersions:
+              - v1beta1
+            operations:
+              - CREATE
+              - UPDATE
+            resources:
+              - nodesets
+            scope: Namespaced
+        sideEffects: None
+        timeoutSeconds: 10
+      - admissionReviewVersions:
+          - v1beta1
+        clientConfig:
+          service:
+            name: slurm-operator-webhook
+            namespace: test-namespace
+            path: /validate-slinky-slurm-net-v1beta1-restapi
+        failurePolicy: Ignore
+        matchPolicy: Equivalent
+        name: restapi-v1beta1.kb.io
+        namespaceSelector:
+          matchExpressions:
+            - key: kubernetes.io/metadata.name
+              operator: NotIn
+              values:
+                - kube-system
+        rules:
+          - apiGroups:
+              - slinky.slurm.net
+            apiVersions:
+              - v1beta1
+            operations:
+              - CREATE
+              - UPDATE
+            resources:
+              - restapis
+            scope: Namespaced
+        sideEffects: None
+        timeoutSeconds: 10
+      - admissionReviewVersions:
+          - v1beta1
+        clientConfig:
+          service:
+            name: slurm-operator-webhook
+            namespace: test-namespace
+            path: /validate-slinky-slurm-net-v1beta1-token
+        failurePolicy: Ignore
+        matchPolicy: Equivalent
+        name: token-v1beta1.kb.io
+        namespaceSelector:
+          matchExpressions:
+            - key: kubernetes.io/metadata.name
+              operator: NotIn
+              values:
+                - kube-system
+        rules:
+          - apiGroups:
+              - slinky.slurm.net
+            apiVersions:
+              - v1beta1
+            operations:
+              - CREATE
+              - UPDATE
+            resources:
+              - tokens
+            scope: Namespaced
+        sideEffects: None
+        timeoutSeconds: 10
+  2: |
+    apiVersion: admissionregistration.k8s.io/v1
+    kind: MutatingWebhookConfiguration
+    metadata:
+      annotations:
+        cert-manager.io/inject-ca-from: test-namespace/slurm-operator-webhook-ca
+        certmanager.k8s.io/inject-ca-from: test-namespace/slurm-operator-webhook-ca
+      labels:
+        app.kubernetes.io/instance: test-release
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: slurm-operator-webhook
+        app.kubernetes.io/part-of: slurm-operator
+        app.kubernetes.io/version: 1.2.3
+        helm.sh/chart: slurm-operator-1.2.3
+      name: slurm-operator-webhook
+    webhooks:
+      - admissionReviewVersions:
+          - v1
+        clientConfig:
+          service:
+            name: slurm-operator-webhook
+            namespace: test-namespace
+            path: /mutate--v1-binding
+        failurePolicy: Ignore
+        matchPolicy: Equivalent
+        name: podsbinding-v1.kb.io
+        namespaceSelector:
+          matchExpressions:
+            - key: kubernetes.io/metadata.name
+              operator: NotIn
+              values:
+                - kube-system
+                - test-namespace
+        rules:
+          - apiGroups:
+              - ""
+            apiVersions:
+              - v1
+            operations:
+              - CREATE
+            resources:
+              - pods/binding
+        sideEffects: None
+        timeoutSeconds: 10

--- a/helm/slurm-operator/tests/webhook_webhook_test.yaml
+++ b/helm/slurm-operator/tests/webhook_webhook_test.yaml
@@ -17,188 +17,15 @@ tests:
       - hasDocuments:
           count: 0
 
-  - it: should render ValidatingWebhookConfiguration with correct webhooks
-    documentSelector:
-      path: kind
-      value: ValidatingWebhookConfiguration
-    set:
-      webhook:
-        enabled: true
-        timeoutSeconds: 10
-      certManager:
-        enabled: false
-        secretName: slurm-operator-webhook-ca
+  - it: default manifest should match snapshot
     asserts:
-      - equal:
-          path: metadata.name
-          value: slurm-operator-webhook
-      - equal:
-          path: webhooks[0].name
-          value: accounting-v1beta1.kb.io
-      - equal:
-          path: webhooks[0].failurePolicy
-          value: Ignore
-      - equal:
-          path: webhooks[0].timeoutSeconds
-          value: 10
-      - equal:
-          path: webhooks[0].sideEffects
-          value: None
-      - equal:
-          path: webhooks[1].name
-          value: controller-v1beta1.kb.io
-      - equal:
-          path: webhooks[2].name
-          value: loginset-v1beta1.kb.io
-      - equal:
-          path: webhooks[3].name
-          value: nodeset-v1beta1.kb.io
-      - equal:
-          path: webhooks[4].name
-          value: restapi-v1beta1.kb.io
-      - equal:
-          path: webhooks[5].name
-          value: token-v1beta1.kb.io
-
-  - it: should render MutatingWebhookConfiguration for pods/binding
-    documentSelector:
-      path: kind
-      value: MutatingWebhookConfiguration
-    set:
-      webhook:
-        enabled: true
-        timeoutSeconds: 10
-      certManager:
-        enabled: false
-        secretName: slurm-operator-webhook-ca
-    asserts:
-      - equal:
-          path: metadata.name
-          value: slurm-operator-webhook
-      - equal:
-          path: webhooks[0].name
-          value: podsbinding-v1.kb.io
-      - equal:
-          path: webhooks[0].failurePolicy
-          value: Ignore
-      - equal:
-          path: webhooks[0].timeoutSeconds
-          value: 10
-      - equal:
-          path: webhooks[0].rules[0].resources[0]
-          value: pods/binding
-
-  - it: should include cert-manager annotations when certManager is enabled
-    documentSelector:
-      path: kind
-      value: ValidatingWebhookConfiguration
-    set:
-      webhook:
-        enabled: true
-      certManager:
-        enabled: true
-        secretName: slurm-operator-webhook-ca
-    asserts:
-      - exists:
-          path: metadata.annotations["cert-manager.io/inject-ca-from"]
-
-  - it: should include caBundle when certManager is disabled
-    documentSelector:
-      path: kind
-      value: ValidatingWebhookConfiguration
-    set:
-      webhook:
-        enabled: true
-      certManager:
-        enabled: false
-        secretName: slurm-operator-webhook-ca
-    asserts:
-      - exists:
-          path: webhooks[0].clientConfig.caBundle
-
-  - it: should render TLS secret when certManager is disabled
-    documentIndex: 0
-    set:
-      webhook:
-        enabled: true
-      certManager:
-        enabled: false
-        secretName: slurm-operator-webhook-ca
-    asserts:
-      - equal:
-          path: kind
-          value: Secret
-      - equal:
-          path: type
-          value: kubernetes.io/tls
-      - equal:
-          path: metadata.name
-          value: slurm-operator-webhook-ca
-      - equal:
-          path: metadata.namespace
-          value: test-namespace
-      - exists:
-          path: data["tls.crt"]
-      - exists:
-          path: data["tls.key"]
-      - exists:
-          path: data["ca.crt"]
-
-  - it: should not render TLS secret when certManager is enabled
-    documentIndex: 0
-    set:
-      webhook:
-        enabled: true
-      certManager:
-        enabled: true
-        secretName: slurm-operator-webhook-ca
-    asserts:
-      - equal:
-          path: kind
-          value: ValidatingWebhookConfiguration
-
-  - it: should apply default failurePolicy and matchPolicy to every webhook entry
-    set:
-      webhook:
-        enabled: true
-      certManager:
-        enabled: false
-        secretName: slurm-operator-webhook-ca
-    asserts:
-      - documentSelector:
-          path: kind
-          value: ValidatingWebhookConfiguration
-        equal:
-          path: webhooks[*].failurePolicy
-          value: Ignore
-      - documentSelector:
-          path: kind
-          value: ValidatingWebhookConfiguration
-        equal:
-          path: webhooks[*].matchPolicy
-          value: Equivalent
-      - documentSelector:
-          path: kind
-          value: MutatingWebhookConfiguration
-        equal:
-          path: webhooks[0].failurePolicy
-          value: Ignore
-      - documentSelector:
-          path: kind
-          value: MutatingWebhookConfiguration
-        equal:
-          path: webhooks[0].matchPolicy
-          value: Equivalent
+      - matchSnapshot: {}
 
   - it: should honor overridden failurePolicy and matchPolicy values
     set:
       webhook:
-        enabled: true
         failurePolicy: Fail
         matchPolicy: Exact
-      certManager:
-        enabled: false
-        secretName: slurm-operator-webhook-ca
     asserts:
       - documentSelector:
           path: kind
@@ -224,3 +51,65 @@ tests:
         equal:
           path: webhooks[0].matchPolicy
           value: Exact
+
+  - it: should honor overridden timeoutSeconds
+    set:
+      webhook:
+        timeoutSeconds: 30
+    asserts:
+      - documentSelector:
+          path: kind
+          value: ValidatingWebhookConfiguration
+        equal:
+          path: webhooks[*].timeoutSeconds
+          value: 30
+      - documentSelector:
+          path: kind
+          value: MutatingWebhookConfiguration
+        equal:
+          path: webhooks[0].timeoutSeconds
+          value: 30
+
+  - it: should inject caBundle and render TLS secret when certManager is disabled
+    set:
+      certManager:
+        enabled: false
+        secretName: slurm-operator-webhook-ca
+    asserts:
+      - documentSelector:
+          path: kind
+          value: ValidatingWebhookConfiguration
+        exists:
+          path: webhooks[0].clientConfig.caBundle
+      - documentSelector:
+          path: kind
+          value: MutatingWebhookConfiguration
+        exists:
+          path: webhooks[0].clientConfig.caBundle
+      - documentSelector:
+          path: kind
+          value: Secret
+        equal:
+          path: type
+          value: kubernetes.io/tls
+      - documentSelector:
+          path: kind
+          value: Secret
+        equal:
+          path: metadata.name
+          value: slurm-operator-webhook-ca
+      - documentSelector:
+          path: kind
+          value: Secret
+        exists:
+          path: data["tls.crt"]
+      - documentSelector:
+          path: kind
+          value: Secret
+        exists:
+          path: data["tls.key"]
+      - documentSelector:
+          path: kind
+          value: Secret
+        exists:
+          path: data["ca.crt"]

--- a/helm/slurm-operator/tests/webhook_webhook_test.yaml
+++ b/helm/slurm-operator/tests/webhook_webhook_test.yaml
@@ -37,7 +37,7 @@ tests:
           value: accounting-v1beta1.kb.io
       - equal:
           path: webhooks[0].failurePolicy
-          value: Fail
+          value: Ignore
       - equal:
           path: webhooks[0].timeoutSeconds
           value: 10
@@ -80,7 +80,7 @@ tests:
           value: podsbinding-v1.kb.io
       - equal:
           path: webhooks[0].failurePolicy
-          value: Fail
+          value: Ignore
       - equal:
           path: webhooks[0].timeoutSeconds
           value: 10
@@ -156,3 +156,71 @@ tests:
       - equal:
           path: kind
           value: ValidatingWebhookConfiguration
+
+  - it: should apply default failurePolicy and matchPolicy to every webhook entry
+    set:
+      webhook:
+        enabled: true
+      certManager:
+        enabled: false
+        secretName: slurm-operator-webhook-ca
+    asserts:
+      - documentSelector:
+          path: kind
+          value: ValidatingWebhookConfiguration
+        equal:
+          path: webhooks[*].failurePolicy
+          value: Ignore
+      - documentSelector:
+          path: kind
+          value: ValidatingWebhookConfiguration
+        equal:
+          path: webhooks[*].matchPolicy
+          value: Equivalent
+      - documentSelector:
+          path: kind
+          value: MutatingWebhookConfiguration
+        equal:
+          path: webhooks[0].failurePolicy
+          value: Ignore
+      - documentSelector:
+          path: kind
+          value: MutatingWebhookConfiguration
+        equal:
+          path: webhooks[0].matchPolicy
+          value: Equivalent
+
+  - it: should honor overridden failurePolicy and matchPolicy values
+    set:
+      webhook:
+        enabled: true
+        failurePolicy: Fail
+        matchPolicy: Exact
+      certManager:
+        enabled: false
+        secretName: slurm-operator-webhook-ca
+    asserts:
+      - documentSelector:
+          path: kind
+          value: ValidatingWebhookConfiguration
+        equal:
+          path: webhooks[*].failurePolicy
+          value: Fail
+      - documentSelector:
+          path: kind
+          value: ValidatingWebhookConfiguration
+        equal:
+          path: webhooks[*].matchPolicy
+          value: Exact
+      - documentSelector:
+          path: kind
+          value: MutatingWebhookConfiguration
+        equal:
+          path: webhooks[0].failurePolicy
+          value: Fail
+      - documentSelector:
+          path: kind
+          value: MutatingWebhookConfiguration
+        equal:
+          path: webhooks[0].matchPolicy
+          value: Exact

--- a/helm/slurm-operator/values.yaml
+++ b/helm/slurm-operator/values.yaml
@@ -127,6 +127,17 @@ webhook:
     name: ""
   # -- Set the timeout period for calls.
   timeoutSeconds: 10
+  # -- Action taken when the admission webhook is unreachable or returns an error.
+  # Applied to every webhook entry in the generated ValidatingWebhookConfiguration and MutatingWebhookConfiguration.
+  # Default is "Ignore" so that an unavailable webhook (e.g. during rollout, eviction, or node drain) does
+  # not block unrelated cluster operations such as pod scheduling via the pods/binding mutating webhook.
+  # Set to "Fail" to require strict enforcement at the cost of cluster availability when the webhook is down.
+  # Ref: https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#failure-policy
+  failurePolicy: Ignore
+  # -- How the rules listed in the webhook are matched against incoming requests.
+  # Applied to every webhook entry in the generated ValidatingWebhookConfiguration and MutatingWebhookConfiguration.
+  # Ref: https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-matchpolicy
+  matchPolicy: Equivalent
   # -- Affinity for pod assignment.
   # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
   affinity: {}


### PR DESCRIPTION
## Summary

- Expose `webhook.failurePolicy` and `webhook.matchPolicy` as Helm values, applied uniformly to every entry in the generated `ValidatingWebhookConfiguration` and the pods/binding `MutatingWebhookConfiguration`.
- Default `webhook.failurePolicy` to `Ignore` (was hard-coded `Fail`); `webhook.matchPolicy` stays at `Equivalent`.
- Documented in `values.yaml` and `README.md`.
- Refactored `tests/webhook_webhook_test.yaml` so the default-rendered manifest is locked in via `matchSnapshot` and each remaining unit test only asserts the single parameter it changes.

## Root cause

The chart previously hard-coded:

```yaml
failurePolicy: Fail
matchPolicy: Equivalent
```

on every webhook entry, including the cluster-wide `podsbinding-v1.kb.io` mutating webhook that runs on every pod's `Bind` step. With `failurePolicy=Fail`, any window in which the webhook Service has no ready endpoints — rollouts, evictions, node drains, image pulls, OOMKill, PDB-induced downtime — causes the kube-scheduler's `DefaultBinder` plugin to fail and **all** new pods in **all** namespaces get stuck in `Pending` with events like:

```text
Warning FailedScheduling default-scheduler
  running Bind plugin "DefaultBinder": Internal error occurred:
  failed calling webhook "podsbinding-v1.kb.io":
  Post "https://slurm-operator-webhook.slurm-operator.svc:443/mutate--v1-binding?timeout=10s":
  no endpoints available for service "slurm-operator-webhook"
```

This effectively makes the slurm-operator webhook a cluster-wide control-plane dependency for unrelated workloads (DNS, ingress, monitoring, the operator's own restart, etc.), and the failure mode is self-reinforcing: if the webhook pod itself can't be rescheduled, nothing else can either.

## Fix

- Default `failurePolicy: Ignore` so an unavailable webhook is fail-open and does **not** block pod scheduling. The pods/binding mutation is best-effort scheduling guidance for Slurm-managed workloads; skipping it during webhook downtime is preferable to halting the entire cluster.
- Strict enforcement remains available with `--set webhook.failurePolicy=Fail` for operators who run the webhook in HA and accept the availability/consistency trade-off.
- `matchPolicy` is exposed as a knob (default unchanged at `Equivalent`) so users can flip it to `Exact` if their admission-policy posture requires it.

## Files changed

- `helm/slurm-operator/values.yaml` — new `webhook.failurePolicy` / `webhook.matchPolicy` values with rationale comments.
- `helm/slurm-operator/templates/webhook/webhook.yaml` — replaced the 7 hard-coded pairs with `.Values.webhook.failurePolicy` / `.Values.webhook.matchPolicy`.
- `helm/slurm-operator/README.md` — value table updated.
- `helm/slurm-operator/tests/webhook_webhook_test.yaml` — restructured: a single `matchSnapshot` test pins the default-rendered ValidatingWebhookConfiguration + MutatingWebhookConfiguration (deterministic because the chart-default `certManager.enabled=true` omits the inline TLS cert), and the remaining tests use `equal`/`exists` to assert only the parameter each one overrides — `failurePolicy`/`matchPolicy`, `timeoutSeconds`, and the `certManager.enabled=false` path (caBundle injection + TLS Secret render).
- `helm/slurm-operator/tests/__snapshot__/webhook_webhook_test.yaml.snap` — new committed snapshot.

## Test plan

- [x] `helm unittest helm/slurm-operator` — 69 tests / 12 snapshots pass locally.
- [x] Re-running the snapshot test multiple times produces identical output (no flake from `genCA` / `genSignedCert`, because the default path uses cert-manager and never generates inline material).
- [x] `helm template t helm/slurm-operator --set webhook.failurePolicy=Ignore --set webhook.matchPolicy=Exact --set certManager.enabled=false` renders the overrides on all 7 webhook entries.
- [ ] CI green.
- [x] Manual: in a cluster with the chart installed, scale the webhook deployment to 0 and confirm new pods still schedule (with the warning event suppressed) instead of getting stuck in `Pending`.

## Backwards compatibility

This changes the default failure mode for the chart from fail-closed to fail-open. Users that rely on strict admission of slurm-operator CRs and the pods/binding mutation should set `webhook.failurePolicy: Fail` in their values overrides on upgrade.