### PR TITLE
fix(client): Add check if CRD is installed to prevent infinite error loops on metrics

### DIFF
--- a/internal/utils/objectutils/delete.go
+++ b/internal/utils/objectutils/delete.go
@@ -13,6 +13,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -60,10 +61,10 @@ func DeleteObject(c client.Client, ctx context.Context, eventRecorder events.Eve
 
 	key := client.ObjectKeyFromObject(newObj)
 	if err := c.Get(ctx, key, oldObj); err != nil {
-		if !apierrors.IsNotFound(err) {
-			return fmt.Errorf("error getting %s: %w", key, err)
+		if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
+			return nil
 		}
-		return nil
+		return fmt.Errorf("error getting %s: %w", key, err)
 	}
 
 	// If the object is being deleted, do not update it

--- a/internal/utils/objectutils/delete_test.go
+++ b/internal/utils/objectutils/delete_test.go
@@ -8,9 +8,12 @@ import (
 	"testing"
 
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -153,5 +156,38 @@ func TestDeleteObject(t *testing.T) {
 				t.Errorf("DeleteObject() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+// mockNoMatchClient mocks the controller-runtime Client to return a NoKindMatchError on Get
+type mockNoMatchClient struct {
+	client.Client
+}
+
+func (m *mockNoMatchClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	return &meta.NoKindMatchError{
+		GroupKind: schema.GroupKind{
+			Group: "test.example.com",
+			Kind:  "Foo",
+		},
+		SearchedVersions: []string{"v1"},
+	}
+}
+
+func TestDeleteObject_NoKindMatch(t *testing.T) {
+	ctx := context.Background()
+
+	serviceMonitor := &monitoringv1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-servicemonitor",
+			Namespace: "default",
+		},
+	}
+
+	c := &mockNoMatchClient{}
+
+	err := DeleteObject(c, ctx, nil, nil, serviceMonitor)
+	if err != nil {
+		t.Fatalf("expected no error (NoMatchError should be ignored), got: %v", err)
 	}
 }


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->

<!--
Feature requests, code contributions, and bug reports are welcome!
GitHub issues and pull requests are handled on a best-effort basis.
The SchedMD official issue tracker is at <https://support.schedmd.com/>.
-->

## Summary
Ran into this while testing #198, if the metrics CRDs are not installed then the operator will get stuck in an infinite loop here. Updated the delete function to ensure that it returns nil if the CRD is not installed on the cluster.
<!--
Describe what this is for and why it is needed.
Link relevant issues which this addresses (e.g. closes #123).
-->

## Checklist

- [x] I have read
  [CONTRIBUTING.md](https://github.com/SlinkyProject/slurm-operator/blob/main/CONTRIBUTING.md)
  and the
  [Code of Conduct](https://github.com/SlinkyProject/slurm-operator/blob/main/CODE_OF_CONDUCT.md).
- [x] New or existing tests cover these changes (where applicable).
- [x] Documentation is updated if user-visible behavior changes.

## Breaking Changes
None

## Testing Notes
Added test case for this scenario, in an actual cluster create a slurm cluster without the ServiceMonitor CRD installed.
<!--
How to test this change.
-->

## Additional Context
N/A
<!--
Any other context for reviewers.
-->
