### PR TITLE
feat: sync Slurm node features from k8s node annotation

### DIFF
--- a/api/v1beta1/well_known.go
+++ b/api/v1beta1/well_known.go
@@ -10,6 +10,7 @@ const (
 	NodeSetPrefix  = "nodeset." + SlinkyPrefix
 	LoginSetPrefix = "loginset." + SlinkyPrefix
 	TopologyPrefix = "topology." + SlinkyPrefix
+	FeaturesPrefix = "features." + SlinkyPrefix
 )
 
 // Well Known Annotations
@@ -40,10 +41,28 @@ const (
 	// Ref: https://slurm.schedmd.com/topology.html#dynamic_topo
 	AnnotationNodeTopologySpec = TopologyPrefix + "spec"
 
+	// AnnotationNodeFeaturesSpec indicates a comma-separated list of Slurm node features (e.g.
+	// "nn-75bfcf47ca3e4f7dc,GPU") for the Slurm node that the NodeSet pod runs on. The operator applies
+	// each value as a NodeFeaturePrefix-namespaced feature (e.g. "k8s/nn-75bfcf47ca3e4f7dc") on the Slurm
+	// node's available and active features via the REST API, preserving all non-prefixed features.
+	// Ref: https://slurm.schedmd.com/slurm.conf.html#OPT_Features
+	AnnotationNodeFeaturesSpec = FeaturesPrefix + "spec"
+
 	// AnnotationNodeHostnameOverride may be set to override the pod hostname assigned to NodeSet DaemonSet-mode
 	// pod scheduled on the node. When present, the value is used verbatim as the pod's spec.hostname
 	// (and therefore the Slurm node name) instead of the default derived from the node name.
 	AnnotationNodeHostnameOverride = NodeSetPrefix + "hostname-override"
+)
+
+// Well Known Slurm node feature prefixes
+const (
+	// NodeFeaturePrefix namespaces the Slurm node features the operator manages from
+	// AnnotationNodeFeaturesSpec. The operator owns features carrying this prefix
+	// (adding, replacing, and removing them to match the annotation) and preserves
+	// all others, including the NodeSet baseline, ExtraConf features, and
+	// externally-managed features such as NodeFeaturesPlugins. This mirrors the
+	// reserved-prefix pattern used for the node Reason ("slurm-operator:").
+	NodeFeaturePrefix = "k8s/"
 )
 
 // Well Known Labels

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -15,6 +15,7 @@
       - [`auth/jwt`](#authjwt)
       - [Dynamic Nodes](#dynamic-nodes)
         - [Dynamic Topology](#dynamic-topology)
+        - [Node Features](#node-features)
   - [Slurm](#slurm)
     - [Hybrid](#hybrid)
     - [Autoscale](#autoscale)
@@ -140,6 +141,17 @@ advance for topology-aware scheduling to work on Kubernetes.
 
 See the [topology usage guide][topology] for more.
 
+##### Node Features
+
+The operator can also propagate Slurm node features from the Kubernetes node a
+slurmd pod is scheduled on. When the node carries the
+`features.slinky.slurm.net/spec` annotation, the operator applies its values to the
+Slurm node's available and active features under a reserved `k8s/` prefix,
+preserving the NodeSet baseline and any externally-managed features, so jobs can
+target those nodes with `--constraint=k8s/<feature>`.
+
+See the [node features usage guide][node-features] for more.
+
 ## Slurm
 
 The following diagram illustrates a containerized Slurm cluster, from a
@@ -236,6 +248,7 @@ Each webhook is named after the Custom Resource Definition (CRD) it manages.
 [kubebuilder]: https://book.kubebuilder.io/
 [kustomize]: https://kustomize.io/
 [munge]: https://github.com/dun/munge
+[node-features]: ../usage/node-features.md
 [operator-pattern]: https://kubernetes.io/docs/concepts/extend-kubernetes/operator/
 [operator-sdk]: https://sdk.operatorframework.io/
 [slurm]: ./slurm.md

--- a/docs/usage/node-features.md
+++ b/docs/usage/node-features.md
@@ -1,0 +1,105 @@
+# Node Features
+
+## Table of Contents
+
+<!-- mdformat-toc start --slug=github --no-anchors --maxlevel=6 --minlevel=1 -->
+
+- [Node Features](#node-features)
+  - [Table of Contents](#table-of-contents)
+  - [Overview](#overview)
+  - [Kubernetes](#kubernetes)
+  - [Slurm](#slurm)
+  - [Example](#example)
+
+<!-- mdformat-toc end -->
+
+## Overview
+
+The operator can propagate node features from Kubernetes nodes to Slurm nodes
+(those running as NodeSet pods). When a NodeSet pod runs on a Kubernetes node, each
+value in the node's `features.slinky.slurm.net/spec` annotation is applied to the
+registered Slurm node's available and active features under a reserved prefix,
+`k8s/` (for example the annotation `nn-75bfcf47ca3e4f7dc` becomes the Slurm feature
+`k8s/nn-75bfcf47ca3e4f7dc`).
+
+Use the annotation for per-node attributes discovered at runtime, such as a network
+switch ID. NodeSet-wide features (the NodeSet name and any `Feature=`/`Features=`
+entries in `extraConf`) are seeded directly by slurmd at registration via `--conf`
+and are not prefixed.
+
+The operator owns only the `k8s/` namespace. On each reconcile it replaces the
+prefixed features with the current annotation values and preserves every other
+feature, including the NodeSet baseline, `extraConf` features, and features managed
+outside the operator such as those from a Slurm `NodeFeaturesPlugins` plugin or a
+manual `scontrol update`. Removing the annotation clears the node's `k8s/` features
+while leaving the rest intact.
+
+## Kubernetes
+
+Annotate each Kubernetes node with `features.slinky.slurm.net/spec` and a
+comma-separated list of feature names. Each token is used verbatim and applied to
+the Slurm node under the `k8s/` prefix. Only Slurm nodes backed by a NodeSet pod
+scheduled on the node are updated.
+
+For example, the following Kubernetes Node snippet has the Slinky node features
+annotation applied.
+
+```yaml
+apiVersion: v1
+kind: Node
+metadata:
+  name: node0
+  annotations:
+    features.slinky.slurm.net/spec: nn-75bfcf47ca3e4f7dc
+```
+
+The annotation is normally written by an external component that discovers each
+node's features (for example, a daemon querying a cloud provider's network
+topology API). The operator only propagates the annotation it finds.
+
+## Slurm
+
+Slurm node features can be requested by a job with `--constraint`. See the Slurm
+[Features][features-conf] documentation. Because operator-managed features carry
+the `k8s/` prefix, jobs target them as `--constraint=k8s/<feature>`. The operator
+applies each prefixed feature to both available and active features, and because it
+only touches the `k8s/` namespace it does not interfere with features managed by a
+`NodeFeaturesPlugins` plugin.
+
+## Example
+
+Suppose the NodeSet is named `slinky` and sets `extraConf: Features=GPU`. slurmd
+registers the node with the baseline features `slinky` and `GPU` (unprefixed). The
+Kubernetes node where the `slinky-0` NodeSet pod runs is annotated with its
+leaf-switch ID.
+
+```yaml
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: node0
+  annotations:
+    features.slinky.slurm.net/spec: nn-75bfcf47ca3e4f7dc
+```
+
+When the `slinky-0` NodeSet pod is scheduled onto Kubernetes node `node0`, the
+operator applies the annotation under the `k8s/` prefix, preserving the baseline.
+Slurm then reports both the baseline and the prefixed feature.
+
+```console
+$ scontrol show node slinky-0 | grep -Eo "NodeName=[^ ]+|[ ]*AvailableFeatures=[^ ]+|[ ]*ActiveFeatures=[^ ]+"
+NodeName=slinky-0
+   AvailableFeatures=GPU,k8s/nn-75bfcf47ca3e4f7dc,slinky
+   ActiveFeatures=GPU,k8s/nn-75bfcf47ca3e4f7dc,slinky
+```
+
+A job can then be constrained to that switch.
+
+```sh
+sbatch --constraint=k8s/nn-75bfcf47ca3e4f7dc ...
+```
+
+<!-- Links -->
+
+[features-conf]: https://slurm.schedmd.com/slurm.conf.html#OPT_Features

--- a/internal/builder/workerbuilder/worker_app.go
+++ b/internal/builder/workerbuilder/worker_app.go
@@ -283,48 +283,66 @@ func slurmdArgs(nodeset *slinkyv1beta1.NodeSet, controller *slinkyv1beta1.Contro
 	return args
 }
 
-func slurmdConfArgs(nodeset *slinkyv1beta1.NodeSet) []string {
-	extraConf := []string{}
-	if nodeset.Spec.ExtraConf != "" {
-		extraConf = strings.Split(nodeset.Spec.ExtraConf, " ")
-	}
-
-	name := common.GetSlurmNodeSetName(nodeset)
-	confMap := map[string]string{
-		"Features": name,
-	}
-	for _, item := range extraConf {
+// ParseExtraConf parses a NodeSet's Spec.ExtraConf into a map of normalized keys
+// to their values. The expected shape is space-separated Key=Value pairs; each
+// value can be a comma-separated list (e.g. Features=a,b,c). Keys are title-cased
+// so "feature=a" and "Feature=a" both produce key "Feature".
+//
+// Tokens are split on whitespace, so leading, trailing, and repeated whitespace
+// are tolerated; any token without '=' returns an error. Exported so the NodeSet
+// validation webhook can reject malformed input with the same parser the worker
+// builder uses, keeping the accepted set identical at admission and at build time.
+func ParseExtraConf(extraConf string) (map[string][]string, error) {
+	out := make(map[string][]string, 10)
+	for item := range strings.FieldsSeq(extraConf) {
 		pair := strings.SplitN(item, "=", 2)
-		key := cases.Title(language.English).String(pair[0])
 		if len(pair) != 2 {
-			panic(fmt.Sprintf("malformed --conf item: %v", item))
+			return nil, fmt.Errorf("malformed --conf item %q: expected Key=Value", item)
 		}
-		val := pair[1]
-		if key == "Features" || key == "Feature" {
-			// Slurm treats trailing 's' as optional. We have to
-			// specially handle 'Feature(s)' because we require at
-			// least one feature but the user can request additional.
-			key = "Features"
-		}
-		if ret, ok := confMap[key]; !ok {
-			confMap[key] = val
-		} else {
-			confMap[key] = ret + fmt.Sprintf(",%s", val)
+		key := cases.Title(language.English).String(pair[0])
+		out[key] = append(out[key], strings.Split(pair[1], ",")...)
+	}
+	return out, nil
+}
+
+// baselineFeatures returns the sorted, de-duplicated list of Slurm features baked
+// into slurmd at registration via --conf: the NodeSet name (or hostname override)
+// plus any Feature=/Features= entries from Spec.ExtraConf.
+//
+// A ParseExtraConf error falls back to the bare baseline (just the name) rather
+// than failing, so malformed ExtraConf does not wedge slurmdConfArgs; the NodeSet
+// webhook rejects such input at admission when it is enabled.
+func baselineFeatures(nodeset *slinkyv1beta1.NodeSet) []string {
+	raw := []string{common.GetSlurmNodeSetName(nodeset)}
+	if conf, err := ParseExtraConf(nodeset.Spec.ExtraConf); err == nil {
+		raw = append(raw, conf["Feature"]...)
+		raw = append(raw, conf["Features"]...)
+	}
+	return structutils.SortedDedup(raw)
+}
+
+func slurmdConfArgs(nodeset *slinkyv1beta1.NodeSet) []string {
+	confMap := map[string]string{"Features": strings.Join(baselineFeatures(nodeset), ",")}
+
+	// The NodeSet webhook validates ExtraConf at admission, but it is a separate,
+	// optional deployment, so the manager cannot assume it ran. On a parse error,
+	// degrade to the baseline (matching baselineFeatures) instead of failing the
+	// NodeSet's reconcile.
+	if conf, err := ParseExtraConf(nodeset.Spec.ExtraConf); err == nil {
+		for key, vals := range conf {
+			if key == "Feature" || key == "Features" {
+				continue
+			}
+			confMap[key] = strings.Join(vals, ",")
 		}
 	}
 
-	confList := []string{}
+	confList := make([]string, 0, len(confMap))
 	for key, val := range confMap {
 		confList = append(confList, fmt.Sprintf("%s=%s", key, val))
 	}
 	sort.Strings(confList)
-
-	args := []string{
-		"--conf",
-		fmt.Sprintf("'%s'", strings.Join(confList, " ")),
-	}
-
-	return args
+	return []string{"--conf", fmt.Sprintf("'%s'", strings.Join(confList, " "))}
 }
 
 func (b *WorkerBuilder) getWorkerHashes(ctx context.Context, nodeset *slinkyv1beta1.NodeSet) (map[string]string, error) {

--- a/internal/builder/workerbuilder/worker_app_test.go
+++ b/internal/builder/workerbuilder/worker_app_test.go
@@ -5,6 +5,7 @@ package workerbuilder
 
 import (
 	_ "embed"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -366,6 +367,179 @@ func TestWorkerBuilder_getResourceLimits(t *testing.T) {
 			}
 			if memory != tt.want.memory {
 				t.Errorf("getResourceLimits() = %v, want %v", memory, tt.want.memory)
+			}
+		})
+	}
+}
+
+func TestParseExtraConf(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		want    map[string][]string
+		wantErr bool
+	}{
+		{name: "empty", input: "", want: map[string][]string{}},
+		{name: "single", input: "Weight=10", want: map[string][]string{"Weight": {"10"}}},
+		{name: "multiple keys", input: "Feature=a Weight=10", want: map[string][]string{"Feature": {"a"}, "Weight": {"10"}}},
+		{name: "csv value splits", input: "Features=a,b,c", want: map[string][]string{"Features": {"a", "b", "c"}}},
+		{name: "case normalised", input: "feature=a", want: map[string][]string{"Feature": {"a"}}},
+		{name: "repeated and surrounding whitespace tolerated", input: "  Weight=5  Feature=a ", want: map[string][]string{"Weight": {"5"}, "Feature": {"a"}}},
+		{name: "missing equals", input: "Weight10", wantErr: true},
+		{name: "missing equals among valid", input: "Weight=5 nope Feature=a", wantErr: true},
+		{name: "Feature and Features stay distinct keys", input: "Feature=a Features=b", want: map[string][]string{"Feature": {"a"}, "Features": {"b"}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseExtraConf(tc.input)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("ParseExtraConf() err = %v, wantErr = %v", err, tc.wantErr)
+			}
+			if tc.wantErr {
+				return
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("ParseExtraConf() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBaselineFeatures(t *testing.T) {
+	cases := []struct {
+		name      string
+		nodesetFn func() *slinkyv1beta1.NodeSet
+		want      []string
+	}{
+		{
+			name: "name only",
+			nodesetFn: func() *slinkyv1beta1.NodeSet {
+				return &slinkyv1beta1.NodeSet{ObjectMeta: metav1.ObjectMeta{Name: "gpu"}}
+			},
+			want: []string{"gpu"},
+		},
+		{
+			name: "single Feature=",
+			nodesetFn: func() *slinkyv1beta1.NodeSet {
+				return &slinkyv1beta1.NodeSet{
+					ObjectMeta: metav1.ObjectMeta{Name: "gpu"},
+					Spec:       slinkyv1beta1.NodeSetSpec{ExtraConf: "Feature=a100"},
+				}
+			},
+			want: []string{"a100", "gpu"},
+		},
+		{
+			name: "Features= CSV",
+			nodesetFn: func() *slinkyv1beta1.NodeSet {
+				return &slinkyv1beta1.NodeSet{
+					ObjectMeta: metav1.ObjectMeta{Name: "gpu"},
+					Spec:       slinkyv1beta1.NodeSetSpec{ExtraConf: "Features=a100,nvlink"},
+				}
+			},
+			want: []string{"a100", "gpu", "nvlink"},
+		},
+		{
+			name: "multiple Feature= entries merged and deduped",
+			nodesetFn: func() *slinkyv1beta1.NodeSet {
+				return &slinkyv1beta1.NodeSet{
+					ObjectMeta: metav1.ObjectMeta{Name: "gpu"},
+					Spec:       slinkyv1beta1.NodeSetSpec{ExtraConf: "Feature=a100 Feature=nvlink Features=a100"},
+				}
+			},
+			want: []string{"a100", "gpu", "nvlink"},
+		},
+		{
+			name: "hostname override replaces nodeset name",
+			nodesetFn: func() *slinkyv1beta1.NodeSet {
+				return &slinkyv1beta1.NodeSet{
+					ObjectMeta: metav1.ObjectMeta{Name: "gpu"},
+					Spec: slinkyv1beta1.NodeSetSpec{
+						Template: slinkyv1beta1.PodTemplate{
+							PodSpecWrapper: slinkyv1beta1.PodSpecWrapper{
+								PodSpec: corev1.PodSpec{Hostname: "gpu-x"},
+							},
+						},
+					},
+				}
+			},
+			want: []string{"gpu-x"},
+		},
+		{
+			name: "malformed ExtraConf falls back to bare baseline",
+			nodesetFn: func() *slinkyv1beta1.NodeSet {
+				return &slinkyv1beta1.NodeSet{
+					ObjectMeta: metav1.ObjectMeta{Name: "gpu"},
+					Spec:       slinkyv1beta1.NodeSetSpec{ExtraConf: "bad"},
+				}
+			},
+			want: []string{"gpu"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := baselineFeatures(tc.nodesetFn())
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("baselineFeatures() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSlurmdConfArgs(t *testing.T) {
+	cases := []struct {
+		name    string
+		nodeset *slinkyv1beta1.NodeSet
+		want    []string
+	}{
+		{
+			name:    "name only",
+			nodeset: &slinkyv1beta1.NodeSet{ObjectMeta: metav1.ObjectMeta{Name: "gpu"}},
+			want:    []string{"--conf", "'Features=gpu'"},
+		},
+		{
+			name: "feature and non-feature keys",
+			nodeset: &slinkyv1beta1.NodeSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "gpu"},
+				Spec:       slinkyv1beta1.NodeSetSpec{ExtraConf: "Weight=10 feature=a"},
+			},
+			want: []string{"--conf", "'Features=a,gpu Weight=10'"},
+		},
+		{
+			name: "Features CSV sorted and merged with name",
+			nodeset: &slinkyv1beta1.NodeSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "gpu"},
+				Spec:       slinkyv1beta1.NodeSetSpec{ExtraConf: "Features=z,a"},
+			},
+			want: []string{"--conf", "'Features=a,gpu,z'"},
+		},
+		{
+			name: "hostname override is the feature name",
+			nodeset: &slinkyv1beta1.NodeSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "gpu"},
+				Spec: slinkyv1beta1.NodeSetSpec{
+					Template: slinkyv1beta1.PodTemplate{
+						PodSpecWrapper: slinkyv1beta1.PodSpecWrapper{
+							PodSpec: corev1.PodSpec{Hostname: "foo-"},
+						},
+					},
+				},
+			},
+			want: []string{"--conf", "'Features=foo'"},
+		},
+		{
+			name: "malformed ExtraConf degrades to baseline instead of panicking",
+			nodeset: &slinkyv1beta1.NodeSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "gpu"},
+				Spec:       slinkyv1beta1.NodeSetSpec{ExtraConf: "Weight10 Feature=a"},
+			},
+			want: []string{"--conf", "'Features=gpu'"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := slurmdConfArgs(tc.nodeset)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("slurmdConfArgs() = %v, want %v", got, tc.want)
 			}
 		})
 	}

--- a/internal/controller/nodeset/nodeset_controller_test.go
+++ b/internal/controller/nodeset/nodeset_controller_test.go
@@ -49,6 +49,8 @@ func newFakeClientList(interceptorFuncs interceptor.Funcs, initObjLists ...objec
 			o.Comment = r.Comment
 			o.Reason = r.Reason
 			o.Topology = r.TopologyStr
+			o.Features = r.Features
+			o.ActiveFeatures = r.FeaturesAct
 		default:
 			return errors.New("failed to cast slurm object")
 		}

--- a/internal/controller/nodeset/nodeset_sync.go
+++ b/internal/controller/nodeset/nodeset_sync.go
@@ -423,6 +423,12 @@ func (r *NodeSetReconciler) sync(
 				return r.syncSlurmReservation(ctx, nodeset, pods)
 			},
 		},
+		{
+			Name: "SlurmFeatures",
+			SyncFn: func(ctx context.Context, nodeset *slinkyv1beta1.NodeSet) error {
+				return r.syncSlurmFeatures(ctx, nodeset, pods)
+			},
+		},
 	}
 	return syncsteps.Sync(ctx, r.eventRecorder, nodeset, steps)
 }
@@ -779,6 +785,57 @@ func (r *NodeSetReconciler) syncSlurmTopology(
 		return nil
 	}
 	if _, err := utils.SlowStartBatch(len(pods), utils.SlowStartInitialBatchSize, syncSlurmTopologyFn); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// syncSlurmFeatures reconciles the NodeFeaturePrefix-namespaced Slurm node features of
+// each pod from its K8s Node's AnnotationNodeFeaturesSpec. The operator owns only
+// that namespace: it replaces the prefixed features with the (prefixed) annotation
+// values and preserves all other features, including the NodeSet baseline (seeded
+// at slurmd registration via --conf), ExtraConf features, and externally-managed
+// features such as those from NodeFeaturesPlugins. Removing the annotation clears
+// the node's prefixed features.
+//
+// Features are applied through the reconcile loop and are eventually consistent: a
+// Node annotation change re-enqueues the NodeSet, after which the prefixed features
+// are reconciled to match.
+func (r *NodeSetReconciler) syncSlurmFeatures(
+	ctx context.Context,
+	nodeset *slinkyv1beta1.NodeSet,
+	pods []*corev1.Pod,
+) error {
+	syncSlurmFeaturesFn := func(i int) error {
+		pod := pods[i]
+
+		if pod.Spec.NodeName == "" {
+			// Skip if Pod has not been allocated to a Node.
+			return nil
+		}
+
+		node := &corev1.Node{}
+		nodeKey := types.NamespacedName{Name: pod.Spec.NodeName}
+		if err := r.Get(ctx, nodeKey, node); err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+
+		// An absent annotation yields an empty feature set, which clears any
+		// previously applied prefixed features on the Slurm node.
+		annotation := node.Annotations[slinkyv1beta1.AnnotationNodeFeaturesSpec]
+		features := structutils.SortedDedup(strings.Split(annotation, ","))
+
+		if err := r.slurmControl.UpdateNodeFeatures(ctx, nodeset, pod, slinkyv1beta1.NodeFeaturePrefix, features); err != nil {
+			return fmt.Errorf("failed to update Slurm node features: %w", err)
+		}
+
+		return nil
+	}
+	if _, err := utils.SlowStartBatch(len(pods), utils.SlowStartInitialBatchSize, syncSlurmFeaturesFn); err != nil {
 		return err
 	}
 

--- a/internal/controller/nodeset/nodeset_sync_test.go
+++ b/internal/controller/nodeset/nodeset_sync_test.go
@@ -3851,6 +3851,208 @@ func TestNodeSetReconciler_syncSlurmTopology(t *testing.T) {
 	}
 }
 
+func TestNodeSetReconciler_syncSlurmFeatures(t *testing.T) {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node0",
+		},
+	}
+	node2 := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node1",
+			Annotations: map[string]string{
+				slinkyv1beta1.AnnotationNodeFeaturesSpec: "nn-75bfcf47ca3e4f7dc,GPU",
+			},
+		},
+	}
+	controller := &slinkyv1beta1.Controller{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "slurm",
+		},
+	}
+	nodeset := newNodeSet("foo", controller.Name, 3)
+	pod := nodesetutils.NewNodeSetStatefulSetPod(fake.NewFakeClient(), nodeset, controller, 0, "")
+	pod2 := nodesetutils.NewNodeSetStatefulSetPod(fake.NewFakeClient(), nodeset, controller, 1, "")
+	pod2.Spec.NodeName = node2.Name
+	pod3 := nodesetutils.NewNodeSetStatefulSetPod(fake.NewFakeClient(), nodeset, controller, 2, "")
+	pod3.Spec.NodeName = node.Name
+	nodeEq := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-eq",
+			Annotations: map[string]string{
+				slinkyv1beta1.AnnotationNodeFeaturesSpec: "location=us-east-2,nn-aaaa1111",
+			},
+		},
+	}
+	podEq := nodesetutils.NewNodeSetStatefulSetPod(fake.NewFakeClient(), nodeset, controller, 3, "")
+	podEq.Spec.NodeName = nodeEq.Name
+
+	// DaemonSet-mode pod: GetSlurmNodeName resolves the Slurm node name from
+	// pod.Spec.Hostname (set by the daemonset pod builder), exercising the other
+	// branch from the StatefulSet-mode pods above.
+	dnode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "dnode",
+			Annotations: map[string]string{
+				slinkyv1beta1.AnnotationNodeFeaturesSpec: "nn-bbbb2222,IB",
+			},
+		},
+	}
+	daemonPod := newDaemonPodForNodeSet("foo-daemon", dnode.Name, nodeset)
+	daemonPod.Spec.Hostname = dnode.Name
+
+	// Node without the features annotation, with a pod whose Slurm node still carries
+	// a stale operator-prefixed feature, used to verify cleanup on annotation removal.
+	nodeClean := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-clean"}}
+	podClean := nodesetutils.NewNodeSetStatefulSetPod(fake.NewFakeClient(), nodeset, controller, 4, "")
+	podClean.Spec.NodeName = nodeClean.Name
+
+	prefix := slinkyv1beta1.NodeFeaturePrefix
+	// slurmNodeForPod returns a one-node list for the pod's Slurm node, seeded with
+	// the given features in both available and active (e.g. the registration baseline).
+	slurmNodeForPod := func(p *corev1.Pod, features ...string) *slurmtypes.V0044NodeList {
+		n := slurmtypes.V0044Node{
+			V0044Node: slurmapi.V0044Node{
+				Name:  ptr.To(nodesetutils.GetSlurmNodeName(p)),
+				State: ptr.To([]slurmapi.V0044NodeState{slurmapi.V0044NodeStateIDLE}),
+			},
+		}
+		if len(features) > 0 {
+			n.Features = ptr.To(slurmapi.V0044CsvString(features))
+			n.ActiveFeatures = ptr.To(slurmapi.V0044CsvString(features))
+		}
+		return &slurmtypes.V0044NodeList{Items: []slurmtypes.V0044Node{n}}
+	}
+
+	tests := []struct {
+		name         string
+		client       client.Client
+		slurmNodes   *slurmtypes.V0044NodeList // Slurm node registered for the pod, or nil
+		nodeset      *slinkyv1beta1.NodeSet
+		pods         []*corev1.Pod
+		wantFeatures []string
+		wantNoUpdate bool // assert the reconcile issues no Slurm node update
+		wantErr      bool
+	}{
+		{
+			name:         "pending",
+			client:       fake.NewFakeClient(node.DeepCopy(), node2.DeepCopy(), pod.DeepCopy()),
+			nodeset:      nodeset,
+			pods:         []*corev1.Pod{pod.DeepCopy()},
+			wantNoUpdate: true,
+		},
+		{
+			name:       "allocated with annotation",
+			client:     fake.NewFakeClient(node.DeepCopy(), node2.DeepCopy(), pod2.DeepCopy()),
+			slurmNodes: slurmNodeForPod(pod2, "foo"),
+			nodeset:    nodeset,
+			pods:       []*corev1.Pod{pod2.DeepCopy()},
+			// Baseline "foo" preserved; annotation "nn-75bfcf47ca3e4f7dc,GPU" applied under the prefix.
+			wantFeatures: []string{"foo", prefix + "GPU", prefix + "nn-75bfcf47ca3e4f7dc"},
+		},
+		{
+			name:       "allocated without annotation skips update",
+			client:     fake.NewFakeClient(node.DeepCopy(), node2.DeepCopy(), pod3.DeepCopy()),
+			slurmNodes: slurmNodeForPod(pod3, "foo"),
+			nodeset:    nodeset,
+			pods:       []*corev1.Pod{pod3.DeepCopy()},
+			// No annotation and no prefixed features present: nothing to do.
+			wantNoUpdate: true,
+			wantFeatures: []string{"foo"},
+		},
+		{
+			name:       "annotation removed clears prefixed features",
+			client:     fake.NewFakeClient(nodeClean.DeepCopy(), podClean.DeepCopy()),
+			slurmNodes: slurmNodeForPod(podClean, "foo", prefix+"stale"),
+			nodeset:    nodeset,
+			pods:       []*corev1.Pod{podClean.DeepCopy()},
+			// No annotation: strip the operator-prefixed feature, preserve the baseline.
+			wantFeatures: []string{"foo"},
+		},
+		{
+			name:       "allocated with =-bearing feature",
+			client:     fake.NewFakeClient(nodeEq.DeepCopy(), podEq.DeepCopy()),
+			slurmNodes: slurmNodeForPod(podEq, "foo"),
+			nodeset:    nodeset,
+			pods:       []*corev1.Pod{podEq.DeepCopy()},
+			// annotation is comma-split only, so "location=us-east-2" stays a single feature token
+			wantFeatures: []string{"foo", prefix + "location=us-east-2", prefix + "nn-aaaa1111"},
+		},
+		{
+			name:       "daemonset mode with annotation",
+			client:     fake.NewFakeClient(dnode.DeepCopy(), daemonPod.DeepCopy()),
+			slurmNodes: slurmNodeForPod(daemonPod, "foo"),
+			nodeset:    nodeset,
+			pods:       []*corev1.Pod{daemonPod.DeepCopy()},
+			// DaemonSet pods resolve the Slurm node name via pod.Spec.Hostname.
+			wantFeatures: []string{"foo", prefix + "IB", prefix + "nn-bbbb2222"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			updates := 0
+			funcs := sinterceptor.Funcs{}
+			if tt.wantNoUpdate {
+				// Count (and suppress) Slurm node updates so we can assert none are issued.
+				funcs.Update = func(_ context.Context, _ slurmobject.Object, _ any, _ ...slurmclient.UpdateOption) error {
+					updates++
+					return nil
+				}
+			}
+			var lists []slurmobject.ObjectList
+			if tt.slurmNodes != nil {
+				lists = append(lists, tt.slurmNodes)
+			}
+			clientMap := newClientMap(controller.Name, newFakeClientList(funcs, lists...))
+			r := newNodeSetController(tt.client, clientMap)
+			gotErr := r.syncSlurmFeatures(ctx, tt.nodeset, tt.pods)
+			if gotErr != nil {
+				if !tt.wantErr {
+					t.Errorf("syncSlurmFeatures() failed: %v", gotErr)
+				}
+				return
+			}
+			if tt.wantErr {
+				t.Fatal("syncSlurmFeatures() succeeded unexpectedly")
+			}
+			if tt.wantNoUpdate && updates != 0 {
+				t.Errorf("syncSlurmFeatures() issued %d Slurm update(s), want 0", updates)
+			}
+			for _, pod := range tt.pods {
+				if pod.Spec.NodeName == "" {
+					continue
+				}
+				mapKey := types.NamespacedName{
+					Namespace: tt.nodeset.Namespace,
+					Name:      tt.nodeset.Spec.ControllerRef.Name,
+				}
+				sclient := clientMap.Get(mapKey)
+				if sclient == nil {
+					continue
+				}
+				slurmNode := &slurmtypes.V0044Node{}
+				slurmNodeKey := slurmclient.ObjectKey(nodesetutils.GetSlurmNodeName(pod))
+				if err := sclient.Get(ctx, slurmNodeKey, slurmNode); err != nil {
+					t.Errorf("Get() failed: %v", err)
+				}
+				gotAvail := ptr.Deref(slurmNode.Features, slurmapi.V0044CsvString{})
+				gotActive := ptr.Deref(slurmNode.ActiveFeatures, slurmapi.V0044CsvString{})
+				slices.Sort(gotAvail)
+				slices.Sort(gotActive)
+				want := slices.Clone(tt.wantFeatures)
+				slices.Sort(want)
+				if !slices.Equal(gotAvail, want) {
+					t.Errorf("Slurm node available features = %v, want %v", gotAvail, want)
+				}
+				if !slices.Equal(gotActive, want) {
+					t.Errorf("Slurm node active features = %v, want %v", gotActive, want)
+				}
+			}
+		})
+	}
+}
+
 func TestGetNodesToDaemonPods(t *testing.T) {
 	nodeset := newNodeSet("foo", "ctrl", 1)
 	nodeset.Spec.ScalingMode = slinkyv1beta1.ScalingModeDaemonset

--- a/internal/controller/nodeset/slurmcontrol/slurmcontrol.go
+++ b/internal/controller/nodeset/slurmcontrol/slurmcontrol.go
@@ -32,6 +32,7 @@ import (
 	"github.com/SlinkyProject/slurm-operator/internal/clientmap"
 	nodesetutils "github.com/SlinkyProject/slurm-operator/internal/controller/nodeset/utils"
 	"github.com/SlinkyProject/slurm-operator/internal/utils/podinfo"
+	"github.com/SlinkyProject/slurm-operator/internal/utils/structutils"
 	"github.com/SlinkyProject/slurm-operator/internal/utils/timestore"
 	slurmconditions "github.com/SlinkyProject/slurm-operator/pkg/conditions"
 )
@@ -43,6 +44,9 @@ type SlurmControlInterface interface {
 	UpdateNodeWithPodInfo(ctx context.Context, nodeset *slinkyv1beta1.NodeSet, pod *corev1.Pod) error
 	// UpdateNodeTopology handles updating the Node with its topologySpec.
 	UpdateNodeTopology(ctx context.Context, nodeset *slinkyv1beta1.NodeSet, pod *corev1.Pod, topologySpec string) error
+	// UpdateNodeFeatures reconciles the prefix-namespaced Slurm node features to the
+	// given (unprefixed) values, preserving all features outside the prefix.
+	UpdateNodeFeatures(ctx context.Context, nodeset *slinkyv1beta1.NodeSet, pod *corev1.Pod, prefix string, features []string) error
 	// MakeNodeDrain handles adding the DRAIN state to the slurm node.
 	MakeNodeDrain(ctx context.Context, nodeset *slinkyv1beta1.NodeSet, pod *corev1.Pod, reason string) error
 	// MakeNodeUndrain handles removing the DRAIN state from the slurm node.
@@ -200,6 +204,78 @@ func (r *realSlurmControl) UpdateNodeTopology(ctx context.Context, nodeset *slin
 	}
 
 	return nil
+}
+
+// UpdateNodeFeatures implements SlurmControlInterface.
+func (r *realSlurmControl) UpdateNodeFeatures(ctx context.Context, nodeset *slinkyv1beta1.NodeSet, pod *corev1.Pod, prefix string, features []string) error {
+	logger := log.FromContext(ctx)
+
+	slurmClient := r.lookupClient(nodeset)
+	if slurmClient == nil {
+		logger.V(2).Info("no client for nodeset, cannot do UpdateNodeFeatures()",
+			"pod", klog.KObj(pod))
+		return nil
+	}
+
+	slurmNode := &slurmtypes.V0044Node{}
+	key := slurmobject.ObjectKey(nodesetutils.GetSlurmNodeName(pod))
+	if err := slurmClient.Get(ctx, key, slurmNode); err != nil {
+		if tolerateError(err) {
+			return nil
+		}
+		return err
+	}
+
+	// The operator owns only the `prefix` namespace. Recompute the available and
+	// active feature sets by replacing the prefixed features with the desired set
+	// and preserving everything else: the NodeSet baseline (seeded at slurmd
+	// registration via --conf), ExtraConf features, and externally-managed features
+	// such as those from NodeFeaturesPlugins.
+	desired := make([]string, 0, len(features))
+	for _, f := range features {
+		desired = append(desired, prefix+f)
+	}
+	curAvailable := ptr.Deref(slurmNode.Features, slurmapi.V0044CsvString{})
+	curActive := ptr.Deref(slurmNode.ActiveFeatures, slurmapi.V0044CsvString{})
+	newAvailable := replaceFeatureNamespace(curAvailable, prefix, desired)
+	newActive := replaceFeatureNamespace(curActive, prefix, desired)
+
+	// Features are a set; compare order-insensitively so we only update when the
+	// prefixed namespace actually changed.
+	availableInSync := set.New(newAvailable...).Equal(set.New(curAvailable...))
+	activeInSync := set.New(newActive...).Equal(set.New(curActive...))
+	if availableInSync && activeInSync {
+		logger.V(3).Info("Node features already in sync, skipping update request",
+			"node", slurmNode.GetKey(), "features", desired)
+		return nil
+	}
+
+	logger.Info("Update Slurm Node features", "Node", slurmNode.GetKey(), "features", desired)
+	req := slurmapi.V0044UpdateNodeMsg{
+		Features:    ptr.To(slurmapi.V0044CsvString(newAvailable)),
+		FeaturesAct: ptr.To(slurmapi.V0044CsvString(newActive)),
+	}
+	if err := slurmClient.Update(ctx, slurmNode, req); err != nil {
+		if tolerateError(err) {
+			return nil
+		}
+		return err
+	}
+
+	return nil
+}
+
+// replaceFeatureNamespace returns current with all features carrying prefix replaced
+// by desired (already prefixed), preserving every feature outside the prefix. The
+// result is sorted and de-duplicated.
+func replaceFeatureNamespace(current []string, prefix string, desired []string) []string {
+	preserved := make([]string, 0, len(current))
+	for _, f := range current {
+		if !strings.HasPrefix(f, prefix) {
+			preserved = append(preserved, f)
+		}
+	}
+	return structutils.SortedDedup(structutils.MergeList(preserved, desired))
 }
 
 const nodeReasonPrefix = "slurm-operator:"

--- a/internal/controller/nodeset/slurmcontrol/slurmcontrol_test.go
+++ b/internal/controller/nodeset/slurmcontrol/slurmcontrol_test.go
@@ -54,6 +54,8 @@ func slurmUpdateFn(_ context.Context, obj object.Object, req any, opts ...client
 		o.Comment = r.Comment
 		o.Reason = r.Reason
 		o.Topology = r.TopologyStr
+		o.Features = r.Features
+		o.ActiveFeatures = r.FeaturesAct
 	case *types.V0044ReservationInfo:
 		_, ok := req.(api.V0044ReservationDescMsg)
 		if !ok {
@@ -405,6 +407,166 @@ func Test_realSlurmControl_UpdateNodeTopology(t *testing.T) {
 			got := ptr.Deref(checkNode.Topology, "")
 			if !apiequality.Semantic.DeepEqual(got, tt.args.topologySpec) {
 				t.Fatalf("UpdateNodeTopology() topologySpec = %v", got)
+			}
+		})
+	}
+}
+
+func Test_realSlurmControl_UpdateNodeFeatures(t *testing.T) {
+	ctx := context.Background()
+	controller := &slinkyv1beta1.Controller{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "slurm",
+		},
+	}
+	nodeset := newNodeSet("foo", controller.Name, 1)
+	pod := nodesetutils.NewNodeSetStatefulSetPod(kubefake.NewFakeClient(), nodeset, controller, 0, "")
+	prefix := slinkyv1beta1.NodeFeaturePrefix
+	// nodeWith returns an IDLE Slurm node with the given available/active features.
+	nodeWith := func(available, active []string) *types.V0044Node {
+		n := &types.V0044Node{
+			V0044Node: api.V0044Node{
+				Name:  ptr.To(nodesetutils.GetSlurmNodeName(pod)),
+				State: ptr.To([]api.V0044NodeState{api.V0044NodeStateIDLE}),
+			},
+		}
+		if available != nil {
+			n.Features = ptr.To(api.V0044CsvString(available))
+		}
+		if active != nil {
+			n.ActiveFeatures = ptr.To(api.V0044CsvString(active))
+		}
+		return n
+	}
+	type args struct {
+		ctx      context.Context
+		nodeset  *slinkyv1beta1.NodeSet
+		pod      *corev1.Pod
+		features []string
+	}
+	tests := []struct {
+		name          string
+		node          *types.V0044Node
+		args          args
+		notRegistered bool  // node absent from slurmctld: Get returns a tolerated 404
+		updateErr     error // non-nil makes the Slurm Update fail with this error
+		wantErr       bool
+		wantSkip      bool
+		wantAvailable []string
+		wantActive    []string
+	}{
+		{
+			name:          "adds prefixed features, preserves baseline",
+			node:          nodeWith([]string{"foo"}, []string{"foo"}),
+			args:          args{ctx: ctx, nodeset: nodeset, pod: pod, features: []string{"a100"}},
+			wantAvailable: []string{"foo", prefix + "a100"},
+			wantActive:    []string{"foo", prefix + "a100"},
+		},
+		{
+			// Stale prefixed feature is replaced; non-prefixed (external) features stay.
+			name:          "replaces stale prefixed, preserves external",
+			node:          nodeWith([]string{"foo", prefix + "old"}, []string{"foo", prefix + "old"}),
+			args:          args{ctx: ctx, nodeset: nodeset, pod: pod, features: []string{"new"}},
+			wantAvailable: []string{"foo", prefix + "new"},
+			wantActive:    []string{"foo", prefix + "new"},
+		},
+		{
+			// Empty desired (annotation removed) strips the prefixed namespace only.
+			name:          "empty desired strips prefixed, preserves external",
+			node:          nodeWith([]string{"foo", prefix + "old"}, []string{"foo", prefix + "old"}),
+			args:          args{ctx: ctx, nodeset: nodeset, pod: pod, features: nil},
+			wantAvailable: []string{"foo"},
+			wantActive:    []string{"foo"},
+		},
+		{
+			name:          "already in sync skips",
+			node:          nodeWith([]string{"foo", prefix + "a100"}, []string{"foo", prefix + "a100"}),
+			args:          args{ctx: ctx, nodeset: nodeset, pod: pod, features: []string{"a100"}},
+			wantSkip:      true,
+			wantAvailable: []string{"foo", prefix + "a100"},
+			wantActive:    []string{"foo", prefix + "a100"},
+		},
+		{
+			name:          "no prefixed and empty desired skips",
+			node:          nodeWith([]string{"foo"}, []string{"foo"}),
+			args:          args{ctx: ctx, nodeset: nodeset, pod: pod, features: nil},
+			wantSkip:      true,
+			wantAvailable: []string{"foo"},
+			wantActive:    []string{"foo"},
+		},
+		{
+			// NodeFeaturesPlugins case: changeable features (mig=on/off available,
+			// mig=on active) must survive; only the prefixed namespace is replaced.
+			name:          "plugin-managed features survive",
+			node:          nodeWith([]string{"foo", "mig=on", "mig=off", prefix + "old"}, []string{"foo", "mig=on", prefix + "old"}),
+			args:          args{ctx: ctx, nodeset: nodeset, pod: pod, features: []string{"nn-a"}},
+			wantAvailable: []string{"foo", "mig=off", "mig=on", prefix + "nn-a"},
+			wantActive:    []string{"foo", "mig=on", prefix + "nn-a"},
+		},
+		{
+			// Node not registered in slurmctld yet: Get returns a tolerated 404 and
+			// the call is a no-op.
+			name:          "node not registered is tolerated",
+			node:          nodeWith([]string{"foo"}, []string{"foo"}),
+			args:          args{ctx: ctx, nodeset: nodeset, pod: pod, features: []string{"a100"}},
+			notRegistered: true,
+		},
+		{
+			// A non-tolerated error from the Slurm update is surfaced to the caller.
+			name:      "update error is returned",
+			node:      nodeWith([]string{"foo"}, []string{"foo"}),
+			args:      args{ctx: ctx, nodeset: nodeset, pod: pod, features: []string{"a100"}},
+			updateErr: errors.New("boom"),
+			wantErr:   true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			updates := 0
+			updateFn := func(ctx context.Context, obj object.Object, req any, opts ...client.UpdateOption) error {
+				updates++
+				if tt.updateErr != nil {
+					return tt.updateErr
+				}
+				return slurmUpdateFn(ctx, obj, req, opts...)
+			}
+			builder := fake.NewClientBuilder().WithUpdateFn(updateFn)
+			if !tt.notRegistered {
+				builder = builder.WithObjects(tt.node)
+			}
+			sclient := builder.Build()
+			controllerName := tt.args.nodeset.Spec.ControllerRef.Name
+			r := NewSlurmControl(newSlurmClientMap(controllerName, sclient))
+			if err := r.UpdateNodeFeatures(tt.args.ctx, tt.args.nodeset, tt.args.pod, prefix, tt.args.features); (err != nil) != tt.wantErr {
+				t.Errorf("UpdateNodeFeatures() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantSkip && updates != 0 {
+				t.Errorf("UpdateNodeFeatures() issued %d update(s), want 0 (already in sync)", updates)
+			}
+			// The Slurm node feature set is only well-defined on the success path; for
+			// the tolerated-404 and error cases there is nothing to assert.
+			if tt.notRegistered || tt.wantErr {
+				return
+			}
+			checkNode := &types.V0044Node{}
+			if err := sclient.Get(ctx, tt.node.GetKey(), checkNode); err != nil {
+				if !tolerateError(err) {
+					t.Fatalf("client.Get() = %v", err)
+				}
+			}
+			gotAvail := ptr.Deref(checkNode.Features, api.V0044CsvString{})
+			gotActive := ptr.Deref(checkNode.ActiveFeatures, api.V0044CsvString{})
+			slices.Sort(gotAvail)
+			slices.Sort(gotActive)
+			wantAvail := slices.Clone(tt.wantAvailable)
+			wantActive := slices.Clone(tt.wantActive)
+			slices.Sort(wantAvail)
+			slices.Sort(wantActive)
+			if !slices.Equal(gotAvail, wantAvail) {
+				t.Errorf("UpdateNodeFeatures() available = %v, want %v", gotAvail, wantAvail)
+			}
+			if !slices.Equal(gotActive, wantActive) {
+				t.Errorf("UpdateNodeFeatures() active = %v, want %v", gotActive, wantActive)
 			}
 		})
 	}

--- a/internal/utils/structutils/list.go
+++ b/internal/utils/structutils/list.go
@@ -3,6 +3,11 @@
 
 package structutils
 
+import (
+	"sort"
+	"strings"
+)
+
 // Convert a list to a referenced list.
 func ReferenceList[T any](items []T) []*T {
 	list := make([]*T, 0, len(items))
@@ -35,4 +40,25 @@ func MergeList[T any](items ...[]T) []T {
 		list = append(list, item...)
 	}
 	return list
+}
+
+// SortedDedup trims whitespace from each entry, drops empty entries and
+// duplicates, and returns the result sorted, normalizing a string set into a
+// deterministic, comparable list.
+func SortedDedup(in []string) []string {
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	sort.Strings(out)
+	return out
 }

--- a/internal/utils/structutils/list_test.go
+++ b/internal/utils/structutils/list_test.go
@@ -90,3 +90,25 @@ func TestDereferenceList(t *testing.T) {
 		})
 	}
 }
+
+func TestSortedDedup(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{name: "empty", in: []string{}, want: []string{}},
+		{name: "sorts", in: []string{"c", "a", "b"}, want: []string{"a", "b", "c"}},
+		{name: "dedups", in: []string{"a", "a", "b"}, want: []string{"a", "b"}},
+		{name: "trims whitespace", in: []string{" a ", "b\t"}, want: []string{"a", "b"}},
+		{name: "drops empty and whitespace-only entries", in: []string{"a", "", "  "}, want: []string{"a"}},
+		{name: "combined sort dedup trim", in: []string{" b ", "a", "b", ""}, want: []string{"a", "b"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SortedDedup(tt.in); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("SortedDedup() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/webhook/nodeset_webhook.go
+++ b/internal/webhook/nodeset_webhook.go
@@ -20,6 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	"github.com/SlinkyProject/slurm-operator/internal/builder/workerbuilder"
 )
 
 // +kubebuilder:rbac:groups=slinky.slurm.net,resources=nodesets,verbs=delete;create;update
@@ -108,6 +109,10 @@ func (r *NodeSetWebhook) validateNodeSet(nodeset *slinkyv1beta1.NodeSet) (admiss
 		for _, msg := range apivalidation.NameIsDNSSubdomain(hostname, true) {
 			errs = append(errs, fmt.Errorf("template.spec.hostname: %s", msg))
 		}
+	}
+
+	if _, err := workerbuilder.ParseExtraConf(nodeset.Spec.ExtraConf); err != nil {
+		errs = append(errs, fmt.Errorf("invalid extraConf: %w", err))
 	}
 
 	return warns, errs

--- a/internal/webhook/nodeset_webhook_test.go
+++ b/internal/webhook/nodeset_webhook_test.go
@@ -76,6 +76,24 @@ var _ = Describe("NodeSet Webhook", func() {
 			_, err := nodeSetWebhook.ValidateCreate(ctx, nodeset)
 			Expect(err).NotTo(HaveOccurred())
 		})
+
+		It("Should deny malformed extraConf", func(ctx SpecContext) {
+			controller := testutils.NewController("some-controller", corev1.SecretKeySelector{}, corev1.SecretKeySelector{}, nil)
+			nodeset := testutils.NewNodeset("test-nodeset", controller, 1)
+			nodeset.Spec.ExtraConf = "Weight10"
+
+			_, err := nodeSetWebhook.ValidateCreate(ctx, nodeset)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("Should admit valid extraConf", func(ctx SpecContext) {
+			controller := testutils.NewController("some-controller", corev1.SecretKeySelector{}, corev1.SecretKeySelector{}, nil)
+			nodeset := testutils.NewNodeset("test-nodeset", controller, 1)
+			nodeset.Spec.ExtraConf = "Feature=a Weight=5"
+
+			_, err := nodeSetWebhook.ValidateCreate(ctx, nodeset)
+			Expect(err).NotTo(HaveOccurred())
+		})
 	})
 
 	Context("When Updating a NodeSet with Validating Webhook", func() {


### PR DESCRIPTION
## Summary

Add support for syncing Slurm node features from a Kubernetes Node annotation.

When a NodeSet pod is running on a Kubernetes Node annotated with `features.slinky.slurm.net/spec` (a comma-separated list of Slurm features), the operator merges that list with the per-NodeSet baseline and applies it to the registered Slurm node's available and active features. Jobs can then target those nodes with `sbatch --constraint=<feature>`.

The driving use case is tagging each node with a dynamically discovered E/W leaf-switch ID (e.g. `nn-75bfcf47ca3e4f7dc`) so users can constrain jobs to a single switch for network locality, but the mechanism is general: the annotation value is an opaque feature set and is not interpreted by the operator.

How it works:

- New well-known node annotation `features.slinky.slurm.net/spec` and `FeaturesPrefix` (`api/v1beta1/well_known.go`).
- A new `syncSlurmFeatures` reconcile step reads the annotation off the Kubernetes Node each NodeSet pod is bound to. For Nodes that carry the annotation it merges it with `BaselineFeatures` (the NodeSet name or hostname override plus any `Feature=`/`Features=` entries from `Spec.ExtraConf`) and pushes the sorted, de-duplicated union to the Slurm node via the REST API, setting both `Features` (available) and `FeaturesAct` (active). Nodes without the annotation are left untouched, since slurmd already registered them with the baseline.
- The existing `ExtraConf` parsing is extracted into shared, exported helpers (`ParseExtraConf`, `BaselineFeatures`, `SortedDedup`) in `workerbuilder`, so the slurmd build path and the new sync path use one contract.
- The NodeSet validation webhook validates `Spec.ExtraConf` at admission using the same parser.

Delivery is through the reconcile loop only: `NodeEventHandler` already re-enqueues a NodeSet when a Node's metadata changes. The component that discovers topology and writes the annotation (e.g. a daemon querying the CSP topology API) is out of scope for this change; the operator only propagates the annotation it finds.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/SlinkyProject/slurm-operator/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/SlinkyProject/slurm-operator/blob/main/CODE_OF_CONDUCT.md).
- [x] New or existing tests cover these changes (where applicable).
- [x] Documentation is updated if user-visible behavior changes.

## Breaking Changes

The NodeSet validation webhook (when `webhook.enabled` is set, the slurm-operator chart default) now rejects `Spec.ExtraConf` whose contents are not whitespace-separated `Key=Value` pairs, on both create and update.

This is not a behavioral regression. Previously, malformed `ExtraConf` wedged the affected NodeSet's reconcile: building its slurmd pod parsed the same string and `panic`ed. controller-runtime recovers the panic (the manager process does not crash), but that NodeSet never gets its worker pods built and the reconcile keeps retrying. This change does two things. It surfaces the problem as a clear admission error at apply time (via the webhook, using the exact same parser), and it makes the build path degrade to the baseline `Features=<name>` instead of panicking, so a NodeSet that bypasses the webhook (a separate, optional deployment) no longer wedges its reconcile. A NodeSet created before this validation that carries malformed `ExtraConf` is rejected on its next update until the `ExtraConf` is corrected.

## Testing Notes

Automated (`make test`, `go vet`, `make golangci-lint` all pass):

- `workerbuilder`: `TestParseExtraConf` (valid, CSV, case-normalisation, `Feature`/`Features` distinct keys, whitespace tolerance, malformed errors), `TestBaselineFeatures` (name-only, `Feature=`, `Features=` CSV, dedup, hostname override, malformed-falls-back-to-baseline, empty-hostname-falls-back-to-name), `TestSlurmdConfArgs` (full `--conf` output, including malformed-degrades-to-baseline).
- `slurmcontrol`: `Test_realSlurmControl_UpdateNodeFeatures` asserts both `Features` and `ActiveFeatures` land, stale features are replaced, an already-in-sync node issues zero updates (order-insensitive skip), an unregistered node is tolerated, and a non-tolerated update error is surfaced.
- `nodeset`: `TestNodeSetReconciler_syncSlurmFeatures` (pending pod, allocated with annotation, allocated-without-annotation skips the update, `=`-bearing feature value) with a counting interceptor asserting no update is issued where expected.
- `webhook`: `nodeset_webhook_test.go` denies malformed and admits valid `ExtraConf`.

Manual (kind cluster, slurm-operator + slurm chart):

```sh
# Annotate the Kubernetes node a worker pod runs on:
kubectl annotate node <node> features.slinky.slurm.net/spec=nn-75bfcf47ca3e4f7dc,GPU

# After one reconcile, both feature lists hold the sorted union of the baseline
# (<nodeset-name>) and the annotation:
kubectl exec -n slurm <controller-pod> -c slurmctld -- \
  scontrol show node <slurm-node> | grep -E 'AvailableFeatures|ActiveFeatures'
# AvailableFeatures=GPU,nn-75bfcf47ca3e4f7dc,<nodeset-name>
# ActiveFeatures=GPU,nn-75bfcf47ca3e4f7dc,<nodeset-name>

# A constraint job targets the tagged node:
sbatch --constraint=nn-75bfcf47ca3e4f7dc ...

# Admission rejects malformed extraConf:
kubectl patch nodeset <name> --type=merge -p '{"spec":{"extraConf":"BadFormat"}}'
# rejected: invalid extraConf: malformed --conf item "BadFormat": expected Key=Value
```

Verified end-to-end on the current code (kind, slurm-operator + slurm chart, webhook enabled, NodeSet `extraConf: Feature=rdma`, Slurm node `slinky-0`):

- Propagation: annotating the node `nn-cccc3333,GPU` set both `AvailableFeatures` and `ActiveFeatures` to `GPU,nn-cccc3333,rdma,slinky` (the sorted union of the baseline and the annotation) in a single REST update.
- Re-annotation: changing the annotation to `nn-dddd4444,GPU` replaced the old switch ID while preserving the `rdma,slinky` baseline.
- Skip when unannotated: removing the annotation issued no update (the operator logged none) and the previously applied features lingered rather than reverting to the baseline, matching the documented opt-in behavior; re-adding the annotation re-applied them.
- Admission: a malformed `extraConf` (`BadFormat`) was rejected with `invalid extraConf: malformed --conf item "BadFormat": expected Key=Value`; a valid `extraConf` was admitted.

The build-path degrade on malformed `extraConf` is covered by unit tests (`TestSlurmdConfArgs`); it is not exercised live because, with the webhook enabled, such input is rejected at admission before reaching the build path.

## Additional Context

Out of scope by design: 

- a `POD_FEATURES` env var / startup injection: The reconcile loop is the simpler, image-change-free, and reliable path, and it's required regardless because discovery is async. Startup injection would only shrink a brief eventual-consistency window for nodes already annotated at pod start, which doesn't apply to the async use case and doesn't remove the need for the loop, so my opinin is it's not worth the added cost but open to discuss.

