### PR TITLE
test: Leverage testify/require in test suite (p1)

### DIFF
--- a/cmd/manager/main_test.go
+++ b/cmd/manager/main_test.go
@@ -11,6 +11,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
@@ -34,12 +36,9 @@ func parseFlagsForTest(t *testing.T, args []string) Flags {
 
 func Test_parseFlags(t *testing.T) {
 	flags := parseFlagsForTest(t, []string{"test", "--health-addr", "8080", "--leader-elect", "true"})
-	if flags.probeAddr != "8080" {
-		t.Errorf("Test_parseFlags() probeAddr = %v, want %v", flags.probeAddr, "8080")
-	}
-	if !flags.enableLeaderElection {
-		t.Errorf("Test_parseFlags() server = %v, want %v", flags.enableLeaderElection, true)
-	}
+
+	require.Equal(t, "8080", flags.probeAddr)
+	require.True(t, flags.enableLeaderElection)
 }
 
 func Test_parseFlags_namespaces(t *testing.T) {
@@ -67,9 +66,7 @@ func Test_parseFlags_namespaces(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			flags := parseFlagsForTest(t, tt.args)
-			if flags.namespaces != tt.want {
-				t.Errorf("parseFlags() namespaces = %v, want %v", flags.namespaces, tt.want)
-			}
+			require.Equal(t, tt.want, flags.namespaces)
 		})
 	}
 }
@@ -83,15 +80,9 @@ func Test_parseFlags_profile(t *testing.T) {
 		"--leader-elect",
 	})
 
-	if !flags.profile {
-		t.Errorf("parseFlags() profile = %v, want %v", flags.profile, true)
-	}
-	if flags.profileAddr != "localhost:6061" {
-		t.Errorf("parseFlags() profileAddr = %v, want %v", flags.profileAddr, "localhost:6061")
-	}
-	if !flags.enableLeaderElection {
-		t.Errorf("parseFlags() enableLeaderElection = %v, want %v", flags.enableLeaderElection, true)
-	}
+	require.True(t, flags.profile)
+	require.Equal(t, "localhost:6061", flags.profileAddr)
+	require.True(t, flags.enableLeaderElection)
 }
 
 func Test_profileAddr(t *testing.T) {
@@ -114,9 +105,7 @@ func Test_profileAddr(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := profileAddr(tt.addr); got != tt.want {
-				t.Errorf("profileAddr(%q) = %q, want %q", tt.addr, got, tt.want)
-			}
+			require.Equal(t, tt.want, profileAddr(tt.addr))
 		})
 	}
 }
@@ -126,32 +115,21 @@ func Test_newProfileMux(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	resp, err := http.Get(server.URL + "/debug/pprof/")
-	if err != nil {
-		t.Fatalf("http.Get(%q) error = %v", server.URL+"/debug/pprof/", err)
-	}
+	require.NoError(t, err)
 	t.Cleanup(func() {
-		if err := resp.Body.Close(); err != nil {
-			t.Errorf("Body.Close() error = %v", err)
-		}
+		require.NoError(t, resp.Body.Close())
 	})
 
-	if resp.StatusCode != http.StatusOK {
-		t.Errorf("GET /debug/pprof/ status = %v, want %v", resp.StatusCode, http.StatusOK)
-	}
+	require.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
 func Test_startProfileServer_bindError(t *testing.T) {
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("net.Listen() error = %v", err)
-	}
+	require.NoError(t, err)
 	t.Cleanup(func() {
-		if err := listener.Close(); err != nil {
-			t.Errorf("listener.Close() error = %v", err)
-		}
+		require.NoError(t, listener.Close())
 	})
 
-	if _, err := startProfileServer(listener.Addr().String()); err == nil {
-		t.Fatalf("startProfileServer(%q) error = nil, want non-nil", listener.Addr().String())
-	}
+	_, err = startProfileServer(listener.Addr().String())
+	require.Error(t, err)
 }

--- a/cmd/webhook/main_test.go
+++ b/cmd/webhook/main_test.go
@@ -8,19 +8,34 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
-func Test_parseFlags(t *testing.T) {
-	flags := Flags{}
-	os.Args = []string{"test", "--health-addr", "8080", "--leader-elect", "true"}
+func parseFlagsForTest(t *testing.T, args []string) Flags {
+	t.Helper()
+
+	oldArgs := os.Args
+	oldCommandLine := flag.CommandLine
+	t.Cleanup(func() {
+		os.Args = oldArgs
+		flag.CommandLine = oldCommandLine
+	})
+
+	flag.CommandLine = flag.NewFlagSet(args[0], flag.ContinueOnError)
+	os.Args = args
+
+	var flags Flags
 	parseFlags(&flags)
-	if flags.probeAddr != "8080" {
-		t.Errorf("Test_parseFlags() probeAddr = %v, want %v", flags.probeAddr, "8080")
-	}
-	if !flags.enableLeaderElection {
-		t.Errorf("Test_parseFlags() server = %v, want %v", flags.enableLeaderElection, true)
-	}
+	return flags
+}
+
+func Test_parseFlags(t *testing.T) {
+	flags := parseFlagsForTest(t, []string{"test", "--health-addr", "8080", "--leader-elect", "true"})
+
+	require.Equal(t, "8080", flags.probeAddr)
+	require.True(t, flags.enableLeaderElection)
 }
 
 func Test_parseFlags_namespaces(t *testing.T) {
@@ -47,13 +62,8 @@ func Test_parseFlags_namespaces(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			flag.CommandLine = flag.NewFlagSet(tt.args[0], flag.ContinueOnError)
-			os.Args = tt.args
-			flags := Flags{}
-			parseFlags(&flags)
-			if flags.namespaces != tt.want {
-				t.Errorf("parseFlags() namespaces = %v, want %v", flags.namespaces, tt.want)
-			}
+			flags := parseFlagsForTest(t, tt.args)
+			require.Equal(t, tt.want, flags.namespaces)
 		})
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/onsi/gomega v1.39.1
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.89.0
 	github.com/puttsk/hostlist v0.1.0
+	github.com/stretchr/testify v1.11.1
 	golang.org/x/crypto v0.52.0
 	golang.org/x/text v0.37.0
 	helm.sh/helm/v3 v3.20.2

--- a/internal/builder/accountingbuilder/accounting_app_test.go
+++ b/internal/builder/accountingbuilder/accounting_app_test.go
@@ -66,7 +66,7 @@ func TestBuilder_BuildAccounting(t *testing.T) {
 			require.Equal(t, common.SlurmUserGid, ptr.Deref(got.Spec.Template.Spec.Containers[0].SecurityContext.RunAsGroup, 0))
 			require.Equal(t, labels.AccountingApp, got.Spec.Template.Spec.Containers[0].Name)
 			require.Equal(t, labels.AccountingApp, got.Spec.Template.Spec.Containers[0].Ports[0].Name)
-			require.Equal(t, common.SlurmdbdPort, got.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort)
+			require.Equal(t, int32(common.SlurmdbdPort), got.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort)
 		})
 	}
 }

--- a/internal/builder/accountingbuilder/accounting_app_test.go
+++ b/internal/builder/accountingbuilder/accounting_app_test.go
@@ -10,6 +10,7 @@ import (
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
 	common "github.com/SlinkyProject/slurm-operator/internal/builder/common"
 	"github.com/SlinkyProject/slurm-operator/internal/builder/labels"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -52,42 +53,20 @@ func TestBuilder_BuildAccounting(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			b := New(tt.fields.client)
 			got, err := b.BuildAccounting(tt.args.accounting)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Builder.BuildAccounting() error = %v, wantErr %v", err, tt.wantErr)
+
+			if tt.wantErr {
+				require.Error(t, err)
 				return
 			}
-			switch {
-			case err != nil:
-				return
 
-			case !set.KeySet(got.Spec.Template.Labels).HasAll(set.KeySet(got.Spec.Selector.MatchLabels).UnsortedList()...):
-				t.Errorf("Template.Labels = %v , Selector.MatchLabels = %v",
-					got.Spec.Template.Labels, got.Spec.Selector.MatchLabels)
-
-			case ptr.Deref(got.Spec.Template.Spec.Containers[0].SecurityContext.RunAsNonRoot, false) != true:
-				t.Errorf("got.Spec.Template.Spec.Containers[0].SecurityContext.RunAsNonRoot = %v , want = %v",
-					got.Spec.Template.Spec.Containers[0].SecurityContext.RunAsNonRoot, true)
-
-			case ptr.Deref(got.Spec.Template.Spec.Containers[0].SecurityContext.RunAsUser, 0) != common.SlurmUserUid:
-				t.Errorf("got.Spec.Template.Spec.Containers[0].SecurityContext.RunAsUser = %v , want = %v",
-					got.Spec.Template.Spec.Containers[0].SecurityContext.RunAsUser, common.SlurmUserUid)
-
-			case ptr.Deref(got.Spec.Template.Spec.Containers[0].SecurityContext.RunAsGroup, 0) != common.SlurmUserGid:
-				t.Errorf("got.Spec.Template.Spec.Containers[0].SecurityContext.RunAsGroup = %v , want = %v",
-					got.Spec.Template.Spec.Containers[0].SecurityContext.RunAsGroup, common.SlurmUserGid)
-
-			case got.Spec.Template.Spec.Containers[0].Name != labels.AccountingApp:
-				t.Errorf("Template.Spec.Containers[0].Name = %v , want = %v",
-					got.Spec.Template.Spec.Containers[0].Name, labels.AccountingApp)
-
-			case got.Spec.Template.Spec.Containers[0].Ports[0].Name != labels.AccountingApp:
-				t.Errorf("Template.Spec.Containers[0].Ports[0].Name = %v , want = %v",
-					got.Spec.Template.Spec.Containers[0].Ports[0].Name, labels.AccountingApp)
-
-			case got.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort != common.SlurmdbdPort:
-				t.Errorf("Template.Spec.Containers[0].Ports[0].ContainerPort = %v , want = %v",
-					got.Spec.Template.Spec.Containers[0].Ports[0].Name, common.SlurmdbdPort)
-			}
+			require.NoError(t, err)
+			require.True(t, set.KeySet(got.Spec.Template.Labels).HasAll(set.KeySet(got.Spec.Selector.MatchLabels).UnsortedList()...))
+			require.True(t, ptr.Deref(got.Spec.Template.Spec.Containers[0].SecurityContext.RunAsNonRoot, false))
+			require.Equal(t, common.SlurmUserUid, ptr.Deref(got.Spec.Template.Spec.Containers[0].SecurityContext.RunAsUser, 0))
+			require.Equal(t, common.SlurmUserGid, ptr.Deref(got.Spec.Template.Spec.Containers[0].SecurityContext.RunAsGroup, 0))
+			require.Equal(t, labels.AccountingApp, got.Spec.Template.Spec.Containers[0].Name)
+			require.Equal(t, labels.AccountingApp, got.Spec.Template.Spec.Containers[0].Ports[0].Name)
+			require.Equal(t, common.SlurmdbdPort, got.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort)
 		})
 	}
 }

--- a/internal/builder/accountingbuilder/accounting_config_test.go
+++ b/internal/builder/accountingbuilder/accounting_config_test.go
@@ -9,6 +9,7 @@ import (
 
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
 	common "github.com/SlinkyProject/slurm-operator/internal/builder/common"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -68,17 +69,14 @@ func TestBuilder_BuildAccountingConfig(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			b := New(tt.fields.client)
 			got, err := b.BuildAccountingConfig(tt.args.accounting)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Builder.BuildAccountingConfig() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			switch {
-			case err != nil:
-				return
 
-			case got.Data[common.SlurmdbdConfFile] == nil && got.StringData[common.SlurmdbdConfFile] == "":
-				t.Errorf("got.Data[%s] = %v", common.SlurmdbdConfFile, got.Data[common.SlurmdbdConfFile])
+			if tt.wantErr {
+				require.Error(t, err)
+				return
 			}
+
+			require.NoError(t, err)
+			require.True(t, got.Data[common.SlurmdbdConfFile] != nil || got.StringData[common.SlurmdbdConfFile] != "")
 		})
 	}
 }

--- a/internal/builder/accountingbuilder/accounting_service_test.go
+++ b/internal/builder/accountingbuilder/accounting_service_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/set"
@@ -177,33 +177,23 @@ func TestBuilder_BuildAccountingService(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			b := New(tt.fields.client)
 			got, err := b.BuildAccountingService(tt.args.accounting)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Builder.BuildAccountingService() error = %v, wantErr %v", err, tt.wantErr)
+
+			if tt.wantErr {
+				require.Error(t, err)
 				return
 			}
+
+			require.NoError(t, err)
+
 			got2, err := b.BuildAccounting(tt.args.accounting)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Builder.BuildAccounting() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			switch {
-			case err != nil:
-				return
+			require.NoError(t, err)
+			require.True(t, set.KeySet(got2.Labels).HasAll(set.KeySet(got.Spec.Selector).UnsortedList()...))
+			require.True(t,
+				got.Spec.Ports[0].TargetPort.String() == got2.Spec.Template.Spec.Containers[0].Ports[0].Name ||
+					got.Spec.Ports[0].TargetPort.IntValue() == int(got2.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort))
 
-			case !set.KeySet(got2.Labels).HasAll(set.KeySet(got.Spec.Selector).UnsortedList()...):
-				t.Errorf("Labels = %v , Selector = %v", got.Labels, got.Spec.Selector)
-
-			case got.Spec.Ports[0].TargetPort.String() != got2.Spec.Template.Spec.Containers[0].Ports[0].Name &&
-				got.Spec.Ports[0].TargetPort.IntValue() != int(got2.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort):
-				t.Errorf("Ports[0].TargetPort = %v , Template.Spec.Containers[0].Ports[0].Name = %v , Template.Spec.Containers[0].Ports[0].ContainerPort = %v",
-					got.Spec.Ports[0].TargetPort,
-					got2.Spec.Template.Spec.Containers[0].Ports[0].Name,
-					got2.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort)
-			}
 			if tt.want != nil {
-				if !apiequality.Semantic.DeepEqual(tt.want.Spec, got.Spec) {
-					t.Errorf("Wanted service = %v, Got service = %v", tt.want.Spec, got.Spec)
-				}
+				require.Equal(t, tt.want.Spec, got.Spec)
 			}
 		})
 	}

--- a/internal/builder/accountingbuilder/builder_test.go
+++ b/internal/builder/accountingbuilder/builder_test.go
@@ -4,12 +4,12 @@
 package accountingbuilder
 
 import (
-	"reflect"
 	"testing"
 
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
 	"github.com/SlinkyProject/slurm-operator/internal/builder/common"
 	"github.com/SlinkyProject/slurm-operator/internal/utils/refresolver"
+	"github.com/stretchr/testify/require"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -55,9 +55,7 @@ func TestNew(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := New(tt.args.c); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("New() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, New(tt.args.c))
 		})
 	}
 }

--- a/internal/builder/common/builder_test.go
+++ b/internal/builder/common/builder_test.go
@@ -4,11 +4,11 @@
 package common
 
 import (
-	"reflect"
 	"testing"
 
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
 	"github.com/SlinkyProject/slurm-operator/internal/utils/refresolver"
+	"github.com/stretchr/testify/require"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -52,9 +52,7 @@ func TestNew(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := New(tt.args.c); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("New() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, New(tt.args.c))
 		})
 	}
 }

--- a/internal/builder/common/common_test.go
+++ b/internal/builder/common/common_test.go
@@ -8,8 +8,8 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -142,9 +142,8 @@ func Test_mergeEnvVar(t *testing.T) {
 				item2 := tt.want[j]
 				return item1.Name < item2.Name
 			})
-			if !apiequality.Semantic.DeepEqual(got, tt.want) {
-				t.Errorf("mergeEnvVar() = %v, want %v", got, tt.want)
-			}
+
+			require.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -193,12 +192,9 @@ func TestCommonBuilder_GetContainerResourceLimits(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			b := New(client)
 			got, got2 := b.GetContainerResourceLimits(tt.container)
-			if got != tt.want {
-				t.Errorf("GetContainerResourceLimits() = %v, want %v", got, tt.want)
-			}
-			if got2 != tt.want2 {
-				t.Errorf("GetContainerResourceLimits() = %v, want %v", got2, tt.want2)
-			}
+
+			require.Equal(t, tt.want, got)
+			require.Equal(t, tt.want2, got2)
 		})
 	}
 }
@@ -246,12 +242,9 @@ func TestCommonBuilder_GetPodResourceLimits(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			b := New(client)
 			got, got2 := b.GetPodResourceLimits(tt.pod)
-			if got != tt.want {
-				t.Errorf("GetPodResourceLimits() = %v, want %v", got, tt.want)
-			}
-			if got2 != tt.want2 {
-				t.Errorf("GetPodResourceLimits() = %v, want %v", got2, tt.want2)
-			}
+
+			require.Equal(t, tt.want, got)
+			require.Equal(t, tt.want2, got2)
 		})
 	}
 }
@@ -370,10 +363,7 @@ Foo=bar1`,
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := BuildMergedConfig(tt.confRaw, tt.mergeParameters)
-			if got != tt.want {
-				t.Errorf("buildMergedParameters() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, BuildMergedConfig(tt.confRaw, tt.mergeParameters))
 		})
 	}
 }
@@ -444,10 +434,7 @@ c`,
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := parseSlurmConfKV(tt.confRaw)
-			if !apiequality.Semantic.DeepEqual(got, tt.want) {
-				t.Errorf("parseSlurmConfKV() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, parseSlurmConfKV(tt.confRaw))
 		})
 	}
 }
@@ -476,10 +463,7 @@ func Test_parseKVKey(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := parseKVKey(tt.s)
-			if got != tt.want {
-				t.Errorf("parseKVKey() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, parseKVKey(tt.s))
 		})
 	}
 }

--- a/internal/builder/common/configmap_test.go
+++ b/internal/builder/common/configmap_test.go
@@ -8,8 +8,8 @@ import (
 
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
 	"github.com/SlinkyProject/slurm-operator/internal/utils/objectutils"
+	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
@@ -68,32 +68,19 @@ func TestBuilder_BuildConfigMap(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			b := New(fake.NewFakeClient())
 			got, err := b.BuildConfigMap(tt.args.opts, tt.args.owner)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Builder.BuildConfigMap() error = %v, wantErr %v", err, tt.wantErr)
+
+			if tt.wantErr {
+				require.Error(t, err)
 				return
 			}
-			switch {
-			case err != nil:
-				return
 
-			case objectutils.KeyFunc(got) != tt.args.opts.Key.String():
-				t.Errorf("NamespacedName = %v , want = %v", objectutils.KeyFunc(got), tt.args.opts.Key.String())
-
-			case !apiequality.Semantic.DeepEqual(got.Annotations, tt.args.opts.Metadata.Annotations):
-				t.Errorf("Annotations = %v , want = %v", got.Annotations, tt.args.opts.Metadata.Annotations)
-
-			case !apiequality.Semantic.DeepEqual(got.Labels, tt.args.opts.Metadata.Labels):
-				t.Errorf("Labels = %v , want = %v", got.Labels, tt.args.opts.Metadata.Labels)
-
-			case ptr.Deref(got.Immutable, false) != tt.args.opts.Immutable:
-				t.Errorf("got.Immutable = %v , want = %v", got.Immutable, tt.args.opts.Immutable)
-
-			case !apiequality.Semantic.DeepEqual(got.Data, tt.args.opts.Data):
-				t.Errorf("got.Data = %v , want = %v", got.Data, tt.args.opts.Data)
-
-			case !apiequality.Semantic.DeepEqual(got.BinaryData, tt.args.opts.BinaryData):
-				t.Errorf("got.BinaryData = %v , want = %v", got.BinaryData, tt.args.opts.BinaryData)
-			}
+			require.NoError(t, err)
+			require.Equal(t, tt.args.opts.Key.String(), objectutils.KeyFunc(got))
+			require.Equal(t, tt.args.opts.Metadata.Annotations, got.Annotations)
+			require.Equal(t, tt.args.opts.Metadata.Labels, got.Labels)
+			require.Equal(t, tt.args.opts.Immutable, ptr.Deref(got.Immutable, false))
+			require.Equal(t, tt.args.opts.Data, got.Data)
+			require.Equal(t, tt.args.opts.BinaryData, got.BinaryData)
 		})
 	}
 }

--- a/internal/builder/common/configmap_test.go
+++ b/internal/builder/common/configmap_test.go
@@ -64,6 +64,12 @@ func TestBuilder_BuildConfigMap(t *testing.T) {
 			},
 		},
 	}
+	normSS := func(m map[string]string) map[string]string {
+		if m == nil {
+			return map[string]string{}
+		}
+		return m
+	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			b := New(fake.NewFakeClient())
@@ -76,8 +82,8 @@ func TestBuilder_BuildConfigMap(t *testing.T) {
 
 			require.NoError(t, err)
 			require.Equal(t, tt.args.opts.Key.String(), objectutils.KeyFunc(got))
-			require.Equal(t, tt.args.opts.Metadata.Annotations, got.Annotations)
-			require.Equal(t, tt.args.opts.Metadata.Labels, got.Labels)
+			require.Equal(t, normSS(tt.args.opts.Metadata.Annotations), got.Annotations)
+			require.Equal(t, normSS(tt.args.opts.Metadata.Labels), got.Labels)
 			require.Equal(t, tt.args.opts.Immutable, ptr.Deref(got.Immutable, false))
 			require.Equal(t, tt.args.opts.Data, got.Data)
 			require.Equal(t, tt.args.opts.BinaryData, got.BinaryData)

--- a/internal/builder/common/container_test.go
+++ b/internal/builder/common/container_test.go
@@ -6,8 +6,8 @@ package common
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -350,11 +350,8 @@ func TestBuilder_BuildContainer(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			b := New(tt.client)
-			got := b.BuildContainer(tt.opts)
-			if !apiequality.Semantic.DeepEqual(got, tt.want) {
-				t.Errorf("Builder.BuildContainer() = %v, want %v", got, tt.want)
-				return
-			}
+
+			require.Equal(t, tt.want, b.BuildContainer(tt.opts))
 		})
 	}
 }

--- a/internal/builder/common/pod_disruption_budget_test.go
+++ b/internal/builder/common/pod_disruption_budget_test.go
@@ -35,6 +35,8 @@ func TestBuilder_BuildPodDisruptionBudget(t *testing.T) {
 			},
 			want: &policyv1.PodDisruptionBudget{
 				ObjectMeta: metav1.ObjectMeta{
+					Labels:      map[string]string{},
+					Annotations: map[string]string{},
 					OwnerReferences: []metav1.OwnerReference{
 						{
 							APIVersion:         "slinky.slurm.net/v1beta1",

--- a/internal/builder/common/pod_disruption_budget_test.go
+++ b/internal/builder/common/pod_disruption_budget_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	"github.com/stretchr/testify/require"
 	policyv1 "k8s.io/api/policy/v1"
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -60,18 +60,14 @@ func TestBuilder_BuildPodDisruptionBudget(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			b := New(tt.c)
 			got, gotErr := b.BuildPodDisruptionBudget(tt.opts, tt.owner)
-			if gotErr != nil {
-				if !tt.wantErr {
-					t.Errorf("BuildPodDisruptionBudget() failed: %v", gotErr)
-				}
+
+			if tt.wantErr {
+				require.Error(t, gotErr)
 				return
 			}
-			if tt.wantErr {
-				t.Fatal("BuildPodDisruptionBudget() succeeded unexpectedly")
-			}
-			if !apiequality.Semantic.DeepEqual(got, tt.want) {
-				t.Errorf("BuildPodDisruptionBudget() = %v, want %v", got, tt.want)
-			}
+
+			require.NoError(t, gotErr)
+			require.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/internal/builder/common/pod_template_test.go
+++ b/internal/builder/common/pod_template_test.go
@@ -6,9 +6,8 @@ package common
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -78,9 +77,8 @@ func TestBuilder_buildPodTemplate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			b := New(tt.fields.client)
-			if got := b.BuildPodTemplate(tt.args.opts); !apiequality.Semantic.DeepEqual(got, tt.want) {
-				t.Errorf("Builder.buildPodTemplate() = %v, want %v", got, tt.want)
-			}
+
+			require.Equal(t, tt.want, b.BuildPodTemplate(tt.args.opts))
 		})
 	}
 }

--- a/internal/builder/common/pod_template_test.go
+++ b/internal/builder/common/pod_template_test.go
@@ -33,7 +33,11 @@ func TestBuilder_buildPodTemplate(t *testing.T) {
 			args: args{
 				opts: PodTemplateOpts{},
 			},
-			want: corev1.PodTemplateSpec{},
+			want: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{},
+				},
+			},
 		},
 		{
 			name: "containers",

--- a/internal/builder/common/secret_test.go
+++ b/internal/builder/common/secret_test.go
@@ -64,6 +64,12 @@ func TestBuilder_BuildSecret(t *testing.T) {
 			},
 		},
 	}
+	normSS := func(m map[string]string) map[string]string {
+		if m == nil {
+			return map[string]string{}
+		}
+		return m
+	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			b := New(fake.NewFakeClient())
@@ -76,8 +82,8 @@ func TestBuilder_BuildSecret(t *testing.T) {
 
 			require.NoError(t, err)
 			require.Equal(t, tt.args.opts.Key.String(), objectutils.KeyFunc(got))
-			require.Equal(t, tt.args.opts.Metadata.Annotations, got.Annotations)
-			require.Equal(t, tt.args.opts.Metadata.Labels, got.Labels)
+			require.Equal(t, normSS(tt.args.opts.Metadata.Annotations), got.Annotations)
+			require.Equal(t, normSS(tt.args.opts.Metadata.Labels), got.Labels)
 			require.Equal(t, tt.args.opts.Immutable, ptr.Deref(got.Immutable, false))
 			require.Equal(t, tt.args.opts.Data, got.Data)
 			require.Equal(t, tt.args.opts.StringData, got.StringData)

--- a/internal/builder/common/secret_test.go
+++ b/internal/builder/common/secret_test.go
@@ -8,8 +8,8 @@ import (
 
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
 	"github.com/SlinkyProject/slurm-operator/internal/utils/objectutils"
+	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
@@ -68,32 +68,19 @@ func TestBuilder_BuildSecret(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			b := New(fake.NewFakeClient())
 			got, err := b.BuildSecret(tt.args.opts, tt.args.owner)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Builder.BuildSecret() error = %v, wantErr %v", err, tt.wantErr)
+
+			if tt.wantErr {
+				require.Error(t, err)
 				return
 			}
-			switch {
-			case err != nil:
-				return
 
-			case objectutils.KeyFunc(got) != tt.args.opts.Key.String():
-				t.Errorf("NamespacedName = %v , want = %v", objectutils.KeyFunc(got), tt.args.opts.Key.String())
-
-			case !apiequality.Semantic.DeepEqual(got.Annotations, tt.args.opts.Metadata.Annotations):
-				t.Errorf("Annotations = %v , want = %v", got.Annotations, tt.args.opts.Metadata.Annotations)
-
-			case !apiequality.Semantic.DeepEqual(got.Labels, tt.args.opts.Metadata.Labels):
-				t.Errorf("Labels = %v , want = %v", got.Labels, tt.args.opts.Metadata.Labels)
-
-			case ptr.Deref(got.Immutable, false) != tt.args.opts.Immutable:
-				t.Errorf("got.Immutable = %v , want = %v", got.Immutable, tt.args.opts.Immutable)
-
-			case !apiequality.Semantic.DeepEqual(got.Data, tt.args.opts.Data):
-				t.Errorf("got.Data = %v , want = %v", got.Data, tt.args.opts.Data)
-
-			case !apiequality.Semantic.DeepEqual(got.StringData, tt.args.opts.StringData):
-				t.Errorf("got.StringData = %v , want = %v", got.StringData, tt.args.opts.StringData)
-			}
+			require.NoError(t, err)
+			require.Equal(t, tt.args.opts.Key.String(), objectutils.KeyFunc(got))
+			require.Equal(t, tt.args.opts.Metadata.Annotations, got.Annotations)
+			require.Equal(t, tt.args.opts.Metadata.Labels, got.Labels)
+			require.Equal(t, tt.args.opts.Immutable, ptr.Deref(got.Immutable, false))
+			require.Equal(t, tt.args.opts.Data, got.Data)
+			require.Equal(t, tt.args.opts.StringData, got.StringData)
 		})
 	}
 }

--- a/internal/builder/common/service_test.go
+++ b/internal/builder/common/service_test.go
@@ -98,6 +98,12 @@ func TestBuilder_BuildService(t *testing.T) {
 			wantErr: true,
 		},
 	}
+	normSS := func(m map[string]string) map[string]string {
+		if m == nil {
+			return map[string]string{}
+		}
+		return m
+	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			b := New(fake.NewFakeClient())
@@ -110,8 +116,8 @@ func TestBuilder_BuildService(t *testing.T) {
 
 			require.NoError(t, err)
 			require.Equal(t, tt.args.opts.Key.String(), objectutils.KeyFunc(got))
-			require.Equal(t, tt.args.opts.Metadata.Annotations, got.Annotations)
-			require.Equal(t, tt.args.opts.Metadata.Labels, got.Labels)
+			require.Equal(t, normSS(tt.args.opts.Metadata.Annotations), got.Annotations)
+			require.Equal(t, normSS(tt.args.opts.Metadata.Labels), got.Labels)
 			require.True(t, set.KeySet(got.Spec.Selector).HasAll(set.KeySet(tt.args.opts.Selector).UnsortedList()...))
 
 			if tt.args.opts.Headless {

--- a/internal/builder/common/service_test.go
+++ b/internal/builder/common/service_test.go
@@ -8,9 +8,9 @@ import (
 
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
 	"github.com/SlinkyProject/slurm-operator/internal/utils/objectutils"
+	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/set"
@@ -102,28 +102,20 @@ func TestBuilder_BuildService(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			b := New(fake.NewFakeClient())
 			got, err := b.BuildService(tt.args.opts, tt.args.owner)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Builder.BuildService() error = %v, wantErr %v", err, tt.wantErr)
+
+			if tt.wantErr {
+				require.Error(t, err)
 				return
 			}
-			switch {
-			case err != nil:
-				return
 
-			case objectutils.KeyFunc(got) != tt.args.opts.Key.String():
-				t.Errorf("NamespacedName = %v , want = %v", objectutils.KeyFunc(got), tt.args.opts.Key.String())
+			require.NoError(t, err)
+			require.Equal(t, tt.args.opts.Key.String(), objectutils.KeyFunc(got))
+			require.Equal(t, tt.args.opts.Metadata.Annotations, got.Annotations)
+			require.Equal(t, tt.args.opts.Metadata.Labels, got.Labels)
+			require.True(t, set.KeySet(got.Spec.Selector).HasAll(set.KeySet(tt.args.opts.Selector).UnsortedList()...))
 
-			case !apiequality.Semantic.DeepEqual(got.Annotations, tt.args.opts.Metadata.Annotations):
-				t.Errorf("Annotations = %v , want = %v", got.Annotations, tt.args.opts.Metadata.Annotations)
-
-			case !apiequality.Semantic.DeepEqual(got.Labels, tt.args.opts.Metadata.Labels):
-				t.Errorf("Labels = %v , want = %v", got.Labels, tt.args.opts.Metadata.Labels)
-
-			case !set.KeySet(got.Spec.Selector).HasAll(set.KeySet(tt.args.opts.Selector).UnsortedList()...):
-				t.Errorf("Selector = %v , want = %v", got.Spec.Selector, tt.args.opts.Selector)
-
-			case tt.args.opts.Headless && got.Spec.ClusterIP != corev1.ClusterIPNone:
-				t.Errorf("Headless enabled but `ClusterIP != %s`", corev1.ClusterIPNone)
+			if tt.args.opts.Headless {
+				require.Equal(t, corev1.ClusterIPNone, got.Spec.ClusterIP)
 			}
 		})
 	}

--- a/internal/builder/common/token_secret_test.go
+++ b/internal/builder/common/token_secret_test.go
@@ -9,6 +9,7 @@ import (
 
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
 	"github.com/SlinkyProject/slurm-operator/internal/defaults"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -89,19 +90,15 @@ func TestBuilder_BuildTokenSecret(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			b := New(tt.fields.client)
 			got, err := b.BuildTokenSecret(tt.args.token)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Builder.BuildTokenSecret() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			refresh := ptr.Deref(tt.args.token.Spec.Refresh, defaults.DefaultTokenRefresh)
-			switch {
-			case err != nil:
-				return
 
-			case ptr.Deref(got.Immutable, false) != !refresh:
-				t.Errorf("Immutable = %v , want = %v",
-					ptr.Deref(got.Immutable, false), !refresh)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
 			}
+
+			require.NoError(t, err)
+			refresh := ptr.Deref(tt.args.token.Spec.Refresh, defaults.DefaultTokenRefresh)
+			require.Equal(t, !refresh, ptr.Deref(got.Immutable, false))
 		})
 	}
 }

--- a/internal/builder/controllerbuilder/builder_test.go
+++ b/internal/builder/controllerbuilder/builder_test.go
@@ -4,12 +4,12 @@
 package controllerbuilder
 
 import (
-	"reflect"
 	"testing"
 
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
 	"github.com/SlinkyProject/slurm-operator/internal/builder/common"
 	"github.com/SlinkyProject/slurm-operator/internal/utils/refresolver"
+	"github.com/stretchr/testify/require"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -55,9 +55,7 @@ func TestNew(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := New(tt.args.c); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("New() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, New(tt.args.c))
 		})
 	}
 }

--- a/internal/builder/controllerbuilder/controller_app_test.go
+++ b/internal/builder/controllerbuilder/controller_app_test.go
@@ -10,6 +10,7 @@ import (
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
 	"github.com/SlinkyProject/slurm-operator/internal/builder/common"
 	"github.com/SlinkyProject/slurm-operator/internal/builder/labels"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -91,42 +92,20 @@ func TestBuilder_BuildController(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			b := New(tt.fields.client)
 			got, err := b.BuildController(tt.args.controller)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Builder.BuildController() error = %v, wantErr %v", err, tt.wantErr)
+
+			if tt.wantErr {
+				require.Error(t, err)
 				return
 			}
-			switch {
-			case err != nil:
-				return
 
-			case !set.KeySet(got.Spec.Template.Labels).HasAll(set.KeySet(got.Spec.Selector.MatchLabels).UnsortedList()...):
-				t.Errorf("Template.Labels = %v , Selector.MatchLabels = %v",
-					got.Spec.Template.Labels, got.Spec.Selector.MatchLabels)
-
-			case ptr.Deref(got.Spec.Template.Spec.Containers[0].SecurityContext.RunAsNonRoot, false) != true:
-				t.Errorf("got.Spec.Template.Spec.Containers[0].SecurityContext.RunAsNonRoot = %v , want = %v",
-					got.Spec.Template.Spec.Containers[0].SecurityContext.RunAsNonRoot, true)
-
-			case ptr.Deref(got.Spec.Template.Spec.Containers[0].SecurityContext.RunAsUser, 0) != common.SlurmUserUid:
-				t.Errorf("got.Spec.Template.Spec.Containers[0].SecurityContext.RunAsUser = %v , want = %v",
-					got.Spec.Template.Spec.Containers[0].SecurityContext.RunAsUser, common.SlurmUserUid)
-
-			case ptr.Deref(got.Spec.Template.Spec.Containers[0].SecurityContext.RunAsGroup, 0) != common.SlurmUserGid:
-				t.Errorf("got.Spec.Template.Spec.Containers[0].SecurityContext.RunAsGroup = %v , want = %v",
-					got.Spec.Template.Spec.Containers[0].SecurityContext.RunAsGroup, common.SlurmUserGid)
-
-			case got.Spec.Template.Spec.Containers[0].Name != labels.ControllerApp:
-				t.Errorf("Template.Spec.Containers[0].Name = %v , want = %v",
-					got.Spec.Template.Spec.Containers[0].Name, labels.ControllerApp)
-
-			case got.Spec.Template.Spec.Containers[0].Ports[0].Name != labels.ControllerApp:
-				t.Errorf("Template.Spec.Containers[0].Ports[0].Name = %v , want = %v",
-					got.Spec.Template.Spec.Containers[0].Ports[0].Name, labels.ControllerApp)
-
-			case got.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort != common.SlurmctldPort:
-				t.Errorf("Template.Spec.Containers[0].Ports[0].ContainerPort = %v , want = %v",
-					got.Spec.Template.Spec.Containers[0].Ports[0].Name, common.SlurmctldPort)
-			}
+			require.NoError(t, err)
+			require.True(t, set.KeySet(got.Spec.Template.Labels).HasAll(set.KeySet(got.Spec.Selector.MatchLabels).UnsortedList()...))
+			require.True(t, ptr.Deref(got.Spec.Template.Spec.Containers[0].SecurityContext.RunAsNonRoot, false))
+			require.Equal(t, common.SlurmUserUid, ptr.Deref(got.Spec.Template.Spec.Containers[0].SecurityContext.RunAsUser, 0))
+			require.Equal(t, common.SlurmUserGid, ptr.Deref(got.Spec.Template.Spec.Containers[0].SecurityContext.RunAsGroup, 0))
+			require.Equal(t, labels.ControllerApp, got.Spec.Template.Spec.Containers[0].Name)
+			require.Equal(t, labels.ControllerApp, got.Spec.Template.Spec.Containers[0].Ports[0].Name)
+			require.Equal(t, common.SlurmctldPort, got.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort)
 		})
 	}
 }

--- a/internal/builder/controllerbuilder/controller_app_test.go
+++ b/internal/builder/controllerbuilder/controller_app_test.go
@@ -105,7 +105,7 @@ func TestBuilder_BuildController(t *testing.T) {
 			require.Equal(t, common.SlurmUserGid, ptr.Deref(got.Spec.Template.Spec.Containers[0].SecurityContext.RunAsGroup, 0))
 			require.Equal(t, labels.ControllerApp, got.Spec.Template.Spec.Containers[0].Name)
 			require.Equal(t, labels.ControllerApp, got.Spec.Template.Spec.Containers[0].Ports[0].Name)
-			require.Equal(t, common.SlurmctldPort, got.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort)
+			require.Equal(t, int32(common.SlurmctldPort), got.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort)
 		})
 	}
 }

--- a/internal/builder/controllerbuilder/controller_config_test.go
+++ b/internal/builder/controllerbuilder/controller_config_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -225,23 +226,18 @@ func TestBuilder_BuildControllerConfig(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			b := New(tt.fields.client)
 			got, err := b.BuildControllerConfig(tt.args.controller)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Builder.BuildControllerConfig() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			switch {
-			case err != nil:
-				return
 
-			case got.Data[SlurmConfFile] == "" && got.BinaryData[SlurmConfFile] == nil:
-				t.Errorf("got.Data[%s] = %v", SlurmConfFile, got.Data[SlurmConfFile])
+			if tt.wantErr {
+				require.Error(t, err)
+				return
 			}
+
+			require.NoError(t, err)
+			require.True(t, got.Data[SlurmConfFile] != "" || got.BinaryData[SlurmConfFile] != nil)
 
 			// Verify expected scripts are present in slurm.conf
 			for _, script := range tt.wantScripts {
-				if !strings.Contains(got.Data[SlurmConfFile], script) {
-					t.Errorf("Expected %s in slurm.conf", script)
-				}
+				require.Contains(t, got.Data[SlurmConfFile], script)
 			}
 		})
 	}
@@ -291,9 +287,7 @@ ignoresystemd=yes`,
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := isCgroupEnabled(tt.args.cgroupConf); got != tt.want {
-				t.Errorf("isCgroupEnabled() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, isCgroupEnabled(tt.args.cgroupConf))
 		})
 	}
 }
@@ -418,22 +412,15 @@ func TestBuilder_BuildControllerConfigExternal(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			b := New(tt.c)
 			got, gotErr := b.BuildControllerConfigExternal(tt.controller)
-			if gotErr != nil {
-				if !tt.wantErr {
-					t.Errorf("BuildControllerConfigExternal() failed: %v", gotErr)
-				}
+
+			if tt.wantErr {
+				require.Error(t, gotErr)
 				return
 			}
-			if tt.wantErr {
-				t.Fatal("BuildControllerConfigExternal() succeeded unexpectedly")
-			}
-			if got.Data[SlurmConfFile] == "" && got.BinaryData[SlurmConfFile] == nil {
-				t.Errorf("got.Data[%s] = %v", SlurmConfFile, got.Data[SlurmConfFile])
-			}
-			if got.Data[SlurmConfFile] != tt.want.Data[SlurmConfFile] {
-				t.Errorf("got.Data[%s] = %v\nwant.Data[%s] = %v", SlurmConfFile, got.Data[SlurmConfFile], SlurmConfFile, tt.want.Data[SlurmConfFile])
 
-			}
+			require.NoError(t, gotErr)
+			require.True(t, got.Data[SlurmConfFile] != "" || got.BinaryData[SlurmConfFile] != nil)
+			require.Equal(t, tt.want.Data[SlurmConfFile], got.Data[SlurmConfFile])
 		})
 	}
 }
@@ -506,13 +493,12 @@ PartitionName=nodeset-2 Nodes=nodeset-2 MaxTime=UNLIMITED PreemptMode=REQUEUE`,
 			for range 5 {
 				idx := rand.Perm(size)
 				randomized := make([]slinkyv1beta1.NodeSet, size)
+
 				for j := range size {
 					randomized[j] = tt.nodesetList.Items[idx[j]]
 				}
-				got := buildNodeSetConf(tt.nodesetList)
-				if got != tt.want {
-					t.Errorf("buildNodeSetConf() = %v, want %v", got, tt.want)
-				}
+
+				require.Equal(t, tt.want, buildNodeSetConf(tt.nodesetList))
 			}
 		})
 	}
@@ -574,10 +560,7 @@ Epilog=epilog-2.sh`,
 				for j := range epilogScriptsSize {
 					randomizedEpilogScripts[j] = tt.epilogScripts[jdx[j]]
 				}
-				got := buildPrologEpilogConf(tt.prologScripts, tt.epilogScripts)
-				if got != tt.want {
-					t.Errorf("buildPrologEpilogConf() = %v, want %v", got, tt.want)
-				}
+				require.Equal(t, tt.want, buildPrologEpilogConf(tt.prologScripts, tt.epilogScripts))
 			}
 		})
 	}
@@ -634,15 +617,14 @@ EpilogSlurmctld=/etc/slurm/epilog-slurmctld-2.sh`,
 				for i := range prologSlurmctldScriptsSize {
 					randomizedPrologSlurmctldScripts[i] = tt.prologSlurmctldScripts[idx[i]]
 				}
+
 				jdx := rand.Perm(epilogSlurmctldScriptsSize)
 				randomizedEpilogSlurmctldScripts := make([]string, epilogSlurmctldScriptsSize)
 				for i := range epilogSlurmctldScriptsSize {
 					randomizedEpilogSlurmctldScripts[i] = tt.epilogSlurmctldScripts[jdx[i]]
 				}
-				got := buildPrologEpilogSlurmctldConf(tt.prologSlurmctldScripts, tt.epilogSlurmctldScripts)
-				if got != tt.want {
-					t.Errorf("buildPrologEpilogSlurmctldConf() = %v, want %v", got, tt.want)
-				}
+
+				require.Equal(t, tt.want, buildPrologEpilogSlurmctldConf(tt.prologSlurmctldScripts, tt.epilogSlurmctldScripts))
 			}
 		})
 	}

--- a/internal/builder/controllerbuilder/controller_service_test.go
+++ b/internal/builder/controllerbuilder/controller_service_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/set"
@@ -126,33 +126,24 @@ func TestBuilder_BuildControllerService(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			b := New(tt.fields.client)
 			got, err := b.BuildControllerService(tt.args.controller)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Builder.BuildControllerService() error = %v, wantErr %v", err, tt.wantErr)
+
+			if tt.wantErr {
+				require.Error(t, err)
 				return
 			}
+
+			require.NoError(t, err)
+
 			got2, err := b.BuildController(tt.args.controller)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Builder.BuildController() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			switch {
-			case err != nil:
-				return
 
-			case !set.KeySet(got2.Labels).HasAll(set.KeySet(got.Spec.Selector).UnsortedList()...):
-				t.Errorf("Labels = %v , Selector = %v", got.Labels, got.Spec.Selector)
+			require.NoError(t, err)
+			require.True(t, set.KeySet(got2.Labels).HasAll(set.KeySet(got.Spec.Selector).UnsortedList()...))
+			require.True(t,
+				got.Spec.Ports[0].TargetPort.String() == got2.Spec.Template.Spec.Containers[0].Ports[0].Name ||
+					got.Spec.Ports[0].TargetPort.IntValue() == int(got2.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort))
 
-			case got.Spec.Ports[0].TargetPort.String() != got2.Spec.Template.Spec.Containers[0].Ports[0].Name &&
-				got.Spec.Ports[0].TargetPort.IntValue() != int(got2.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort):
-				t.Errorf("Ports[0].TargetPort = %v , Template.Spec.Containers[0].Ports[0].Name = %v , Template.Spec.Containers[0].Ports[0].ContainerPort = %v",
-					got.Spec.Ports[0].TargetPort,
-					got2.Spec.Template.Spec.Containers[0].Ports[0].Name,
-					got2.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort)
-			}
 			if tt.want != nil {
-				if !apiequality.Semantic.DeepEqual(tt.want.Spec, got.Spec) {
-					t.Errorf("Wanted service = %v, Got service = %v", tt.want.Spec, got.Spec)
-				}
+				require.Equal(t, tt.want.Spec, got.Spec)
 			}
 		})
 	}

--- a/internal/builder/controllerbuilder/controller_servicemonitor_test.go
+++ b/internal/builder/controllerbuilder/controller_servicemonitor_test.go
@@ -8,6 +8,7 @@ import (
 
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
 	"github.com/SlinkyProject/slurm-operator/internal/utils/testutils"
+	"github.com/stretchr/testify/require"
 	"k8s.io/utils/set"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -61,24 +62,18 @@ func TestBuilder_BuildControllerServiceMonitor(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			b := New(tt.c)
 			got, gotErr := b.BuildControllerServiceMonitor(tt.controller)
-			if gotErr != nil {
-				if !tt.wantErr {
-					t.Errorf("BuildControllerServiceMonitor() failed: %v", gotErr)
-				}
-				return
-			}
-			got2, err := b.BuildController(tt.controller)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Builder.BuildControllerServiceMonitor() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			switch {
-			case tt.wantErr:
-				t.Fatal("BuildControllerServiceMonitor() succeeded unexpectedly")
 
-			case !set.KeySet(got2.Labels).HasAll(set.KeySet(got.Spec.Selector.MatchLabels).UnsortedList()...):
-				t.Errorf("Labels = %v , Selector = %v", got.Labels, got.Spec.Selector)
+			if tt.wantErr {
+				require.Error(t, gotErr)
+				return
 			}
+
+			require.NoError(t, gotErr)
+
+			got2, err := b.BuildController(tt.controller)
+
+			require.NoError(t, err)
+			require.True(t, set.KeySet(got2.Labels).HasAll(set.KeySet(got.Spec.Selector.MatchLabels).UnsortedList()...))
 		})
 	}
 }

--- a/internal/builder/controllerbuilder/servicemonitor_test.go
+++ b/internal/builder/controllerbuilder/servicemonitor_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -36,19 +36,14 @@ func TestBuilder_BuildServiceMonitor(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			b := New(tt.c)
 			got, gotErr := b.BuildServiceMonitor(tt.opts, tt.owner)
-			if gotErr != nil {
-				if !tt.wantErr {
-					t.Errorf("BuildServiceMonitor() failed: %v", gotErr)
-				}
+
+			if tt.wantErr {
+				require.Error(t, gotErr)
 				return
 			}
-			switch {
-			case tt.wantErr:
-				t.Fatal("BuildServiceMonitor() succeeded unexpectedly")
 
-			case !apiequality.Semantic.DeepEqual(got.Spec, tt.want.Spec):
-				t.Errorf("BuildServiceMonitor() = %v, want %v", got, tt.want)
-			}
+			require.NoError(t, gotErr)
+			require.Equal(t, tt.want.Spec, got.Spec)
 		})
 	}
 }

--- a/internal/builder/controllerbuilder/servicemonitor_test.go
+++ b/internal/builder/controllerbuilder/servicemonitor_test.go
@@ -24,11 +24,18 @@ func TestBuilder_BuildServiceMonitor(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name:    "empty",
-			c:       fake.NewFakeClient(),
-			opts:    ServiceMonitorOpts{},
-			owner:   &corev1.Pod{},
-			want:    &monitoringv1.ServiceMonitor{},
+			name:  "empty",
+			c:     fake.NewFakeClient(),
+			opts:  ServiceMonitorOpts{},
+			owner: &corev1.Pod{},
+			want: &monitoringv1.ServiceMonitor{
+				Spec: monitoringv1.ServiceMonitorSpec{
+					TargetLabels:    []string{},
+					PodTargetLabels: []string{},
+					Endpoints:       []monitoringv1.Endpoint{},
+					ScrapeProtocols: []monitoringv1.ScrapeProtocol{},
+				},
+			},
 			wantErr: false,
 		},
 	}

--- a/internal/builder/labels/labels_test.go
+++ b/internal/builder/labels/labels_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -294,10 +294,7 @@ func TestNewBuilder(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := tt.args.builder.Build()
-			if !equality.Semantic.DeepEqual(got, tt.want) {
-				t.Errorf("got = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, tt.args.builder.Build())
 		})
 	}
 }

--- a/internal/builder/loginbuilder/builder_test.go
+++ b/internal/builder/loginbuilder/builder_test.go
@@ -4,12 +4,12 @@
 package loginbuilder
 
 import (
-	"reflect"
 	"testing"
 
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
 	"github.com/SlinkyProject/slurm-operator/internal/builder/common"
 	"github.com/SlinkyProject/slurm-operator/internal/utils/refresolver"
+	"github.com/stretchr/testify/require"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -55,9 +55,7 @@ func TestNew(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := New(tt.args.c); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("New() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, New(tt.args.c))
 		})
 	}
 }

--- a/internal/builder/loginbuilder/login_app_test.go
+++ b/internal/builder/loginbuilder/login_app_test.go
@@ -9,6 +9,7 @@ import (
 
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
 	"github.com/SlinkyProject/slurm-operator/internal/builder/labels"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/set"
@@ -139,61 +140,44 @@ func TestBuilder_BuildLogin(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			b := New(tt.fields.client)
 			got, err := b.BuildLogin(tt.args.loginset)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Builder.BuildLogin() error = %v, wantErr %v", err, tt.wantErr)
+
+			if tt.wantErr {
+				require.Error(t, err)
 				return
 			}
-			switch {
-			case err != nil:
-				return
 
-			case !set.KeySet(got.Spec.Template.Labels).HasAll(set.KeySet(got.Spec.Selector.MatchLabels).UnsortedList()...):
-				t.Errorf("Template.Labels = %v , Selector.MatchLabels = %v",
-					got.Spec.Template.Labels, got.Spec.Selector.MatchLabels)
+			require.NoError(t, err)
+			require.True(t, set.KeySet(got.Spec.Template.Labels).HasAll(set.KeySet(got.Spec.Selector.MatchLabels).UnsortedList()...))
+			require.Equal(t, labels.LoginApp, got.Spec.Template.Spec.Containers[0].Name)
+			require.Equal(t, labels.LoginApp, got.Spec.Template.Spec.Containers[0].Ports[0].Name)
 
-			case got.Spec.Template.Spec.Containers[0].Name != labels.LoginApp:
-				t.Errorf("Template.Spec.Containers[0].Name = %v , want = %v",
-					got.Spec.Template.Spec.Containers[0].Name, labels.LoginApp)
-
-			case got.Spec.Template.Spec.Containers[0].Ports[0].Name != labels.LoginApp:
-				t.Errorf("Template.Spec.Containers[0].Ports[0].Name = %v , want = %v",
-					got.Spec.Template.Spec.Containers[0].Ports[0].Name, labels.LoginApp)
-
-			case got.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort != LoginPort:
-				if len(tt.args.loginset.Spec.Login.Ports) > 0 && tt.args.loginset.Spec.Login.Ports[0].ContainerPort != 0 {
-					if tt.args.loginset.Spec.Login.Ports[0].ContainerPort != got.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort {
-						t.Errorf("Template.Spec.Containers[0].Ports[0].ContainerPort = %v , want = %v",
-							got.Spec.Template.Spec.Containers[0].Ports[0].Name, tt.args.loginset.Spec.Login.Ports[0].ContainerPort)
-					}
-				} else {
-					t.Errorf("Template.Spec.Containers[0].Ports[0].ContainerPort = %v , want = %v",
-						got.Spec.Template.Spec.Containers[0].Ports[0].Name, LoginPort)
-				}
-
-			case got.Spec.Template.Spec.DNSConfig == nil:
-				t.Errorf("Template.Spec.DNSConfig = %v , want = non-nil", got.Spec.Template.Spec.DNSConfig)
-
-			case len(got.Spec.Template.Spec.DNSConfig.Searches) == 0:
-				t.Errorf("len(Template.Spec.DNSConfig.Searches) = %v , want = > 0", len(got.Spec.Template.Spec.DNSConfig.Searches))
+			if len(tt.args.loginset.Spec.Login.Ports) > 0 && tt.args.loginset.Spec.Login.Ports[0].ContainerPort != 0 {
+				require.Equal(t, tt.args.loginset.Spec.Login.Ports[0].ContainerPort, got.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort)
+			} else {
+				require.Equal(t, LoginPort, got.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort)
 			}
+
+			require.NotNil(t, got.Spec.Template.Spec.DNSConfig)
+			require.NotEmpty(t, got.Spec.Template.Spec.DNSConfig.Searches)
+
 			if tt.name == "envars" {
 				envs := got.Spec.Template.Spec.Containers[0].Env
 				envMap := make(map[string]struct{})
+
 				for _, env := range envs {
-					if _, exists := envMap[env.Name]; exists {
-						t.Errorf("duplicate env var: %s", env.Name)
-					}
+					_, exists := envMap[env.Name]
+					require.False(t, exists, "duplicate env var: %s", env.Name)
 					envMap[env.Name] = struct{}{}
 				}
-				if _, ok := envMap["A"]; !ok {
-					t.Errorf("env var A not found")
-				}
-				if _, ok := envMap["B"]; !ok {
-					t.Errorf("env var B not found")
-				}
-				if _, ok := envMap["SACKD_OPTIONS"]; !ok {
-					t.Errorf("env var SACKD_OPTIONS not found")
-				}
+
+				_, hasA := envMap["A"]
+				require.True(t, hasA, "env var A not found")
+
+				_, hasB := envMap["B"]
+				require.True(t, hasB, "env var B not found")
+
+				_, hasSackd := envMap["SACKD_OPTIONS"]
+				require.True(t, hasSackd, "env var SACKD_OPTIONS not found")
 			}
 		})
 	}

--- a/internal/builder/loginbuilder/login_app_test.go
+++ b/internal/builder/loginbuilder/login_app_test.go
@@ -154,7 +154,7 @@ func TestBuilder_BuildLogin(t *testing.T) {
 			if len(tt.args.loginset.Spec.Login.Ports) > 0 && tt.args.loginset.Spec.Login.Ports[0].ContainerPort != 0 {
 				require.Equal(t, tt.args.loginset.Spec.Login.Ports[0].ContainerPort, got.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort)
 			} else {
-				require.Equal(t, LoginPort, got.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort)
+				require.Equal(t, int32(LoginPort), got.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort)
 			}
 
 			require.NotNil(t, got.Spec.Template.Spec.DNSConfig)

--- a/internal/builder/loginbuilder/login_config_test.go
+++ b/internal/builder/loginbuilder/login_config_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -50,20 +51,15 @@ func TestBuilder_BuildLoginSshConfig(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			b := New(tt.fields.client)
 			got, err := b.BuildLoginSshConfig(tt.args.loginset)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Builder.BuildLoginSshConfig() error = %v, wantErr %v", err, tt.wantErr)
+
+			if tt.wantErr {
+				require.Error(t, err)
 				return
 			}
-			switch {
-			case err != nil:
-				return
 
-			case got.Data[authorizedKeysFile] == "" && got.BinaryData[authorizedKeysFile] == nil:
-				t.Errorf("got.Data[%s] = %v", authorizedKeysFile, got.Data[authorizedKeysFile])
-
-			case got.Data[SshdConfigFile] == "" && got.BinaryData[SshdConfigFile] == nil:
-				t.Errorf("got.Data[%s] = %v", SshdConfigFile, got.Data[SshdConfigFile])
-			}
+			require.NoError(t, err)
+			require.True(t, got.Data[authorizedKeysFile] != "" || got.BinaryData[authorizedKeysFile] != nil)
+			require.True(t, got.Data[SshdConfigFile] != "" || got.BinaryData[SshdConfigFile] != nil)
 		})
 	}
 }

--- a/internal/builder/loginbuilder/login_secret_test.go
+++ b/internal/builder/loginbuilder/login_secret_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -43,29 +44,19 @@ func TestBuilder_BuildLoginSshHostKeys(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			b := New(tt.fields.client)
 			got, err := b.BuildLoginSshHostKeys(tt.args.loginset)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Builder.BuildLoginSshHostKeys() error = %v, wantErr %v", err, tt.wantErr)
+
+			if tt.wantErr {
+				require.Error(t, err)
 				return
 			}
-			switch {
-			case err != nil:
-				return
 
-			case got.Data[SshHostEcdsaKeyFile] == nil && got.StringData[SshHostEcdsaKeyFile] == "":
-				t.Errorf("got.Data[%s] = %v", SshHostEcdsaKeyFile, got.Data[SshHostEcdsaKeyFile])
-			case got.Data[SshHostEcdsaPubKeyFile] == nil && got.StringData[SshHostEcdsaPubKeyFile] == "":
-				t.Errorf("got.Data[%s] = %v", SshHostEcdsaPubKeyFile, got.Data[SshHostEcdsaPubKeyFile])
-
-			case got.Data[SshHostEd25519KeyFile] == nil && got.StringData[SshHostEd25519KeyFile] == "":
-				t.Errorf("got.Data[%s] = %v", SshHostEd25519KeyFile, got.Data[SshHostEd25519KeyFile])
-			case got.Data[SshHostEd25519PubKeyFile] == nil && got.StringData[SshHostEd25519PubKeyFile] == "":
-				t.Errorf("got.Data[%s] = %v", SshHostEd25519PubKeyFile, got.Data[SshHostEd25519PubKeyFile])
-
-			case got.Data[SshHostRsaKeyFile] == nil && got.StringData[SshHostRsaKeyFile] == "":
-				t.Errorf("got.Data[%s] = %v", SshHostRsaKeyFile, got.Data[SshHostRsaKeyFile])
-			case got.Data[SshHostRsaPubKeyFile] == nil && got.StringData[SshHostRsaPubKeyFile] == "":
-				t.Errorf("got.Data[%s] = %v", SshHostRsaPubKeyFile, got.Data[SshHostRsaPubKeyFile])
-			}
+			require.NoError(t, err)
+			require.True(t, got.Data[SshHostEcdsaKeyFile] != nil || got.StringData[SshHostEcdsaKeyFile] != "")
+			require.True(t, got.Data[SshHostEcdsaPubKeyFile] != nil || got.StringData[SshHostEcdsaPubKeyFile] != "")
+			require.True(t, got.Data[SshHostEd25519KeyFile] != nil || got.StringData[SshHostEd25519KeyFile] != "")
+			require.True(t, got.Data[SshHostEd25519PubKeyFile] != nil || got.StringData[SshHostEd25519PubKeyFile] != "")
+			require.True(t, got.Data[SshHostRsaKeyFile] != nil || got.StringData[SshHostRsaKeyFile] != "")
+			require.True(t, got.Data[SshHostRsaPubKeyFile] != nil || got.StringData[SshHostRsaPubKeyFile] != "")
 		})
 	}
 }

--- a/internal/builder/loginbuilder/login_service_test.go
+++ b/internal/builder/loginbuilder/login_service_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/set"
@@ -150,33 +150,24 @@ func TestBuilder_BuildLoginService(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			b := New(tt.fields.client)
 			got, err := b.BuildLoginService(tt.args.loginset)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Builder.BuildLoginService() error = %v, wantErr %v", err, tt.wantErr)
+
+			if tt.wantErr {
+				require.Error(t, err)
 				return
 			}
+
+			require.NoError(t, err)
+
 			got2, err := b.BuildLogin(tt.args.loginset)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Builder.BuildLogin() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			switch {
-			case err != nil:
-				return
 
-			case !set.KeySet(got2.Labels).HasAll(set.KeySet(got.Spec.Selector).UnsortedList()...):
-				t.Errorf("Labels = %v , Selector = %v", got.Labels, got.Spec.Selector)
+			require.NoError(t, err)
+			require.True(t, set.KeySet(got2.Labels).HasAll(set.KeySet(got.Spec.Selector).UnsortedList()...))
+			require.True(t,
+				got.Spec.Ports[0].TargetPort.String() == got2.Spec.Template.Spec.Containers[0].Ports[0].Name ||
+					got.Spec.Ports[0].TargetPort.IntValue() == int(got2.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort))
 
-			case got.Spec.Ports[0].TargetPort.String() != got2.Spec.Template.Spec.Containers[0].Ports[0].Name &&
-				got.Spec.Ports[0].TargetPort.IntValue() != int(got2.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort):
-				t.Errorf("Ports[0].TargetPort = %v , Template.Spec.Containers[0].Ports[0].Name = %v , Template.Spec.Containers[0].Ports[0].ContainerPort = %v",
-					got.Spec.Ports[0].TargetPort,
-					got2.Spec.Template.Spec.Containers[0].Ports[0].Name,
-					got2.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort)
-			}
 			if tt.want != nil {
-				if !apiequality.Semantic.DeepEqual(tt.want.Spec, got.Spec) {
-					t.Errorf("Wanted service = %v, Got service = %v", tt.want.Spec, got.Spec)
-				}
+				require.Equal(t, tt.want.Spec, got.Spec)
 			}
 		})
 	}

--- a/internal/builder/metadata/metadata_test.go
+++ b/internal/builder/metadata/metadata_test.go
@@ -26,7 +26,10 @@ func TestNewBuilder(t *testing.T) {
 			args: args{
 				key: types.NamespacedName{},
 			},
-			want: metav1.ObjectMeta{},
+			want: metav1.ObjectMeta{
+				Labels:      map[string]string{},
+				Annotations: map[string]string{},
+			},
 		},
 		{
 			name: "non-empty",
@@ -37,8 +40,10 @@ func TestNewBuilder(t *testing.T) {
 				},
 			},
 			want: metav1.ObjectMeta{
-				Name:      "foo",
-				Namespace: "bar",
+				Name:        "foo",
+				Namespace:   "bar",
+				Labels:      map[string]string{},
+				Annotations: map[string]string{},
 			},
 		},
 	}
@@ -74,8 +79,10 @@ func TestMetadataBuilder_WithMetadata(t *testing.T) {
 				meta: slinkyv1beta1.Metadata{},
 			},
 			want: metav1.ObjectMeta{
-				Name:      "foo",
-				Namespace: "bar",
+				Name:        "foo",
+				Namespace:   "bar",
+				Labels:      map[string]string{},
+				Annotations: map[string]string{},
 			},
 		},
 		{
@@ -141,8 +148,10 @@ func TestMetadataBuilder_WithAnnotations(t *testing.T) {
 				annotations: map[string]string{},
 			},
 			want: metav1.ObjectMeta{
-				Name:      "foo",
-				Namespace: "bar",
+				Name:        "foo",
+				Namespace:   "bar",
+				Labels:      map[string]string{},
+				Annotations: map[string]string{},
 			},
 		},
 		{
@@ -161,6 +170,7 @@ func TestMetadataBuilder_WithAnnotations(t *testing.T) {
 			want: metav1.ObjectMeta{
 				Name:      "foo",
 				Namespace: "bar",
+				Labels:    map[string]string{},
 				Annotations: map[string]string{
 					"foo": "bar",
 				},
@@ -200,8 +210,10 @@ func TestMetadataBuilder_WithLabels(t *testing.T) {
 				labels: map[string]string{},
 			},
 			want: metav1.ObjectMeta{
-				Name:      "foo",
-				Namespace: "bar",
+				Name:        "foo",
+				Namespace:   "bar",
+				Labels:      map[string]string{},
+				Annotations: map[string]string{},
 			},
 		},
 		{
@@ -218,8 +230,9 @@ func TestMetadataBuilder_WithLabels(t *testing.T) {
 				},
 			},
 			want: metav1.ObjectMeta{
-				Name:      "foo",
-				Namespace: "bar",
+				Name:        "foo",
+				Namespace:   "bar",
+				Annotations: map[string]string{},
 				Labels: map[string]string{
 					"fizz": "buzz",
 				},

--- a/internal/builder/metadata/metadata_test.go
+++ b/internal/builder/metadata/metadata_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -44,9 +44,7 @@ func TestNewBuilder(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := NewBuilder(tt.args.key).Build(); !apiequality.Semantic.DeepEqual(got, tt.want) {
-				t.Errorf("NewBuilder() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, NewBuilder(tt.args.key).Build())
 		})
 	}
 }
@@ -113,9 +111,7 @@ func TestMetadataBuilder_WithMetadata(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			b := NewBuilder(tt.fields.key)
-			if got := b.WithMetadata(tt.args.meta).Build(); !apiequality.Semantic.DeepEqual(got, tt.want) {
-				t.Errorf("MetadataBuilder.WithMetadata() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, b.WithMetadata(tt.args.meta).Build())
 		})
 	}
 }
@@ -174,9 +170,7 @@ func TestMetadataBuilder_WithAnnotations(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			b := NewBuilder(tt.fields.key)
-			if got := b.WithAnnotations(tt.args.annotations).Build(); !apiequality.Semantic.DeepEqual(got, tt.want) {
-				t.Errorf("MetadataBuilder.WithAnnotations() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, b.WithAnnotations(tt.args.annotations).Build())
 		})
 	}
 }
@@ -235,9 +229,7 @@ func TestMetadataBuilder_WithLabels(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			b := NewBuilder(tt.fields.key)
-			if got := b.WithLabels(tt.args.labels).Build(); !apiequality.Semantic.DeepEqual(got, tt.want) {
-				t.Errorf("MetadataBuilder.WithLabels() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, b.WithLabels(tt.args.labels).Build())
 		})
 	}
 }

--- a/internal/builder/restapibuilder/builder_test.go
+++ b/internal/builder/restapibuilder/builder_test.go
@@ -4,12 +4,12 @@
 package restapibuilder
 
 import (
-	"reflect"
 	"testing"
 
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
 	"github.com/SlinkyProject/slurm-operator/internal/builder/common"
 	"github.com/SlinkyProject/slurm-operator/internal/utils/refresolver"
+	"github.com/stretchr/testify/require"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -55,9 +55,7 @@ func TestNew(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := New(tt.args.c); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("New() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, New(tt.args.c))
 		})
 	}
 }

--- a/internal/builder/restapibuilder/restapi_app_test.go
+++ b/internal/builder/restapibuilder/restapi_app_test.go
@@ -87,7 +87,7 @@ func TestBuilder_BuildRestapi(t *testing.T) {
 			require.Equal(t, slurmrestdUserGid, ptr.Deref(got.Spec.Template.Spec.Containers[0].SecurityContext.RunAsGroup, 0))
 			require.Equal(t, labels.RestapiApp, got.Spec.Template.Spec.Containers[0].Name)
 			require.Equal(t, labels.RestapiApp, got.Spec.Template.Spec.Containers[0].Ports[0].Name)
-			require.Equal(t, SlurmrestdPort, got.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort)
+			require.Equal(t, int32(SlurmrestdPort), got.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort)
 		})
 	}
 }

--- a/internal/builder/restapibuilder/restapi_app_test.go
+++ b/internal/builder/restapibuilder/restapi_app_test.go
@@ -9,6 +9,7 @@ import (
 
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
 	"github.com/SlinkyProject/slurm-operator/internal/builder/labels"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -73,42 +74,20 @@ func TestBuilder_BuildRestapi(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			b := New(tt.fields.client)
 			got, err := b.BuildRestapi(tt.args.restapi)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Builder.BuildRestapi() error = %v, wantErr %v", err, tt.wantErr)
+
+			if tt.wantErr {
+				require.Error(t, err)
 				return
 			}
-			switch {
-			case err != nil:
-				return
 
-			case !set.KeySet(got.Spec.Template.Labels).HasAll(set.KeySet(got.Spec.Selector.MatchLabels).UnsortedList()...):
-				t.Errorf("Template.Labels = %v , Selector.MatchLabels = %v",
-					got.Spec.Template.Labels, got.Spec.Selector.MatchLabels)
-
-			case ptr.Deref(got.Spec.Template.Spec.Containers[0].SecurityContext.RunAsNonRoot, false) != true:
-				t.Errorf("got.Spec.Template.Spec.Containers[0].SecurityContext.RunAsNonRoot = %v , want = %v",
-					got.Spec.Template.Spec.Containers[0].SecurityContext.RunAsNonRoot, true)
-
-			case ptr.Deref(got.Spec.Template.Spec.Containers[0].SecurityContext.RunAsUser, 0) != slurmrestdUserUid:
-				t.Errorf("got.Spec.Template.Spec.Containers[0].SecurityContext.RunAsUser = %v , want = %v",
-					got.Spec.Template.Spec.Containers[0].SecurityContext.RunAsUser, slurmrestdUserUid)
-
-			case ptr.Deref(got.Spec.Template.Spec.Containers[0].SecurityContext.RunAsGroup, 0) != slurmrestdUserGid:
-				t.Errorf("got.Spec.Template.Spec.Containers[0].SecurityContext.RunAsGroup = %v , want = %v",
-					got.Spec.Template.Spec.Containers[0].SecurityContext.RunAsGroup, slurmrestdUserGid)
-
-			case got.Spec.Template.Spec.Containers[0].Name != labels.RestapiApp:
-				t.Errorf("Template.Spec.Containers[0].Name = %v , want = %v",
-					got.Spec.Template.Spec.Containers[0].Name, labels.RestapiApp)
-
-			case got.Spec.Template.Spec.Containers[0].Ports[0].Name != labels.RestapiApp:
-				t.Errorf("Template.Spec.Containers[0].Ports[0].Name = %v , want = %v",
-					got.Spec.Template.Spec.Containers[0].Ports[0].Name, labels.RestapiApp)
-
-			case got.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort != SlurmrestdPort:
-				t.Errorf("Template.Spec.Containers[0].Ports[0].ContainerPort = %v , want = %v",
-					got.Spec.Template.Spec.Containers[0].Ports[0].Name, SlurmrestdPort)
-			}
+			require.NoError(t, err)
+			require.True(t, set.KeySet(got.Spec.Template.Labels).HasAll(set.KeySet(got.Spec.Selector.MatchLabels).UnsortedList()...))
+			require.True(t, ptr.Deref(got.Spec.Template.Spec.Containers[0].SecurityContext.RunAsNonRoot, false))
+			require.Equal(t, slurmrestdUserUid, ptr.Deref(got.Spec.Template.Spec.Containers[0].SecurityContext.RunAsUser, 0))
+			require.Equal(t, slurmrestdUserGid, ptr.Deref(got.Spec.Template.Spec.Containers[0].SecurityContext.RunAsGroup, 0))
+			require.Equal(t, labels.RestapiApp, got.Spec.Template.Spec.Containers[0].Name)
+			require.Equal(t, labels.RestapiApp, got.Spec.Template.Spec.Containers[0].Ports[0].Name)
+			require.Equal(t, SlurmrestdPort, got.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort)
 		})
 	}
 }

--- a/internal/builder/restapibuilder/restapi_service_test.go
+++ b/internal/builder/restapibuilder/restapi_service_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/set"
@@ -150,33 +150,24 @@ func TestBuilder_BuildRestapiService(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			b := New(tt.fields.client)
 			got, err := b.BuildRestapiService(tt.args.restapi)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Builder.BuildRestapiService() error = %v, wantErr %v", err, tt.wantErr)
+
+			if tt.wantErr {
+				require.Error(t, err)
 				return
 			}
+
+			require.NoError(t, err)
+
 			got2, err := b.BuildRestapi(tt.args.restapi)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Builder.BuildRestapi() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			switch {
-			case err != nil:
-				return
 
-			case !set.KeySet(got2.Labels).HasAll(set.KeySet(got.Spec.Selector).UnsortedList()...):
-				t.Errorf("Labels = %v , Selector = %v", got.Labels, got.Spec.Selector)
+			require.NoError(t, err)
+			require.True(t, set.KeySet(got2.Labels).HasAll(set.KeySet(got.Spec.Selector).UnsortedList()...))
+			require.True(t,
+				got.Spec.Ports[0].TargetPort.String() == got2.Spec.Template.Spec.Containers[0].Ports[0].Name ||
+					got.Spec.Ports[0].TargetPort.IntValue() == int(got2.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort))
 
-			case got.Spec.Ports[0].TargetPort.String() != got2.Spec.Template.Spec.Containers[0].Ports[0].Name &&
-				got.Spec.Ports[0].TargetPort.IntValue() != int(got2.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort):
-				t.Errorf("Ports[0].TargetPort = %v , Template.Spec.Containers[0].Ports[0].Name = %v , Template.Spec.Containers[0].Ports[0].ContainerPort = %v",
-					got.Spec.Ports[0].TargetPort,
-					got2.Spec.Template.Spec.Containers[0].Ports[0].Name,
-					got2.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort)
-			}
 			if tt.want != nil {
-				if !apiequality.Semantic.DeepEqual(tt.want.Spec, got.Spec) {
-					t.Errorf("Wanted service = %v, Got service = %v", tt.want.Spec, got.Spec)
-				}
+				require.Equal(t, tt.want.Spec, got.Spec)
 			}
 		})
 	}

--- a/internal/builder/workerbuilder/builder_test.go
+++ b/internal/builder/workerbuilder/builder_test.go
@@ -4,12 +4,12 @@
 package workerbuilder
 
 import (
-	"reflect"
 	"testing"
 
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
 	"github.com/SlinkyProject/slurm-operator/internal/builder/common"
 	"github.com/SlinkyProject/slurm-operator/internal/utils/refresolver"
+	"github.com/stretchr/testify/require"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -55,9 +55,7 @@ func TestNew(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := New(tt.args.c); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("New() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, New(tt.args.c))
 		})
 	}
 }

--- a/internal/builder/workerbuilder/worker_app_test.go
+++ b/internal/builder/workerbuilder/worker_app_test.go
@@ -82,7 +82,7 @@ func TestBuilder_BuildWorkerPodTemplate(t *testing.T) {
 			require.True(t, set.KeySet(got.Labels).HasAll(set.KeySet(selector).UnsortedList()...))
 			require.Equal(t, labels.WorkerApp, got.Spec.Containers[0].Name)
 			require.Equal(t, labels.WorkerApp, got.Spec.Containers[0].Ports[0].Name)
-			require.Equal(t, common.SlurmdPort, got.Spec.Containers[0].Ports[0].ContainerPort)
+			require.Equal(t, int32(common.SlurmdPort), got.Spec.Containers[0].Ports[0].ContainerPort)
 			require.NotEmpty(t, got.Spec.Subdomain)
 			require.NotNil(t, got.Spec.DNSConfig)
 			require.NotEmpty(t, got.Spec.DNSConfig.Searches)

--- a/internal/builder/workerbuilder/worker_app_test.go
+++ b/internal/builder/workerbuilder/worker_app_test.go
@@ -11,6 +11,7 @@ import (
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
 	"github.com/SlinkyProject/slurm-operator/internal/builder/common"
 	"github.com/SlinkyProject/slurm-operator/internal/builder/labels"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -76,34 +77,15 @@ func TestBuilder_BuildWorkerPodTemplate(t *testing.T) {
 			b := New(tt.fields.client)
 			got := b.BuildWorkerPodTemplate(tt.args.nodeset, tt.args.controller)
 			selector, err := k8slabels.ConvertSelectorToLabelsMap(tt.args.nodeset.Status.Selector)
-			if err != nil {
-				t.Errorf("ConvertSelectorToLabelsMap() = %v", err)
-			}
-			switch {
-			case !set.KeySet(got.Labels).HasAll(set.KeySet(selector).UnsortedList()...):
-				t.Errorf("Labels = %v , Selector = %v", got.Labels, selector)
 
-			case got.Spec.Containers[0].Name != labels.WorkerApp:
-				t.Errorf("Containers[0].Name = %v , want = %v",
-					got.Spec.Containers[0].Name, labels.WorkerApp)
-
-			case got.Spec.Containers[0].Ports[0].Name != labels.WorkerApp:
-				t.Errorf("Containers[0].Ports[0].Name = %v , want = %v",
-					got.Spec.Containers[0].Ports[0].Name, labels.WorkerApp)
-
-			case got.Spec.Containers[0].Ports[0].ContainerPort != common.SlurmdPort:
-				t.Errorf("Containers[0].Ports[0].ContainerPort = %v , want = %v",
-					got.Spec.Containers[0].Ports[0].Name, common.SlurmdPort)
-
-			case got.Spec.Subdomain == "":
-				t.Errorf("Subdomain = %v , want = non-empty", got.Spec.Subdomain)
-
-			case got.Spec.DNSConfig == nil:
-				t.Errorf("DNSConfig = %v , want = non-nil", got.Spec.DNSConfig)
-
-			case len(got.Spec.DNSConfig.Searches) == 0:
-				t.Errorf("len(DNSConfig.Searches) = %v , want = > 0", len(got.Spec.DNSConfig.Searches))
-			}
+			require.NoError(t, err)
+			require.True(t, set.KeySet(got.Labels).HasAll(set.KeySet(selector).UnsortedList()...))
+			require.Equal(t, labels.WorkerApp, got.Spec.Containers[0].Name)
+			require.Equal(t, labels.WorkerApp, got.Spec.Containers[0].Ports[0].Name)
+			require.Equal(t, common.SlurmdPort, got.Spec.Containers[0].Ports[0].ContainerPort)
+			require.NotEmpty(t, got.Spec.Subdomain)
+			require.NotNil(t, got.Spec.DNSConfig)
+			require.NotEmpty(t, got.Spec.DNSConfig.Searches)
 		})
 	}
 }
@@ -361,12 +343,9 @@ func TestWorkerBuilder_getResourceLimits(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			b := New(client)
 			cpu, memory := b.getResourceLimits(tt.nodeset)
-			if cpu != tt.want.cpu {
-				t.Errorf("getResourceLimits() = %v, want %v", cpu, tt.want.cpu)
-			}
-			if memory != tt.want.memory {
-				t.Errorf("getResourceLimits() = %v, want %v", memory, tt.want.memory)
-			}
+
+			require.Equal(t, tt.want.cpu, cpu)
+			require.Equal(t, tt.want.memory, memory)
 		})
 	}
 }

--- a/internal/builder/workerbuilder/worker_config_test.go
+++ b/internal/builder/workerbuilder/worker_config_test.go
@@ -8,6 +8,7 @@ import (
 
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
 	loginbuilder "github.com/SlinkyProject/slurm-operator/internal/builder/loginbuilder"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -49,17 +50,14 @@ func TestBuilder_BuildWorkerSshConfig(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			b := New(tt.fields.client)
 			got, err := b.BuildWorkerSshConfig(tt.args.nodeset)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Builder.BuildWorkerSshConfig() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			switch {
-			case err != nil:
-				return
 
-			case got.Data[loginbuilder.SshdConfigFile] == "" && got.BinaryData[loginbuilder.SshdConfigFile] == nil:
-				t.Errorf("got.Data[%s] = %v", loginbuilder.SshdConfigFile, got.Data[loginbuilder.SshdConfigFile])
+			if tt.wantErr {
+				require.Error(t, err)
+				return
 			}
+
+			require.NoError(t, err)
+			require.True(t, got.Data[loginbuilder.SshdConfigFile] != "" || got.BinaryData[loginbuilder.SshdConfigFile] != nil)
 		})
 	}
 }

--- a/internal/builder/workerbuilder/worker_pdb_test.go
+++ b/internal/builder/workerbuilder/worker_pdb_test.go
@@ -8,9 +8,9 @@ import (
 
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
 	"github.com/SlinkyProject/slurm-operator/internal/builder/labels"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
@@ -71,18 +71,14 @@ func TestBuilder_BuildClusterWorkerPodDisruptionBudget(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			b := New(tt.c)
 			got, gotErr := b.BuildClusterWorkerPodDisruptionBudget(tt.nodeset)
-			if gotErr != nil {
-				if !tt.wantErr {
-					t.Errorf("BuildClusterWorkerPodDisruptionBudget() failed: %v", gotErr)
-				}
+
+			if tt.wantErr {
+				require.Error(t, gotErr)
 				return
 			}
-			if tt.wantErr {
-				t.Fatal("BuildClusterWorkerPodDisruptionBudget() succeeded unexpectedly")
-			}
-			if !apiequality.Semantic.DeepEqual(got, tt.want) {
-				t.Errorf("BuildClusterWorkerPodDisruptionBudget() = %v, want %v", got, tt.want)
-			}
+
+			require.NoError(t, gotErr)
+			require.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/internal/builder/workerbuilder/worker_pdb_test.go
+++ b/internal/builder/workerbuilder/worker_pdb_test.go
@@ -32,7 +32,10 @@ func TestBuilder_BuildClusterWorkerPodDisruptionBudget(t *testing.T) {
 			nodeset: &slinkyv1beta1.NodeSet{},
 			want: &policyv1.PodDisruptionBudget{
 				ObjectMeta: v1.ObjectMeta{
-					Name: "slurm-workers-pdb-",
+					Name:            "slurm-workers-pdb-",
+					Labels:          map[string]string{},
+					Annotations:     map[string]string{},
+					OwnerReferences: []v1.OwnerReference{},
 				},
 				Spec: policyv1.PodDisruptionBudgetSpec{
 					Selector: &v1.LabelSelector{
@@ -55,7 +58,10 @@ func TestBuilder_BuildClusterWorkerPodDisruptionBudget(t *testing.T) {
 			},
 			want: &policyv1.PodDisruptionBudget{
 				ObjectMeta: v1.ObjectMeta{
-					Name: "slurm-workers-pdb-slurm",
+					Name:            "slurm-workers-pdb-slurm",
+					Labels:          map[string]string{},
+					Annotations:     map[string]string{},
+					OwnerReferences: []v1.OwnerReference{},
 				},
 				Spec: policyv1.PodDisruptionBudgetSpec{
 					Selector: &v1.LabelSelector{

--- a/internal/builder/workerbuilder/worker_service_test.go
+++ b/internal/builder/workerbuilder/worker_service_test.go
@@ -64,7 +64,7 @@ func TestBuilder_BuildClusterWorkerService(t *testing.T) {
 			require.Empty(t, got.OwnerReferences)
 			require.Equal(t, corev1.ClusterIPNone, got.Spec.ClusterIP)
 			require.Len(t, got.Spec.Ports, 1)
-			require.Equal(t, common.SlurmdPort, got.Spec.Ports[0].Port)
+			require.Equal(t, int32(common.SlurmdPort), got.Spec.Ports[0].Port)
 		})
 	}
 }

--- a/internal/builder/workerbuilder/worker_service_test.go
+++ b/internal/builder/workerbuilder/worker_service_test.go
@@ -8,6 +8,7 @@ import (
 
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
 	"github.com/SlinkyProject/slurm-operator/internal/builder/common"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -52,26 +53,18 @@ func TestBuilder_BuildClusterWorkerService(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			b := New(tt.fields.client)
 			got, err := b.BuildClusterWorkerService(tt.args.nodeset)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Builder.BuildClusterWorkerService() error = %v, wantErr %v", err, tt.wantErr)
+
+			if tt.wantErr {
+				require.Error(t, err)
 				return
 			}
-			switch {
-			case err != nil:
-				return
 
-			case got.Name != common.SlurmClusterWorkerServiceName(tt.args.nodeset.Spec.ControllerRef.Name):
-				t.Errorf("Service.Name = %v, want %v", got.Name, common.SlurmClusterWorkerServiceName(tt.args.nodeset.Spec.ControllerRef.Name))
-
-			case len(got.OwnerReferences) != 0:
-				t.Errorf("Service.OwnerReferences = length %v, want zero", len(got.OwnerReferences))
-
-			case got.Spec.ClusterIP != corev1.ClusterIPNone:
-				t.Errorf("Service.Spec.ClusterIP = %v, want headless service", got.Spec.ClusterIP)
-
-			case len(got.Spec.Ports) != 1 || got.Spec.Ports[0].Port != common.SlurmdPort:
-				t.Errorf("Service.Spec.Ports = %v, want single port %d", got.Spec.Ports, common.SlurmdPort)
-			}
+			require.NoError(t, err)
+			require.Equal(t, common.SlurmClusterWorkerServiceName(tt.args.nodeset.Spec.ControllerRef.Name), got.Name)
+			require.Empty(t, got.OwnerReferences)
+			require.Equal(t, corev1.ClusterIPNone, got.Spec.ClusterIP)
+			require.Len(t, got.Spec.Ports, 1)
+			require.Equal(t, common.SlurmdPort, got.Spec.Ports[0].Port)
 		})
 	}
 }

--- a/internal/clientmap/clientmap_test.go
+++ b/internal/clientmap/clientmap_test.go
@@ -4,10 +4,10 @@
 package clientmap
 
 import (
-	"reflect"
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/SlinkyProject/slurm-client/pkg/client"
@@ -28,9 +28,7 @@ func TestNewClientMap(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := NewClientMap(); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("NewClientMap() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, NewClientMap())
 		})
 	}
 }
@@ -84,9 +82,7 @@ func TestClientMap_Get(t *testing.T) {
 				lock:    sync.RWMutex{},
 				clients: tt.fields.clients,
 			}
-			if got := c.Get(tt.args.name); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("ClientMap.Get() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, c.Get(tt.args.name))
 		})
 	}
 }
@@ -143,9 +139,7 @@ func TestClientMap_add(t *testing.T) {
 				lock:    sync.RWMutex{},
 				clients: tt.fields.clients,
 			}
-			if got := c.add(tt.args.name, tt.args.client); got != tt.want {
-				t.Errorf("ClientMap.add() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, c.add(tt.args.name, tt.args.client))
 		})
 	}
 }
@@ -202,9 +196,7 @@ func TestClientMap_Add(t *testing.T) {
 				lock:    sync.RWMutex{},
 				clients: tt.fields.clients,
 			}
-			if got := c.Add(tt.args.name, tt.args.client); got != tt.want {
-				t.Errorf("ClientMap.Add() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, c.Add(tt.args.name, tt.args.client))
 		})
 	}
 }
@@ -261,9 +253,7 @@ func TestClientMap_Has(t *testing.T) {
 				lock:    sync.RWMutex{},
 				clients: tt.fields.clients,
 			}
-			if got := c.Has(tt.args.names...); got != tt.want {
-				t.Errorf("ClientMap.Has() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, c.Has(tt.args.names...))
 		})
 	}
 }
@@ -317,9 +307,7 @@ func TestClientMap_Remove(t *testing.T) {
 				lock:    sync.RWMutex{},
 				clients: tt.fields.clients,
 			}
-			if got := c.Remove(tt.args.name); got != tt.want {
-				t.Errorf("ClientMap.Remove() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, c.Remove(tt.args.name))
 		})
 	}
 }

--- a/internal/clientmap/clientmap_test.go
+++ b/internal/clientmap/clientmap_test.go
@@ -82,6 +82,7 @@ func TestClientMap_Get(t *testing.T) {
 				lock:    sync.RWMutex{},
 				clients: tt.fields.clients,
 			}
+
 			require.Equal(t, tt.want, c.Get(tt.args.name))
 		})
 	}
@@ -139,6 +140,7 @@ func TestClientMap_add(t *testing.T) {
 				lock:    sync.RWMutex{},
 				clients: tt.fields.clients,
 			}
+
 			require.Equal(t, tt.want, c.add(tt.args.name, tt.args.client))
 		})
 	}
@@ -196,6 +198,7 @@ func TestClientMap_Add(t *testing.T) {
 				lock:    sync.RWMutex{},
 				clients: tt.fields.clients,
 			}
+
 			require.Equal(t, tt.want, c.Add(tt.args.name, tt.args.client))
 		})
 	}
@@ -253,6 +256,7 @@ func TestClientMap_Has(t *testing.T) {
 				lock:    sync.RWMutex{},
 				clients: tt.fields.clients,
 			}
+
 			require.Equal(t, tt.want, c.Has(tt.args.names...))
 		})
 	}
@@ -307,6 +311,7 @@ func TestClientMap_Remove(t *testing.T) {
 				lock:    sync.RWMutex{},
 				clients: tt.fields.clients,
 			}
+
 			require.Equal(t, tt.want, c.Remove(tt.args.name))
 		})
 	}

--- a/internal/defaults/accounting_test.go
+++ b/internal/defaults/accounting_test.go
@@ -6,6 +6,8 @@ package defaults
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
 )
 
@@ -17,12 +19,9 @@ func TestSetAccountingDefaults(t *testing.T) {
 	t.Run("zero value spec gets defaults", func(t *testing.T) {
 		a := &slinkyv1beta1.Accounting{}
 		SetAccountingDefaults(a)
-		if a.Spec.StorageConfig.Port != DefaultAccountingStoragePort {
-			t.Errorf("StorageConfig.Port: want default %d, got %d", DefaultAccountingStoragePort, a.Spec.StorageConfig.Port)
-		}
-		if a.Spec.StorageConfig.Database != DefaultAccountingStorageDB {
-			t.Errorf("StorageConfig.Database: want default %q, got %q", DefaultAccountingStorageDB, a.Spec.StorageConfig.Database)
-		}
+
+		require.Equal(t, DefaultAccountingStoragePort, a.Spec.StorageConfig.Port)
+		require.Equal(t, DefaultAccountingStorageDB, a.Spec.StorageConfig.Database)
 	})
 
 	t.Run("explicit values are not overridden", func(t *testing.T) {
@@ -30,11 +29,8 @@ func TestSetAccountingDefaults(t *testing.T) {
 		a.Spec.StorageConfig.Port = 9999
 		a.Spec.StorageConfig.Database = "mydb"
 		SetAccountingDefaults(a)
-		if a.Spec.StorageConfig.Port != 9999 {
-			t.Errorf("StorageConfig.Port: want 9999, got %d", a.Spec.StorageConfig.Port)
-		}
-		if a.Spec.StorageConfig.Database != "mydb" {
-			t.Errorf("StorageConfig.Database: want mydb, got %q", a.Spec.StorageConfig.Database)
-		}
+
+		require.Equal(t, 9999, a.Spec.StorageConfig.Port)
+		require.Equal(t, "mydb", a.Spec.StorageConfig.Database)
 	})
 }

--- a/internal/defaults/controller_test.go
+++ b/internal/defaults/controller_test.go
@@ -6,6 +6,7 @@ package defaults
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/utils/ptr"
 
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
@@ -19,22 +20,18 @@ func TestSetControllerDefaults(t *testing.T) {
 	t.Run("zero value spec gets defaults", func(t *testing.T) {
 		c := &slinkyv1beta1.Controller{}
 		SetControllerDefaults(c)
-		if c.Spec.Persistence.Enabled == nil || *c.Spec.Persistence.Enabled != DefaultControllerPersistenceEnabled {
-			t.Errorf("Persistence.Enabled: want %v, got %v", DefaultControllerPersistenceEnabled, c.Spec.Persistence.Enabled)
-		}
+
+		require.Equal(t, ptr.To(DefaultControllerPersistenceEnabled), c.Spec.Persistence.Enabled)
 	})
 
 	t.Run("explicit values are not overridden", func(t *testing.T) {
 		c := &slinkyv1beta1.Controller{}
 		c.Spec.Persistence.Enabled = ptr.To(true)
 		SetControllerDefaults(c)
-		if ptr.Deref(c.Spec.Persistence.Enabled, DefaultControllerPersistenceEnabled) != true {
-			t.Errorf("Persistence.Enabled: want true, got %v", c.Spec.Persistence.Enabled)
-		}
+		require.Equal(t, ptr.To(true), c.Spec.Persistence.Enabled)
+
 		c.Spec.Persistence.Enabled = ptr.To(false)
 		SetControllerDefaults(c)
-		if ptr.Deref(c.Spec.Persistence.Enabled, DefaultControllerPersistenceEnabled) != false {
-			t.Errorf("Persistence.Enabled after explicit false: defaulting sets to true, got %v", c.Spec.Persistence.Enabled)
-		}
+		require.Equal(t, ptr.To(false), c.Spec.Persistence.Enabled)
 	})
 }

--- a/internal/defaults/loginset_test.go
+++ b/internal/defaults/loginset_test.go
@@ -6,6 +6,7 @@ package defaults
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/utils/ptr"
 
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
@@ -19,17 +20,15 @@ func TestSetLoginSetDefaults(t *testing.T) {
 	t.Run("zero value spec gets defaults", func(t *testing.T) {
 		ls := &slinkyv1beta1.LoginSet{}
 		SetLoginSetDefaults(ls)
-		if ls.Spec.Replicas == nil || *ls.Spec.Replicas != DefaultLoginSetReplicas {
-			t.Errorf("Replicas: want default %d, got %v", DefaultLoginSetReplicas, ls.Spec.Replicas)
-		}
+
+		require.Equal(t, ptr.To(DefaultLoginSetReplicas), ls.Spec.Replicas)
 	})
 
 	t.Run("explicit values are not overridden", func(t *testing.T) {
 		ls := &slinkyv1beta1.LoginSet{}
 		ls.Spec.Replicas = ptr.To(int32(3))
 		SetLoginSetDefaults(ls)
-		if ptr.Deref(ls.Spec.Replicas, 0) != 3 {
-			t.Errorf("Replicas: want 3, got %v", ptr.Deref(ls.Spec.Replicas, 0))
-		}
+
+		require.Equal(t, ptr.To(int32(3)), ls.Spec.Replicas)
 	})
 }

--- a/internal/defaults/nodeset_test.go
+++ b/internal/defaults/nodeset_test.go
@@ -6,7 +6,7 @@ package defaults
 import (
 	"testing"
 
-	"k8s.io/apimachinery/pkg/api/equality"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 
@@ -21,30 +21,15 @@ func TestSetNodeSetDefaults(t *testing.T) {
 	t.Run("zero value spec gets defaults", func(t *testing.T) {
 		ns := &slinkyv1beta1.NodeSet{}
 		SetNodeSetDefaults(ns)
-		if ns.Spec.Replicas == nil || *ns.Spec.Replicas != DefaultNodeSetReplicas {
-			t.Errorf("Replicas: want default %d, got %v", DefaultNodeSetReplicas, ns.Spec.Replicas)
-		}
-		if ns.Spec.ScalingMode != DefaultNodeSetScalingMode {
-			t.Errorf("ScalingMode: want %q, got %q", DefaultNodeSetScalingMode, ns.Spec.ScalingMode)
-		}
-		if ns.Spec.WorkloadDisruptionProtection == nil || *ns.Spec.WorkloadDisruptionProtection != DefaultNodeSetWorkloadDisruptionProtection {
-			t.Errorf("WorkloadDisruptionProtection: want %v, got %v", DefaultNodeSetWorkloadDisruptionProtection, ns.Spec.WorkloadDisruptionProtection)
-		}
-		if ns.Spec.UpdateStrategy.Type != DefaultNodeSetUpdateStrategyType {
-			t.Errorf("UpdateStrategy.Type: want %q, got %q", DefaultNodeSetUpdateStrategyType, ns.Spec.UpdateStrategy.Type)
-		}
-		if ns.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable == nil {
-			t.Error("UpdateStrategy.RollingUpdate.MaxUnavailable: want default, got nil")
-		}
-		if ns.Spec.PersistentVolumeClaimRetentionPolicy.WhenDeleted != slinkyv1beta1.RetainPersistentVolumeClaimRetentionPolicyType {
-			t.Errorf("PersistentVolumeClaimRetentionPolicy.WhenDeleted: want %q, got %q", slinkyv1beta1.RetainPersistentVolumeClaimRetentionPolicyType, ns.Spec.PersistentVolumeClaimRetentionPolicy.WhenDeleted)
-		}
-		if ns.Spec.PersistentVolumeClaimRetentionPolicy.WhenScaled != slinkyv1beta1.RetainPersistentVolumeClaimRetentionPolicyType {
-			t.Errorf("PersistentVolumeClaimRetentionPolicy.WhenScaled: want %q, got %q", slinkyv1beta1.RetainPersistentVolumeClaimRetentionPolicyType, ns.Spec.PersistentVolumeClaimRetentionPolicy.WhenScaled)
-		}
-		if ns.Spec.PruneSlurmNodeRecords != DefaultNodeSetPruneSlurmNodeRecordType {
-			t.Errorf("PruneSlurmNodeRecords: want %q, got %q", DefaultNodeSetPruneSlurmNodeRecordType, ns.Spec.PruneSlurmNodeRecords)
-		}
+
+		require.Equal(t, ptr.To(DefaultNodeSetReplicas), ns.Spec.Replicas)
+		require.Equal(t, DefaultNodeSetScalingMode, ns.Spec.ScalingMode)
+		require.Equal(t, ptr.To(DefaultNodeSetWorkloadDisruptionProtection), ns.Spec.WorkloadDisruptionProtection)
+		require.Equal(t, DefaultNodeSetUpdateStrategyType, ns.Spec.UpdateStrategy.Type)
+		require.NotNil(t, ns.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable)
+		require.Equal(t, slinkyv1beta1.RetainPersistentVolumeClaimRetentionPolicyType, ns.Spec.PersistentVolumeClaimRetentionPolicy.WhenDeleted)
+		require.Equal(t, slinkyv1beta1.RetainPersistentVolumeClaimRetentionPolicyType, ns.Spec.PersistentVolumeClaimRetentionPolicy.WhenScaled)
+		require.Equal(t, DefaultNodeSetPruneSlurmNodeRecordType, ns.Spec.PruneSlurmNodeRecords)
 	})
 
 	t.Run("explicit values are not overridden", func(t *testing.T) {
@@ -58,26 +43,13 @@ func TestSetNodeSetDefaults(t *testing.T) {
 		ns.Spec.PersistentVolumeClaimRetentionPolicy.WhenScaled = slinkyv1beta1.DeletePersistentVolumeClaimRetentionPolicyType
 		ns.Spec.PruneSlurmNodeRecords = slinkyv1beta1.NodeSetPruneNodeRecordTypeNodeNotFound
 		SetNodeSetDefaults(ns)
-		if ptr.Deref(ns.Spec.Replicas, 0) != 3 {
-			t.Errorf("Replicas: want 3, got %v", ptr.Deref(ns.Spec.Replicas, 0))
-		}
-		if ns.Spec.ScalingMode != slinkyv1beta1.ScalingModeDaemonset {
-			t.Errorf("ScalingMode: want DaemonSet, got %q", ns.Spec.ScalingMode)
-		}
-		if !equality.Semantic.DeepEqual(ns.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable, ptr.To(maxUnavailable)) {
-			t.Errorf("RollingUpdate.MaxUnavailable: want %q, got %q", maxUnavailable.String(), ns.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable)
-		}
-		if ns.Spec.UpdateStrategy.Type != slinkyv1beta1.OnDeleteNodeSetStrategyType {
-			t.Errorf("UpdateStrategy.Type: want OnDelete, got %q", ns.Spec.UpdateStrategy.Type)
-		}
-		if ns.Spec.PersistentVolumeClaimRetentionPolicy.WhenDeleted != slinkyv1beta1.DeletePersistentVolumeClaimRetentionPolicyType {
-			t.Errorf("PersistentVolumeClaimRetentionPolicy.WhenDeleted: want %q, got %q", slinkyv1beta1.DeletePersistentVolumeClaimRetentionPolicyType, ns.Spec.PersistentVolumeClaimRetentionPolicy.WhenDeleted)
-		}
-		if ns.Spec.PersistentVolumeClaimRetentionPolicy.WhenScaled != slinkyv1beta1.DeletePersistentVolumeClaimRetentionPolicyType {
-			t.Errorf("PersistentVolumeClaimRetentionPolicy.WhenScaled: want %q, got %q", slinkyv1beta1.DeletePersistentVolumeClaimRetentionPolicyType, ns.Spec.PersistentVolumeClaimRetentionPolicy.WhenScaled)
-		}
-		if ns.Spec.PruneSlurmNodeRecords != slinkyv1beta1.NodeSetPruneNodeRecordTypeNodeNotFound {
-			t.Errorf("PruneSlurmNodeRecords: want %q, got %q", slinkyv1beta1.NodeSetPruneNodeRecordTypeNodeNotFound, ns.Spec.PruneSlurmNodeRecords)
-		}
+
+		require.Equal(t, ptr.To(int32(3)), ns.Spec.Replicas)
+		require.Equal(t, slinkyv1beta1.ScalingModeDaemonset, ns.Spec.ScalingMode)
+		require.Equal(t, ptr.To(maxUnavailable), ns.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable)
+		require.Equal(t, slinkyv1beta1.OnDeleteNodeSetStrategyType, ns.Spec.UpdateStrategy.Type)
+		require.Equal(t, slinkyv1beta1.DeletePersistentVolumeClaimRetentionPolicyType, ns.Spec.PersistentVolumeClaimRetentionPolicy.WhenDeleted)
+		require.Equal(t, slinkyv1beta1.DeletePersistentVolumeClaimRetentionPolicyType, ns.Spec.PersistentVolumeClaimRetentionPolicy.WhenScaled)
+		require.Equal(t, slinkyv1beta1.NodeSetPruneNodeRecordTypeNodeNotFound, ns.Spec.PruneSlurmNodeRecords)
 	})
 }

--- a/internal/defaults/restapi_test.go
+++ b/internal/defaults/restapi_test.go
@@ -6,6 +6,7 @@ package defaults
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/utils/ptr"
 
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
@@ -19,17 +20,15 @@ func TestSetRestApiDefaults(t *testing.T) {
 	t.Run("zero value spec gets defaults", func(t *testing.T) {
 		ra := &slinkyv1beta1.RestApi{}
 		SetRestApiDefaults(ra)
-		if ra.Spec.Replicas == nil || *ra.Spec.Replicas != DefaultRestApiReplicas {
-			t.Errorf("Replicas: want default %d, got %v", DefaultRestApiReplicas, ra.Spec.Replicas)
-		}
+
+		require.Equal(t, ptr.To(DefaultRestApiReplicas), ra.Spec.Replicas)
 	})
 
 	t.Run("explicit values are not overridden", func(t *testing.T) {
 		ra := &slinkyv1beta1.RestApi{}
 		ra.Spec.Replicas = ptr.To(int32(5))
 		SetRestApiDefaults(ra)
-		if ptr.Deref(ra.Spec.Replicas, 0) != 5 {
-			t.Errorf("Replicas: want 5, got %v", ptr.Deref(ra.Spec.Replicas, 0))
-		}
+
+		require.Equal(t, ptr.To(int32(5)), ra.Spec.Replicas)
 	})
 }

--- a/internal/defaults/token_test.go
+++ b/internal/defaults/token_test.go
@@ -6,6 +6,7 @@ package defaults
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/utils/ptr"
 
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
@@ -19,23 +20,19 @@ func TestSetTokenDefaults(t *testing.T) {
 	t.Run("zero value spec gets defaults", func(t *testing.T) {
 		tok := &slinkyv1beta1.Token{}
 		SetTokenDefaults(tok)
-		if tok.Spec.Refresh == nil || !*tok.Spec.Refresh {
-			t.Errorf("Refresh: want default %v, got %v", DefaultTokenRefresh, tok.Spec.Refresh)
-		}
+
+		require.Equal(t, ptr.To(DefaultTokenRefresh), tok.Spec.Refresh)
 	})
 
 	t.Run("explicit values are not overridden", func(t *testing.T) {
 		tok := &slinkyv1beta1.Token{}
 		tok.Spec.Refresh = ptr.To(true)
 		SetTokenDefaults(tok)
-		if tok.Spec.Refresh == nil || !*tok.Spec.Refresh {
-			t.Errorf("Refresh: want true, got %v", tok.Spec.Refresh)
-		}
+		require.Equal(t, ptr.To(true), tok.Spec.Refresh)
+
 		tok.Spec.Refresh = ptr.To(false)
 		SetTokenDefaults(tok)
 		// Explicit false is not changed (we only set when nil).
-		if tok.Spec.Refresh == nil || *tok.Spec.Refresh {
-			t.Errorf("Refresh: want explicit false preserved, got %v", tok.Spec.Refresh)
-		}
+		require.Equal(t, ptr.To(false), tok.Spec.Refresh)
 	})
 }

--- a/internal/syncsteps/syncsteps_test.go
+++ b/internal/syncsteps/syncsteps_test.go
@@ -20,7 +20,7 @@ func readOneEvent(t *testing.T, rec *events.FakeRecorder) string {
 	case ev := <-rec.Events:
 		return ev
 	default:
-		require.Fail(t, "expected one event on channel")
+		t.Fatal("expected one event on channel")
 		return ""
 	}
 }
@@ -29,7 +29,7 @@ func assertNoEvents(t *testing.T, rec *events.FakeRecorder) {
 	t.Helper()
 	select {
 	case ev := <-rec.Events:
-		require.Failf(t, "unexpected event", "%q", ev)
+		t.Fatalf("unexpected event: %q", ev)
 	default:
 	}
 }

--- a/internal/syncsteps/syncsteps_test.go
+++ b/internal/syncsteps/syncsteps_test.go
@@ -6,9 +6,9 @@ package syncsteps
 import (
 	"context"
 	"errors"
-	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/tools/events"
@@ -20,7 +20,7 @@ func readOneEvent(t *testing.T, rec *events.FakeRecorder) string {
 	case ev := <-rec.Events:
 		return ev
 	default:
-		t.Fatal("expected one event on channel")
+		require.Fail(t, "expected one event on channel")
 		return ""
 	}
 }
@@ -29,7 +29,7 @@ func assertNoEvents(t *testing.T, rec *events.FakeRecorder) {
 	t.Helper()
 	select {
 	case ev := <-rec.Events:
-		t.Fatalf("unexpected event: %q", ev)
+		require.Failf(t, "unexpected event", "%q", ev)
 	default:
 	}
 }
@@ -43,9 +43,7 @@ func TestSync_AllStepsSucceed_ReturnsNil(t *testing.T) {
 		{Name: "a", SyncFn: func(context.Context, *corev1.ConfigMap) error { return nil }},
 		{Name: "b", SyncFn: func(context.Context, *corev1.ConfigMap) error { return nil }},
 	}
-	if err := Sync(ctx, rec, obj, steps); err != nil {
-		t.Fatalf("Sync: %v", err)
-	}
+	require.NoError(t, Sync(ctx, rec, obj, steps))
 	assertNoEvents(t, rec)
 }
 
@@ -54,9 +52,7 @@ func TestSync_EmptySteps_ReturnsNil(t *testing.T) {
 	ctx := context.Background()
 	rec := events.NewFakeRecorder(10)
 	obj := &corev1.ConfigMap{}
-	if err := Sync(ctx, rec, obj, nil); err != nil {
-		t.Fatalf("Sync: %v", err)
-	}
+	require.NoError(t, Sync(ctx, rec, obj, nil))
 	assertNoEvents(t, rec)
 }
 
@@ -71,19 +67,12 @@ func TestSync_SingleFailure_OneEventAndWrappedError(t *testing.T) {
 		{Name: "bad", SyncFn: func(context.Context, *corev1.ConfigMap) error { return wantErr }},
 	}
 	err := Sync(ctx, rec, obj, steps)
-	if err == nil {
-		t.Fatal("expected error")
-	}
-	if !errors.Is(err, wantErr) {
-		t.Fatalf("errors.Is aggregate leaf: %v", err)
-	}
-	if !strings.Contains(err.Error(), `failed "bad" step`) {
-		t.Fatalf("error text: %v", err)
-	}
+	require.ErrorIs(t, err, wantErr)
+	require.ErrorContains(t, err, `failed "bad" step`)
 	ev := readOneEvent(t, rec)
-	if !strings.Contains(ev, "Warning") || !strings.Contains(ev, failedReason) || !strings.Contains(ev, `Failed "bad" step`) {
-		t.Fatalf("event: %q", ev)
-	}
+	require.Contains(t, ev, "Warning")
+	require.Contains(t, ev, failedReason)
+	require.Contains(t, ev, `Failed "bad" step`)
 	assertNoEvents(t, rec)
 }
 
@@ -103,16 +92,9 @@ func TestSync_TwoFailuresWithoutStop_BothRecordedAndContinues(t *testing.T) {
 	}
 	err := Sync(ctx, rec, obj, steps)
 	var agg utilerrors.Aggregate
-	ok := errors.As(err, &agg)
-	if !ok {
-		t.Fatalf("want Aggregate, got %T", err)
-	}
-	if len(agg.Errors()) != 3 {
-		t.Fatalf("want 3 errors, got %d: %v", len(agg.Errors()), agg.Errors())
-	}
-	if !thirdRan {
-		t.Fatal("expected third step to Sync when StopOnError is false")
-	}
+	require.ErrorAs(t, err, &agg)
+	require.Len(t, agg.Errors(), 3)
+	require.True(t, thirdRan, "expected third step to Sync when StopOnError is false")
 	readOneEvent(t, rec)
 	readOneEvent(t, rec)
 	readOneEvent(t, rec)
@@ -133,17 +115,11 @@ func TestSync_StopOnError_SkipsFollowingSteps(t *testing.T) {
 		}},
 	}
 	err := Sync(ctx, rec, obj, steps)
-	if err == nil {
-		t.Fatal("expected error")
-	}
-	if after {
-		t.Fatal("step after StopOnError failure should not Sync")
-	}
+	require.Error(t, err)
+	require.False(t, after, "step after StopOnError failure should not Sync")
 	var agg utilerrors.Aggregate
-	ok := errors.As(err, &agg)
-	if !ok || len(agg.Errors()) != 1 {
-		t.Fatalf("want single error in aggregate, got %v", err)
-	}
+	require.ErrorAs(t, err, &agg)
+	require.Len(t, agg.Errors(), 1)
 	readOneEvent(t, rec)
 	assertNoEvents(t, rec)
 }
@@ -156,9 +132,7 @@ func TestSync_NilRecorder_NoPanicStillAggregates(t *testing.T) {
 		{Name: "x", SyncFn: func(context.Context, *corev1.ConfigMap) error { return errors.New("oops") }},
 	}
 	err := Sync(ctx, nil, obj, steps)
-	if err == nil || !strings.Contains(err.Error(), `failed "x" step`) {
-		t.Fatalf("Sync(nil recorder): %v", err)
-	}
+	require.ErrorContains(t, err, `failed "x" step`)
 }
 
 func TestSync_FirstSucceedsSecondFails_OneError(t *testing.T) {
@@ -171,9 +145,7 @@ func TestSync_FirstSucceedsSecondFails_OneError(t *testing.T) {
 		{Name: "b", SyncFn: func(context.Context, *corev1.ConfigMap) error { return errors.New("bad") }},
 	}
 	err := Sync(ctx, rec, obj, steps)
-	if err == nil {
-		t.Fatal("expected error")
-	}
+	require.Error(t, err)
 	readOneEvent(t, rec)
 	assertNoEvents(t, rec)
 }

--- a/internal/utils/config/config_test.go
+++ b/internal/utils/config/config_test.go
@@ -3,7 +3,11 @@
 
 package config
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func Test_configBuilder_Build(t *testing.T) {
 	type fields struct {
@@ -36,9 +40,7 @@ func Test_configBuilder_Build(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			b := tt.fields.builder
-			if got := b.Build(); got != tt.want {
-				t.Errorf("configBuilder.Build() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, b.Build())
 		})
 	}
 }

--- a/internal/utils/crypto/hash_test.go
+++ b/internal/utils/crypto/hash_test.go
@@ -5,6 +5,8 @@ package crypto
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestCheckSum(t *testing.T) {
@@ -33,9 +35,7 @@ func TestCheckSum(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := CheckSum(tt.args.b); got != tt.want {
-				t.Errorf("CheckSum() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, CheckSum(tt.args.b))
 		})
 	}
 }
@@ -69,9 +69,7 @@ func TestCheckSumFromMap(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := CheckSumFromMap(tt.args.items); got != tt.want {
-				t.Errorf("CheckSumFromMap() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, CheckSumFromMap(tt.args.items))
 		})
 	}
 }

--- a/internal/utils/crypto/keypair_test.go
+++ b/internal/utils/crypto/keypair_test.go
@@ -6,6 +6,8 @@ package crypto
 import (
 	"crypto/elliptic"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewKeyPair(t *testing.T) {
@@ -97,27 +99,21 @@ func TestNewKeyPair(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := NewKeyPair(tt.args.opts...)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("NewKeyPair() error = %v, wantErr %v", err, tt.wantErr)
+
+			if tt.wantErr {
+				require.Error(t, err)
 				return
 			}
-			if err != nil {
-				return
-			}
-			if key, err := got.PrivateKey(); err != nil {
-				t.Errorf("PrivateKey() error = %v", err)
-				return
-			} else if len(key) == 0 {
-				t.Errorf("PrivateKey() len() = %v", len(key))
-				return
-			}
-			if key, err := got.PublicKey(); err != nil {
-				t.Errorf("PublicKey() error = %v", err)
-				return
-			} else if len(key) == 0 {
-				t.Errorf("PublicKey() len() = %v", len(key))
-				return
-			}
+
+			require.NoError(t, err)
+
+			privKey, err := got.PrivateKey()
+			require.NoError(t, err)
+			require.NotEmpty(t, privKey)
+
+			pubKey, err := got.PublicKey()
+			require.NoError(t, err)
+			require.NotEmpty(t, pubKey)
 		})
 	}
 }

--- a/internal/utils/crypto/signing_key_test.go
+++ b/internal/utils/crypto/signing_key_test.go
@@ -5,6 +5,8 @@ package crypto
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewSigningKeyWithLength(t *testing.T) {
@@ -43,9 +45,8 @@ func TestNewSigningKeyWithLength(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := NewSigningKeyWithLength(tt.args.length)
-			if len(got) != tt.args.length {
-				t.Errorf("NewSigningKeyWithLength(): length = %v, got %v", tt.args.length, len(got))
-			}
+
+			require.Len(t, got, tt.args.length)
 		})
 	}
 }

--- a/internal/utils/domainname/domainname_test.go
+++ b/internal/utils/domainname/domainname_test.go
@@ -6,6 +6,8 @@ package domainname
 import (
 	"path"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func Test_clusterDomain(t *testing.T) {
@@ -39,9 +41,8 @@ func Test_clusterDomain(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			resolvConfPath = path.Join(".testdata", tt.resolveConf)
 			got := clusterDomain()
-			if got != tt.want {
-				t.Errorf("clusterDomain() = %v, want %v", got, tt.want)
-			}
+
+			require.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/internal/utils/durationstore/durationstore_test.go
+++ b/internal/utils/durationstore/durationstore_test.go
@@ -6,6 +6,8 @@ package durationstore
 import (
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestDurationStore_Push(t *testing.T) {
@@ -50,9 +52,7 @@ func TestDurationStore_Push(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ds := NewDurationStore(Greater)
 			ds.Push(tt.args.key, tt.args.newDur)
-			if got := ds.Pop(tt.args.key); got != tt.args.newDur {
-				t.Errorf("ds.Pop() = %v, want %v", got, tt.args.newDur)
-			}
+			require.Equal(t, tt.args.newDur, ds.Pop(tt.args.key))
 		})
 	}
 }
@@ -120,9 +120,7 @@ func TestDurationStore_Peek(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ds.Push(tt.args.key, tt.args.newDur)
-			if got := ds.Peek(tt.args.key); got != tt.want {
-				t.Errorf("ds.Peek() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, ds.Peek(tt.args.key))
 		})
 	}
 }
@@ -192,9 +190,7 @@ func TestDurationStore_Pop(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.ds.Pop(tt.args.key); got != tt.want {
-				t.Errorf("DurationStore.Pop() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, tt.ds.Pop(tt.args.key))
 		})
 	}
 }
@@ -264,9 +260,8 @@ func Test_duration_Update(t *testing.T) {
 				dur: tt.fields.dur,
 			}
 			d.Update(tt.args.newDur, tt.args.eval)
-			if got := d.dur; got != tt.want {
-				t.Errorf("DurationStore.Pop() = %v, want %v", got, tt.want)
-			}
+
+			require.Equal(t, tt.want, d.dur)
 		})
 	}
 }

--- a/internal/utils/historycontrol/historycontrol_test.go
+++ b/internal/utils/historycontrol/historycontrol_test.go
@@ -68,7 +68,7 @@ func Test_realHistory_ListControllerRevisions(t *testing.T) {
 				parent:   rs,
 				selector: selector,
 			},
-			want:    []*appsv1.ControllerRevision{},
+			want:    nil,
 			wantErr: false,
 		},
 		{

--- a/internal/utils/historycontrol/historycontrol_test.go
+++ b/internal/utils/historycontrol/historycontrol_test.go
@@ -7,8 +7,8 @@ package historycontrol
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -90,13 +90,14 @@ func Test_realHistory_ListControllerRevisions(t *testing.T) {
 				Client: tt.fields.Client,
 			}
 			got, err := rh.ListControllerRevisions(tt.args.parent, tt.args.selector)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("realHistory.ListControllerRevisions() error = %v, wantErr %v", err, tt.wantErr)
+
+			if tt.wantErr {
+				require.Error(t, err)
 				return
 			}
-			if !apiequality.Semantic.DeepEqual(got, tt.want) {
-				t.Errorf("realHistory.ListControllerRevisions() = %v, want %v", got, tt.want)
-			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -158,10 +159,13 @@ func Test_realHistory_CreateControllerRevision(t *testing.T) {
 				Client: tt.fields.Client,
 			}
 			_, err := rh.CreateControllerRevision(tt.args.parent, tt.args.revision, tt.args.collisionCount)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("realHistory.CreateControllerRevision() error = %v, wantErr %v", err, tt.wantErr)
+
+			if tt.wantErr {
+				require.Error(t, err)
 				return
 			}
+
+			require.NoError(t, err)
 		})
 	}
 }
@@ -226,10 +230,13 @@ func Test_realHistory_UpdateControllerRevision(t *testing.T) {
 				Client: tt.fields.Client,
 			}
 			_, err := rh.UpdateControllerRevision(tt.args.revision, tt.args.newRevision)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("realHistory.UpdateControllerRevision() error = %v, wantErr %v", err, tt.wantErr)
+
+			if tt.wantErr {
+				require.Error(t, err)
 				return
 			}
+
+			require.NoError(t, err)
 		})
 	}
 }
@@ -279,9 +286,14 @@ func Test_realHistory_DeleteControllerRevision(t *testing.T) {
 			rh := &realHistory{
 				Client: tt.fields.Client,
 			}
-			if err := rh.DeleteControllerRevision(tt.args.revision); (err != nil) != tt.wantErr {
-				t.Errorf("realHistory.DeleteControllerRevision() error = %v, wantErr %v", err, tt.wantErr)
+			err := rh.DeleteControllerRevision(tt.args.revision)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
 			}
+
+			require.NoError(t, err)
 		})
 	}
 }
@@ -348,13 +360,14 @@ func Test_realHistory_AdoptControllerRevision(t *testing.T) {
 				Client: tt.fields.Client,
 			}
 			got, err := rh.AdoptControllerRevision(tt.args.parent, tt.args.parentKind, tt.args.revision)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("realHistory.AdoptControllerRevision() error = %v, wantErr %v", err, tt.wantErr)
+
+			if tt.wantErr {
+				require.Error(t, err)
 				return
 			}
-			if !apiequality.Semantic.DeepEqual(got, tt.want) {
-				t.Errorf("realHistory.AdoptControllerRevision() = %v, want %v", got, tt.want)
-			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -410,13 +423,14 @@ func Test_realHistory_ReleaseControllerRevision(t *testing.T) {
 				Client: tt.fields.Client,
 			}
 			got, err := rh.ReleaseControllerRevision(tt.args.parent, tt.args.revision)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("realHistory.ReleaseControllerRevision() error = %v, wantErr %v", err, tt.wantErr)
+
+			if tt.wantErr {
+				require.Error(t, err)
 				return
 			}
-			if !apiequality.Semantic.DeepEqual(got, tt.want) {
-				t.Errorf("realHistory.ReleaseControllerRevision() = %v, want %v", got, tt.want)
-			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/internal/utils/historycontrol/utils_test.go
+++ b/internal/utils/historycontrol/utils_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 	"k8s.io/kubernetes/pkg/controller/history"
 )
 
@@ -92,9 +93,7 @@ func TestGetRevision(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := GetRevision(tt.args.labels); got != tt.want {
-				t.Errorf("GetRevision() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, GetRevision(tt.args.labels))
 		})
 	}
 }

--- a/internal/utils/mathutils/math_test.go
+++ b/internal/utils/mathutils/math_test.go
@@ -4,9 +4,9 @@
 package mathutils
 
 import (
-	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 )
@@ -88,9 +88,7 @@ func Test_clamp(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := Clamp(tt.args.val, tt.args.min, tt.args.max); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("clamp() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, Clamp(tt.args.val, tt.args.min, tt.args.max))
 		})
 	}
 }
@@ -140,9 +138,16 @@ func Test_GetScaledValueFromIntOrPercent(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := GetScaledValueFromIntOrPercent(tt.args.intOrPercent, tt.args.total, tt.args.roundUp, tt.args.defaultValue); got != tt.want {
-				t.Errorf("GetScaledValueFromIntOrPercent() = %v, want %v", got, tt.want)
-			}
+			require.Equal(
+				t,
+				tt.want,
+				GetScaledValueFromIntOrPercent(
+					tt.args.intOrPercent,
+					tt.args.total,
+					tt.args.roundUp,
+					tt.args.defaultValue,
+				),
+			)
 		})
 	}
 }

--- a/internal/utils/objectutils/delete_test.go
+++ b/internal/utils/objectutils/delete_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -149,9 +150,14 @@ func TestDeleteObject(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := DeleteObject(tt.args.c, tt.args.ctx, nil, nil, tt.args.newObj); (err != nil) != tt.wantErr {
-				t.Errorf("DeleteObject() error = %v, wantErr %v", err, tt.wantErr)
+			err := DeleteObject(tt.args.c, tt.args.ctx, nil, nil, tt.args.newObj)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
 			}
+
+			require.NoError(t, err)
 		})
 	}
 }

--- a/internal/utils/objectutils/enqueue_test.go
+++ b/internal/utils/objectutils/enqueue_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/workqueue"
@@ -44,9 +45,8 @@ func TestEnqueueRequestAfter(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			EnqueueRequestAfter(tt.args.q, tt.args.obj, tt.args.duration)
-			if tt.args.q.Len() == 0 {
-				t.Errorf("Len() = %d", tt.args.q.Len())
-			}
+
+			require.NotZero(t, tt.args.q.Len())
 		})
 	}
 }
@@ -75,9 +75,8 @@ func TestEnqueueRequest(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			EnqueueRequest(tt.args.q, tt.args.obj)
-			if tt.args.q.Len() == 0 {
-				t.Errorf("Len() = %d", tt.args.q.Len())
-			}
+
+			require.NotZero(t, tt.args.q.Len())
 		})
 	}
 }

--- a/internal/utils/objectutils/meta_test.go
+++ b/internal/utils/objectutils/meta_test.go
@@ -6,8 +6,8 @@ package objectutils
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -43,9 +43,7 @@ func TestKeyFunc(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := KeyFunc(tt.args.obj); got != tt.want {
-				t.Errorf("KeyFunc() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, KeyFunc(tt.args.obj))
 		})
 	}
 }
@@ -84,9 +82,7 @@ func TestNamespacedName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := NamespacedName(tt.args.obj); !apiequality.Semantic.DeepEqual(got, tt.want) {
-				t.Errorf("NamespacedName() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, NamespacedName(tt.args.obj))
 		})
 	}
 }

--- a/internal/utils/objectutils/patch_test.go
+++ b/internal/utils/objectutils/patch_test.go
@@ -10,10 +10,10 @@ import (
 
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -771,18 +771,21 @@ func TestSyncObject(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := SyncObject(tt.args.c, tt.args.ctx, nil, nil, tt.args.newObj, tt.args.shouldUpdate); (err != nil) != tt.wantErr {
-				t.Errorf("SyncObject() error = %v, wantErr %v", err, tt.wantErr)
+			err := SyncObject(tt.args.c, tt.args.ctx, nil, nil, tt.args.newObj, tt.args.shouldUpdate)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
 			}
+
+			require.NoError(t, err)
+
 			if tt.wantOwnerRefs != nil {
 				key := client.ObjectKeyFromObject(tt.args.newObj)
 				fetchObj := reflect.New(reflect.TypeOf(tt.args.newObj).Elem()).Interface().(client.Object)
-				if err := tt.args.c.Get(tt.args.ctx, key, fetchObj); err != nil {
-					t.Fatalf("failed to get object after sync: %v", err)
-				}
-				if !equality.Semantic.DeepEqual(fetchObj.GetOwnerReferences(), tt.wantOwnerRefs) {
-					t.Errorf("OwnerReferences = %v, want %v", fetchObj.GetOwnerReferences(), tt.wantOwnerRefs)
-				}
+
+				require.NoError(t, tt.args.c.Get(tt.args.ctx, key, fetchObj))
+				require.Equal(t, tt.wantOwnerRefs, fetchObj.GetOwnerReferences())
 			}
 		})
 	}
@@ -822,30 +825,16 @@ func TestPatchObject_Pod(t *testing.T) {
 		pod.Annotations = map[string]string{"note": "via PatchObject"}
 		return nil
 	})
-	if err != nil {
-		t.Fatalf("PatchObject() error = %v", err)
-	}
-
-	if pod.Labels["app"] != "after" || pod.Labels["patched"] != "true" {
-		t.Errorf("pod.Labels after PatchObject = %v, want app=after and patched=true", pod.Labels)
-	}
-	if pod.Annotations["note"] != "via PatchObject" {
-		t.Errorf("pod.Annotations after PatchObject = %v", pod.Annotations)
-	}
+	require.NoError(t, err)
+	require.Equal(t, "after", pod.Labels["app"])
+	require.Equal(t, "true", pod.Labels["patched"])
+	require.Equal(t, "via PatchObject", pod.Annotations["note"])
 
 	stored := &corev1.Pod{}
-	if err := c.Get(ctx, key, stored); err != nil {
-		t.Fatalf("Get() after patch: %v", err)
-	}
-	if stored.Labels["app"] != "after" {
-		t.Errorf("stored pod labels = %v, want app=after", stored.Labels)
-	}
-	if stored.Annotations["note"] != "via PatchObject" {
-		t.Errorf("stored pod annotations = %v", stored.Annotations)
-	}
-	if !equality.Semantic.DeepEqual(pod.Labels, stored.Labels) {
-		t.Errorf("returned pod labels %v != stored %v", pod.Labels, stored.Labels)
-	}
+	require.NoError(t, c.Get(ctx, key, stored))
+	require.Equal(t, "after", stored.Labels["app"])
+	require.Equal(t, "via PatchObject", stored.Annotations["note"])
+	require.Equal(t, pod.Labels, stored.Labels)
 }
 
 func TestStatusPatchObject_Pod(t *testing.T) {
@@ -881,19 +870,10 @@ func TestStatusPatchObject_Pod(t *testing.T) {
 		pod.Status.ObservedGeneration = 2
 		return nil
 	})
-	if err != nil {
-		t.Fatalf("StatusPatchObject() error = %v", err)
-	}
-
-	if pod.Status.ObservedGeneration != 2 {
-		t.Errorf("pod.Status.ObservedGeneration after StatusPatchObject = %v, want 2", pod.Status.ObservedGeneration)
-	}
+	require.NoError(t, err)
+	require.Equal(t, int64(2), pod.Status.ObservedGeneration)
 
 	stored := &corev1.Pod{}
-	if err := c.Get(ctx, key, stored); err != nil {
-		t.Fatalf("Get() after patch: %v", err)
-	}
-	if stored.Status.ObservedGeneration != 2 {
-		t.Errorf("stored.Status.ObservedGeneration after StatusPatchObject = %v, want 2", stored.Status.ObservedGeneration)
-	}
+	require.NoError(t, c.Get(ctx, key, stored))
+	require.Equal(t, int64(2), stored.Status.ObservedGeneration)
 }

--- a/internal/utils/podcontrol/podcontrol_test.go
+++ b/internal/utils/podcontrol/podcontrol_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -134,9 +135,14 @@ func Test_realPodControl_CreatePods(t *testing.T) {
 				Client:   tt.fields.Client,
 				recorder: tt.fields.recorder,
 			}
-			if err := r.CreatePods(tt.args.ctx, tt.args.namespace, tt.args.template, tt.args.object, tt.args.controllerRef); (err != nil) != tt.wantErr {
-				t.Errorf("realPodControl.CreatePods() error = %v, wantErr %v", err, tt.wantErr)
+			err := r.CreatePods(tt.args.ctx, tt.args.namespace, tt.args.template, tt.args.object, tt.args.controllerRef)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
 			}
+
+			require.NoError(t, err)
 		})
 	}
 }
@@ -217,9 +223,14 @@ func Test_realPodControl_CreatePodsWithGenerateName(t *testing.T) {
 				Client:   tt.fields.Client,
 				recorder: tt.fields.recorder,
 			}
-			if err := r.CreatePodsWithGenerateName(tt.args.ctx, tt.args.namespace, tt.args.template, tt.args.object, tt.args.controllerRef, tt.args.generateName); (err != nil) != tt.wantErr {
-				t.Errorf("realPodControl.CreatePodsWithGenerateName() error = %v, wantErr %v", err, tt.wantErr)
+			err := r.CreatePodsWithGenerateName(tt.args.ctx, tt.args.namespace, tt.args.template, tt.args.object, tt.args.controllerRef, tt.args.generateName)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
 			}
+
+			require.NoError(t, err)
 		})
 	}
 }
@@ -273,9 +284,14 @@ func Test_realPodControl_CreateThisPod(t *testing.T) {
 				Client:   tt.fields.Client,
 				recorder: tt.fields.recorder,
 			}
-			if err := r.CreateThisPod(tt.args.ctx, tt.args.pod, tt.args.object); (err != nil) != tt.wantErr {
-				t.Errorf("realPodControl.CreateThisPod() error = %v, wantErr %v", err, tt.wantErr)
+			err := r.CreateThisPod(tt.args.ctx, tt.args.pod, tt.args.object)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
 			}
+
+			require.NoError(t, err)
 		})
 	}
 }
@@ -365,9 +381,14 @@ func Test_realPodControl_createPods(t *testing.T) {
 				Client:   tt.fields.Client,
 				recorder: tt.fields.recorder,
 			}
-			if err := r.createPods(tt.args.ctx, tt.args.pod, tt.args.object); (err != nil) != tt.wantErr {
-				t.Errorf("realPodControl.createPods() error = %v, wantErr %v", err, tt.wantErr)
+			err := r.createPods(tt.args.ctx, tt.args.pod, tt.args.object)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
 			}
+
+			require.NoError(t, err)
 		})
 	}
 }
@@ -434,9 +455,14 @@ func Test_realPodControl_DeletePod(t *testing.T) {
 				Client:   tt.fields.Client,
 				recorder: tt.fields.recorder,
 			}
-			if err := r.DeletePod(tt.args.ctx, tt.args.namespace, tt.args.podName, tt.args.object); (err != nil) != tt.wantErr {
-				t.Errorf("realPodControl.DeletePod() error = %v, wantErr %v", err, tt.wantErr)
+			err := r.DeletePod(tt.args.ctx, tt.args.namespace, tt.args.podName, tt.args.object)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
 			}
+
+			require.NoError(t, err)
 		})
 	}
 }
@@ -516,9 +542,14 @@ func Test_realPodControl_PatchPod(t *testing.T) {
 				Client:   tt.fields.Client,
 				recorder: tt.fields.recorder,
 			}
-			if err := r.PatchPod(tt.args.ctx, tt.args.namespace, tt.args.name, tt.args.data); (err != nil) != tt.wantErr {
-				t.Errorf("realPodControl.PatchPod() error = %v, wantErr %v", err, tt.wantErr)
+			err := r.PatchPod(tt.args.ctx, tt.args.namespace, tt.args.name, tt.args.data)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
 			}
+
+			require.NoError(t, err)
 		})
 	}
 }

--- a/internal/utils/podinfo/podinfo_test.go
+++ b/internal/utils/podinfo/podinfo_test.go
@@ -6,8 +6,8 @@ package podinfo
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/utils/ptr"
 )
 
@@ -135,9 +135,7 @@ func TestPodInfo_Equal(t *testing.T) {
 				NodeSetName: tt.fields.NodeSetName,
 				NodeSetUID:  tt.fields.NodeSetUID,
 			}
-			if got := podInfo.Equal(tt.args.cmp); got != tt.want {
-				t.Errorf("PodInfo.Equal() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, podInfo.Equal(tt.args.cmp))
 		})
 	}
 }
@@ -181,9 +179,7 @@ func TestPodInfo_ToString(t *testing.T) {
 				NodeSetName: tt.fields.NodeSetName,
 				NodeSetUID:  tt.fields.NodeSetUID,
 			}
-			if got := podInfo.ToString(); got != tt.want {
-				t.Errorf("PodInfo.ToString() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, podInfo.ToString())
 		})
 	}
 }
@@ -241,12 +237,15 @@ func TestParseIntoPodInfo(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := ParseIntoPodInfo(tt.args.str, tt.args.out); (err != nil) != tt.wantErr {
-				t.Errorf("ParseIntoPodInfo() error = %v, wantErr %v", err, tt.wantErr)
+			err := ParseIntoPodInfo(tt.args.str, tt.args.out)
+
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
-			if got := tt.args.out; !apiequality.Semantic.DeepEqual(got, tt.want) {
-				t.Errorf("ParseIntoPodInfo() = %v, want %v", got, tt.want)
-			}
+
+			require.Equal(t, tt.want, tt.args.out)
 		})
 	}
 }

--- a/internal/utils/podutils/pod_test.go
+++ b/internal/utils/podutils/pod_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -49,9 +50,7 @@ func TestIsRunningAndReady(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := IsRunningAndReady(tt.args.pod); got != tt.want {
-				t.Errorf("IsRunningAndReady() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, IsRunningAndReady(tt.args.pod))
 		})
 	}
 }
@@ -119,9 +118,7 @@ func TestIsRunningAndAvailable(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := IsRunningAndAvailable(tt.args.pod, tt.args.minReadySeconds); got != tt.want {
-				t.Errorf("IsRunningAndAvailable() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, IsRunningAndAvailable(tt.args.pod, tt.args.minReadySeconds))
 		})
 	}
 }
@@ -155,9 +152,7 @@ func TestIsCreated(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := IsCreated(tt.args.pod); got != tt.want {
-				t.Errorf("IsCreated() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, IsCreated(tt.args.pod))
 		})
 	}
 }
@@ -191,9 +186,7 @@ func TestIsPending(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := IsPending(tt.args.pod); got != tt.want {
-				t.Errorf("IsPending() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, IsPending(tt.args.pod))
 		})
 	}
 }
@@ -227,9 +220,7 @@ func TestIsFailed(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := IsFailed(tt.args.pod); got != tt.want {
-				t.Errorf("IsFailed() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, IsFailed(tt.args.pod))
 		})
 	}
 }
@@ -263,9 +254,7 @@ func TestIsSucceeded(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := IsSucceeded(tt.args.pod); got != tt.want {
-				t.Errorf("IsSucceeded() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, IsSucceeded(tt.args.pod))
 		})
 	}
 }
@@ -295,13 +284,12 @@ func TestIsTerminating(t *testing.T) {
 			args: args{
 				pod: &podB,
 			},
-			want: false},
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := IsTerminating(tt.args.pod); got != tt.want {
-				t.Errorf("IsTerminating() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, IsTerminating(tt.args.pod))
 		})
 	}
 }
@@ -358,9 +346,7 @@ func TestIsHealthy(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := IsHealthy(tt.args.pod); got != tt.want {
-				t.Errorf("IsHealthy() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, IsHealthy(tt.args.pod))
 		})
 	}
 }

--- a/internal/utils/reflectutils/reflect_test.go
+++ b/internal/utils/reflectutils/reflect_test.go
@@ -6,7 +6,7 @@ package reflectutils
 import (
 	"testing"
 
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	"github.com/stretchr/testify/require"
 	"k8s.io/utils/ptr"
 )
 
@@ -34,10 +34,7 @@ func TestUseNonZeroOrDefault_String(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := UseNonZeroOrDefault(tt.in, tt.def)
-			if got != tt.want {
-				t.Errorf("UseNonZeroOrDefault() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, UseNonZeroOrDefault(tt.in, tt.def))
 		})
 	}
 }
@@ -66,10 +63,7 @@ func TestUseNonZeroOrDefault_Pointer(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := UseNonZeroOrDefault(tt.in, tt.def)
-			if !apiequality.Semantic.DeepEqual(got, tt.want) {
-				t.Errorf("UseNonZeroOrDefault() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, UseNonZeroOrDefault(tt.in, tt.def))
 		})
 	}
 }

--- a/internal/utils/refresolver/refresolver_test.go
+++ b/internal/utils/refresolver/refresolver_test.go
@@ -9,8 +9,8 @@ import (
 
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
 	"github.com/SlinkyProject/slurm-operator/internal/utils/objectutils"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -90,12 +90,16 @@ func TestRefResolver_GetController(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := New(tt.fields.reader)
 			got, err := r.GetController(tt.args.ctx, tt.args.ref, tt.args.namespace)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("RefResolver.GetController() error = %v, wantErr %v", err, tt.wantErr)
+
+			if tt.wantErr {
+				require.Error(t, err)
 				return
 			}
-			if got != nil && objectutils.KeyFunc(got) != objectutils.KeyFunc(tt.want) {
-				t.Errorf("RefResolver.GetController() = %v, want %v", objectutils.KeyFunc(got), objectutils.KeyFunc(tt.want))
+
+			require.NoError(t, err)
+
+			if got != nil {
+				require.Equal(t, objectutils.KeyFunc(tt.want), objectutils.KeyFunc(got))
 			}
 		})
 	}
@@ -165,12 +169,16 @@ func TestRefResolver_GetAccounting(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := New(tt.fields.reader)
 			got, err := r.GetAccounting(tt.args.ctx, tt.args.ref, tt.args.namespace)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("RefResolver.GetAccounting() error = %v, wantErr %v", err, tt.wantErr)
+
+			if tt.wantErr {
+				require.Error(t, err)
 				return
 			}
-			if got != nil && objectutils.KeyFunc(got) != objectutils.KeyFunc(tt.want) {
-				t.Errorf("RefResolver.GetAccounting() = %v, want %v", objectutils.KeyFunc(got), objectutils.KeyFunc(tt.want))
+
+			require.NoError(t, err)
+
+			if got != nil {
+				require.Equal(t, objectutils.KeyFunc(tt.want), objectutils.KeyFunc(got))
 			}
 		})
 	}
@@ -254,13 +262,14 @@ func TestRefResolver_GetNodeSetsForController(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := New(tt.fields.reader)
 			got, err := r.GetNodeSetsForController(tt.args.ctx, tt.args.controller)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("RefResolver.GetNodeSetsForController() error = %v, wantErr %v", err, tt.wantErr)
+
+			if tt.wantErr {
+				require.Error(t, err)
 				return
 			}
-			if len(got.Items) != tt.want {
-				t.Errorf("RefResolver.GetNodeSetsForController() = %v, want %v", len(got.Items), tt.want)
-			}
+
+			require.NoError(t, err)
+			require.Len(t, got.Items, tt.want)
 		})
 	}
 }
@@ -343,13 +352,14 @@ func TestRefResolver_GetLoginSetsForController(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := New(tt.fields.reader)
 			got, err := r.GetLoginSetsForController(tt.args.ctx, tt.args.controller)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("RefResolver.GetLoginSetsForController() error = %v, wantErr %v", err, tt.wantErr)
+
+			if tt.wantErr {
+				require.Error(t, err)
 				return
 			}
-			if len(got.Items) != tt.want {
-				t.Errorf("RefResolver.GetLoginSetsForController() = %v, want %v", len(got.Items), tt.want)
-			}
+
+			require.NoError(t, err)
+			require.Len(t, got.Items, tt.want)
 		})
 	}
 }
@@ -432,13 +442,14 @@ func TestRefResolver_GetRestapisForController(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := New(tt.fields.reader)
 			got, err := r.GetRestapisForController(tt.args.ctx, tt.args.controller)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("RefResolver.GetRestapisForController() error = %v, wantErr %v", err, tt.wantErr)
+
+			if tt.wantErr {
+				require.Error(t, err)
 				return
 			}
-			if len(got.Items) != tt.want {
-				t.Errorf("RefResolver.GetRestapisForController() = %v, want %v", len(got.Items), tt.want)
-			}
+
+			require.NoError(t, err)
+			require.Len(t, got.Items, tt.want)
 		})
 	}
 }
@@ -521,13 +532,14 @@ func TestRefResolver_GetControllersForAccounting(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := New(tt.fields.reader)
 			got, err := r.GetControllersForAccounting(tt.args.ctx, tt.args.accounting)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("RefResolver.GetControllersForAccounting() error = %v, wantErr %v", err, tt.wantErr)
+
+			if tt.wantErr {
+				require.Error(t, err)
 				return
 			}
-			if len(got.Items) != tt.want {
-				t.Errorf("RefResolver.GetControllersForAccounting() = %v, want %v", len(got.Items), tt.want)
-			}
+
+			require.NoError(t, err)
+			require.Len(t, got.Items, tt.want)
 		})
 	}
 }
@@ -600,13 +612,14 @@ func TestRefResolver_GetSecretKeyRef(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := New(tt.fields.reader)
 			got, err := r.GetSecretKeyRef(tt.args.ctx, tt.args.selector, tt.args.namespace)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("RefResolver.GetSecretKeyRef() error = %v, wantErr %v", err, tt.wantErr)
+
+			if tt.wantErr {
+				require.Error(t, err)
 				return
 			}
-			if !apiequality.Semantic.DeepEqual(got, tt.want) {
-				t.Errorf("RefResolver.GetSecretKeyRef() = %v, want %v", got, tt.want)
-			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/internal/utils/structutils/kube_test.go
+++ b/internal/utils/structutils/kube_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/SlinkyProject/slurm-operator/internal/utils/structutils"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -104,10 +104,7 @@ func test_strategicMergePatch_pod(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := structutils.StrategicMergePatch(tt.base, tt.patch)
-			if !apiequality.Semantic.DeepEqual(got, tt.want) {
-				t.Errorf("StrategicMergePatch() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, structutils.StrategicMergePatch(tt.base, tt.patch))
 		})
 	}
 }

--- a/internal/utils/structutils/list_test.go
+++ b/internal/utils/structutils/list_test.go
@@ -4,8 +4,9 @@
 package structutils
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestReferenceList(t *testing.T) {
@@ -38,9 +39,7 @@ func TestReferenceList(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := ReferenceList(tt.args.items); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("ReferenceList() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, ReferenceList(tt.args.items))
 		})
 	}
 }
@@ -84,9 +83,7 @@ func TestDereferenceList(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := DereferenceList(tt.args.items); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("DereferenceList() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, DereferenceList(tt.args.items))
 		})
 	}
 }

--- a/internal/utils/structutils/map_test.go
+++ b/internal/utils/structutils/map_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	"github.com/stretchr/testify/require"
 )
 
 func TestKeys(t *testing.T) {
@@ -52,9 +52,8 @@ func TestKeys(t *testing.T) {
 			got := Keys(tt.args.items)
 			slices.Sort(got)
 			slices.Sort(tt.want)
-			if !apiequality.Semantic.DeepEqual(got, tt.want) {
-				t.Errorf("Keys() = %v, want %v", got, tt.want)
-			}
+
+			require.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -100,9 +99,8 @@ func TestValues(t *testing.T) {
 			got := Values(tt.args.items)
 			slices.Sort(got)
 			slices.Sort(tt.want)
-			if !apiequality.Semantic.DeepEqual(got, tt.want) {
-				t.Errorf("Values() = %v, want %v", got, tt.want)
-			}
+
+			require.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -146,9 +144,7 @@ func TestMergeMaps(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := MergeMaps(tt.args.mapList...); !apiequality.Semantic.DeepEqual(got, tt.want) {
-				t.Errorf("MergeMaps() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, MergeMaps(tt.args.mapList...))
 		})
 	}
 }
@@ -221,9 +217,7 @@ func Test_validFirstDigit(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := validFirstDigit(tt.args.str); got != tt.want {
-				t.Errorf("validFirstDigit() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, validFirstDigit(tt.args.str))
 		})
 	}
 }
@@ -270,13 +264,14 @@ func TestGetNumberFromAnnotations(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := GetNumberFromAnnotations(tt.args.annotations, tt.args.key)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("GetNumberFromAnnotations() error = %v, wantErr %v", err, tt.wantErr)
+
+			if tt.wantErr {
+				require.Error(t, err)
 				return
 			}
-			if got != tt.want {
-				t.Errorf("GetNumberFromAnnotations() = %v, want %v", got, tt.want)
-			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -350,13 +345,14 @@ func TestGetBoolFromAnnotations(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := GetBoolFromAnnotations(tt.args.annotations, tt.args.key)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("GetBoolFromAnnotations() error = %v, wantErr %v", err, tt.wantErr)
+
+			if tt.wantErr {
+				require.Error(t, err)
 				return
 			}
-			if got != tt.want {
-				t.Errorf("GetBoolFromAnnotations() = %v, want %v", got, tt.want)
-			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -396,14 +392,15 @@ func TestGetTimeFromAnnotations(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := GetTimeFromAnnotations(tt.args.annotations, tt.args.key)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("GetTimeFromAnnotations() error = %v, wantErr %v", err, tt.wantErr)
+
+			if tt.wantErr {
+				require.Error(t, err)
 				return
 			}
+
+			require.NoError(t, err)
 			// Compare Unix to avoid nanosecond precision loss due to (un)marshaling
-			if tt.want.Unix() != got.Unix() {
-				t.Errorf("GetTimeFromAnnotations() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want.Unix(), got.Unix())
 		})
 	}
 }

--- a/internal/utils/testutils/helpers_test.go
+++ b/internal/utils/testutils/helpers_test.go
@@ -4,10 +4,10 @@
 package testutils
 
 import (
-	"strings"
 	"testing"
 
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
 )
@@ -45,12 +45,9 @@ func TestNewController(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := NewController(tt.args.name, tt.args.slurmKeyRef, tt.args.jwtKeyRef, tt.args.accounting)
-			switch {
-			case got == nil:
-				t.Error("returned object was nil")
-			case !strings.Contains(got.Name, tt.args.name):
-				t.Error("name does not match")
-			}
+
+			require.NotNil(t, got)
+			require.Contains(t, got.Name, tt.args.name)
 		})
 	}
 }
@@ -73,9 +70,7 @@ func TestNewSlurmKeyRef(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := NewSlurmKeyRef(tt.args.name)
-			if !strings.Contains(got.Name, tt.args.name) {
-				t.Error("name does not match")
-			}
+			require.Contains(t, got.Name, tt.args.name)
 		})
 	}
 }
@@ -98,12 +93,9 @@ func TestNewSlurmKeySecret(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := NewSlurmKeySecret(tt.args.ref)
-			switch {
-			case got == nil:
-				t.Error("returned object was nil")
-			case !strings.Contains(got.Name, tt.args.ref.Name):
-				t.Error("name does not match")
-			}
+
+			require.NotNil(t, got)
+			require.Contains(t, got.Name, tt.args.ref.Name)
 		})
 	}
 }
@@ -126,9 +118,8 @@ func TestNewJwtKeyRef(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := NewJwtKeyRef(tt.args.name)
-			if !strings.Contains(got.Name, tt.args.name) {
-				t.Error("name does not match")
-			}
+
+			require.Contains(t, got.Name, tt.args.name)
 		})
 	}
 }
@@ -151,12 +142,9 @@ func TestNewJwtKeySecret(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := NewJwtKeySecret(tt.args.ref)
-			switch {
-			case got == nil:
-				t.Error("returned object was nil")
-			case !strings.Contains(got.Name, tt.args.ref.Name):
-				t.Error("name does not match")
-			}
+
+			require.NotNil(t, got)
+			require.Contains(t, got.Name, tt.args.ref.Name)
 		})
 	}
 }
@@ -184,12 +172,9 @@ func TestNewAccounting(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := NewAccounting(tt.args.name, tt.args.slurmKeyRef, tt.args.jwtKeyRef, tt.args.passwordRef)
-			switch {
-			case got == nil:
-				t.Error("returned object was nil")
-			case !strings.Contains(got.Name, tt.args.name):
-				t.Error("name does not match")
-			}
+
+			require.NotNil(t, got)
+			require.Contains(t, got.Name, tt.args.name)
 		})
 	}
 }
@@ -212,9 +197,8 @@ func TestNewPasswordRef(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := NewPasswordRef(tt.args.name)
-			if !strings.Contains(got.Name, tt.args.name) {
-				t.Error("name does not match")
-			}
+
+			require.Contains(t, got.Name, tt.args.name)
 		})
 	}
 }
@@ -237,12 +221,9 @@ func TestNewPasswordSecret(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := NewPasswordSecret(tt.args.ref)
-			switch {
-			case got == nil:
-				t.Error("returned object was nil")
-			case !strings.Contains(got.Name, tt.args.ref.Name):
-				t.Error("name does not match")
-			}
+
+			require.NotNil(t, got)
+			require.Contains(t, got.Name, tt.args.ref.Name)
 		})
 	}
 }
@@ -269,14 +250,10 @@ func TestNewNodeset(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := NewNodeset(tt.args.name, tt.args.controller, tt.args.replicas)
-			switch {
-			case got == nil:
-				t.Error("returned object was nil")
-			case !strings.Contains(got.Name, tt.args.name):
-				t.Error("name does not match")
-			case ptr.Deref(got.Spec.Replicas, 0) != tt.args.replicas:
-				t.Errorf("replicas do not match: got = %v, want = %v", ptr.Deref(got.Spec.Replicas, 0), tt.args.replicas)
-			}
+
+			require.NotNil(t, got)
+			require.Contains(t, got.Name, tt.args.name)
+			require.Equal(t, tt.args.replicas, ptr.Deref(got.Spec.Replicas, 0))
 		})
 	}
 }
@@ -303,12 +280,9 @@ func TestNewLoginset(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := NewLoginset(tt.args.name, tt.args.controller, tt.args.sssdConfRef)
-			switch {
-			case got == nil:
-				t.Error("returned object was nil")
-			case !strings.Contains(got.Name, tt.args.name):
-				t.Error("name does not match")
-			}
+
+			require.NotNil(t, got)
+			require.Contains(t, got.Name, tt.args.name)
 		})
 	}
 }
@@ -331,9 +305,8 @@ func TestNewSssdConfRef(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := NewSssdConfRef(tt.args.name)
-			if !strings.Contains(got.Name, tt.args.name) {
-				t.Error("name does not match")
-			}
+
+			require.Contains(t, got.Name, tt.args.name)
 		})
 	}
 }
@@ -356,12 +329,9 @@ func TestNewSssdConfSecret(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := NewSssdConfSecret(tt.args.ref)
-			switch {
-			case got == nil:
-				t.Error("returned object was nil")
-			case !strings.Contains(got.Name, tt.args.ref.Name):
-				t.Error("name does not match")
-			}
+
+			require.NotNil(t, got)
+			require.Contains(t, got.Name, tt.args.ref.Name)
 		})
 	}
 }
@@ -386,12 +356,9 @@ func TestNewRestapi(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := NewRestapi(tt.args.name, tt.args.controller)
-			switch {
-			case got == nil:
-				t.Error("returned object was nil")
-			case !strings.Contains(got.Name, tt.args.name):
-				t.Error("name does not match")
-			}
+
+			require.NotNil(t, got)
+			require.Contains(t, got.Name, tt.args.name)
 		})
 	}
 }

--- a/internal/utils/testutils/testutils_test.go
+++ b/internal/utils/testutils/testutils_test.go
@@ -6,6 +6,8 @@ package testutils
 import (
 	"path"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetEnvTestBinary(t *testing.T) {
@@ -35,8 +37,11 @@ func TestGetEnvTestBinary(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := GetEnvTestBinary(tt.args.rootPath)
-			if tt.wantFound && got == "" || !tt.wantFound && got != "" {
-				t.Errorf("GetEnvTestBinary() = %v, wantFound %v", got, tt.wantFound)
+
+			if tt.wantFound {
+				require.NotEmpty(t, got)
+			} else {
+				require.Empty(t, got)
 			}
 		})
 	}
@@ -67,9 +72,8 @@ func TestGenerateResourceName(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := GenerateResourceName(tt.args.length)
-			if len(got) != tt.args.length {
-				t.Errorf("got wrong length: got = %v, want = %v", len(got), tt.args.length)
-			}
+
+			require.Len(t, got, tt.args.length)
 		})
 	}
 }

--- a/internal/utils/timestore/timestore_test.go
+++ b/internal/utils/timestore/timestore_test.go
@@ -6,6 +6,8 @@ package timestore
 import (
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestTimeStore_Push(t *testing.T) {
@@ -51,9 +53,8 @@ func TestTimeStore_Push(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ts := NewTimeStore(Greater)
 			ts.Push(tt.args.key, tt.args.newTime)
-			if got := ts.Pop(tt.args.key); got != tt.args.newTime {
-				t.Errorf("ts.Pop() = %v, want %v", got, tt.args.newTime)
-			}
+
+			require.Equal(t, tt.args.newTime, ts.Pop(tt.args.key))
 		})
 	}
 }
@@ -122,9 +123,8 @@ func TestTimeStore_Peek(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ts.Push(tt.args.key, tt.args.newTime)
-			if got := ts.Peek(tt.args.key); got != tt.want {
-				t.Errorf("ts.Peek() = %v, want %v", got, tt.want)
-			}
+
+			require.Equal(t, tt.want, ts.Peek(tt.args.key))
 		})
 	}
 }
@@ -195,9 +195,7 @@ func TestTimeStore_Pop(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.ts.Pop(tt.args.key); got != tt.want {
-				t.Errorf("TimeStore.Pop() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, tt.ts.Pop(tt.args.key))
 		})
 	}
 }
@@ -268,9 +266,8 @@ func Test_duration_Update(t *testing.T) {
 				t: tt.fielts.t,
 			}
 			d.Update(tt.args.newTime, tt.args.eval)
-			if got := d.t; got != tt.want {
-				t.Errorf("TimeStore.Pop() = %v, want %v", got, tt.want)
-			}
+
+			require.Equal(t, tt.want, d.t)
 		})
 	}
 }

--- a/internal/utils/tools_test.go
+++ b/internal/utils/tools_test.go
@@ -5,10 +5,11 @@
 package utils
 
 import (
-	"errors"
 	"fmt"
 	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestSlowStartBatch(t *testing.T) {
@@ -68,15 +69,10 @@ func TestSlowStartBatch(t *testing.T) {
 		callCnt = 0
 		callLimit = test.callLimit
 		successes, err := SlowStartBatch(test.count, 1, test.fn)
-		if successes != test.expectedSuccesses {
-			t.Errorf("%s: unexpected processed batch size, expected %d, got %d", test.name, test.expectedSuccesses, successes)
-		}
-		if !errors.Is(err, test.expectedErr) {
-			t.Errorf("%s: unexpected processed batch size, expected %v, got %v", test.name, test.expectedErr, err)
-		}
+
+		require.Equal(t, test.expectedSuccesses, successes, "%s: unexpected processed batch size", test.name)
+		require.ErrorIs(t, err, test.expectedErr, "%s: unexpected error", test.name)
 		// verify that slowStartBatch stops trying more calls after a batch fails
-		if callCnt != test.expectedCallCnt {
-			t.Errorf("%s: slowStartBatch() still tries calls after a batch fails, expected %d calls, got %d", test.name, test.expectedCallCnt, callCnt)
-		}
+		require.Equal(t, test.expectedCallCnt, callCnt, "%s: slowStartBatch() still tries calls after a batch fails", test.name)
 	}
 }

--- a/internal/webhook/pod_binding_webhook_test.go
+++ b/internal/webhook/pod_binding_webhook_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -189,19 +190,17 @@ func TestPodBindingWebhook_Default(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &PodBindingWebhook{Client: tt.client}
-			if err := r.Default(tt.args.ctx, tt.args.binding); (err != nil) != tt.wantErr {
-				t.Errorf("PodBindingWebhook.Default() error = %v, wantErr %v", err, tt.wantErr)
+			err := r.Default(tt.args.ctx, tt.args.binding)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 			if tt.checkTopology {
 				gotPod := &corev1.Pod{}
 				podKey := client.ObjectKeyFromObject(tt.args.binding)
-				if err := tt.client.Get(tt.args.ctx, podKey, gotPod); err != nil {
-					t.Fatalf("failed to get pod after Default: %v", err)
-				}
-				got := gotPod.Annotations[slinkyv1beta1.AnnotationNodeTopologySpec]
-				if got != tt.wantTopology {
-					t.Errorf("pod topology annotation = %q, want %q", got, tt.wantTopology)
-				}
+				require.NoError(t, tt.client.Get(tt.args.ctx, podKey, gotPod))
+				require.Equal(t, tt.wantTopology, gotPod.Annotations[slinkyv1beta1.AnnotationNodeTopologySpec])
 			}
 		})
 	}

--- a/pkg/conditions/conditions_test.go
+++ b/pkg/conditions/conditions_test.go
@@ -6,6 +6,7 @@ package conditions
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -86,9 +87,7 @@ func TestIsConditionTrue(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := IsConditionTrue(tt.args.status, tt.args.condType); got != tt.want {
-				t.Errorf("IsCondition() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, IsConditionTrue(tt.args.status, tt.args.condType))
 		})
 	}
 }
@@ -159,9 +158,7 @@ func TestIsNodeDrained(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := IsNodeDrained(tt.args.status); got != tt.want {
-				t.Errorf("IsNodeDrained() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, IsNodeDrained(tt.args.status))
 		})
 	}
 }
@@ -228,9 +225,7 @@ func TestIsNodeDraining(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := IsNodeDraining(tt.args.status); got != tt.want {
-				t.Errorf("IsNodeDraining() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, IsNodeDraining(tt.args.status))
 		})
 	}
 }
@@ -284,9 +279,7 @@ func TestIsSlurmNodeDrain(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := IsNodeDrain(tt.args.status); got != tt.want {
-				t.Errorf("IsSlurmNodeDrain() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, IsNodeDrain(tt.args.status))
 		})
 	}
 }
@@ -349,9 +342,7 @@ func TestAreJobsRunning(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := IsNodeBusy(tt.args.status); got != tt.want {
-				t.Errorf("AreJobsRunning() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, IsNodeBusy(tt.args.status))
 		})
 	}
 }

--- a/test/component_utils.go
+++ b/test/component_utils.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -22,22 +23,18 @@ func DoCertMgrInstall(ctx context.Context, t *testing.T, config *envconf.Config)
 	manager := helm.New(config.KubeconfigFile())
 
 	err := manager.RunRepo(helm.WithArgs("add", "jetstack", "https://charts.jetstack.io"))
-	if err != nil {
-		t.Fatal("failed to add jetstack helm chart repo")
-	}
+	require.NoError(t, err, "failed to add jetstack helm chart repo")
+
 	err = manager.RunRepo(helm.WithArgs("update"))
-	if err != nil {
-		t.Fatal("failed to upgrade helm repo")
-	}
+	require.NoError(t, err, "failed to upgrade helm repo")
+
 	err = manager.RunInstall(helm.WithName("cert-manager"), helm.WithNamespace("cert-manager"),
 		helm.WithReleaseName("jetstack/cert-manager"),
 		// pinning to a specific version to make sure we will have reproducible executions
 		helm.WithVersion("1.19.1"),
 		helm.WithArgs("--set 'crds.enabled=true'"),
 	)
-	if err != nil {
-		t.Fatal("failed to install cert-manager Helm chart", err)
-	}
+	require.NoError(t, err, "failed to install cert-manager Helm chart")
 
 	return ctx
 }
@@ -46,22 +43,18 @@ func DoMariaDBInstall(ctx context.Context, t *testing.T, config *envconf.Config)
 	manager := helm.New(config.KubeconfigFile())
 
 	err := manager.RunRepo(helm.WithArgs("add", "mariadb-operator", "https://helm.mariadb.com/mariadb-operator"))
-	if err != nil {
-		t.Fatal("failed to add mariadb-operator helm chart repo")
-	}
+	require.NoError(t, err, "failed to add mariadb-operator helm chart repo")
+
 	err = manager.RunRepo(helm.WithArgs("update"))
-	if err != nil {
-		t.Fatal("failed to upgrade helm repo")
-	}
+	require.NoError(t, err, "failed to upgrade helm repo")
+
 	err = manager.RunInstall(helm.WithName("mariadb-operator"), helm.WithNamespace("mariadb"),
 		helm.WithReleaseName("mariadb-operator/mariadb-operator"),
 		// pinning to a specific version to make sure we will have reproducible executions
 		helm.WithVersion("25.10.2"),
 		helm.WithArgs("--set 'crds.enabled=true'"),
 	)
-	if err != nil {
-		t.Fatal("failed to install mariadb-operator Helm chart", err)
-	}
+	require.NoError(t, err, "failed to install mariadb-operator Helm chart")
 
 	return ctx
 }
@@ -70,20 +63,16 @@ func DoPrometheusInstall(ctx context.Context, t *testing.T, config *envconf.Conf
 	manager := helm.New(config.KubeconfigFile())
 
 	err := manager.RunRepo(helm.WithArgs("add", "prometheus-community", "https://prometheus-community.github.io/helm-charts"))
-	if err != nil {
-		t.Fatal("failed to add prometheus-community helm chart repo")
-	}
+	require.NoError(t, err, "failed to add prometheus-community helm chart repo")
+
 	err = manager.RunRepo(helm.WithArgs("update"))
-	if err != nil {
-		t.Fatal("failed to update helm repo")
-	}
+	require.NoError(t, err, "failed to update helm repo")
+
 	err = manager.RunInstall(helm.WithName("prometheus"), helm.WithNamespace("prometheus"),
 		helm.WithReleaseName("prometheus-community/kube-prometheus-stack"),
 		helm.WithArgs("--set 'installCRDs=true'"),
 	)
-	if err != nil {
-		t.Fatal("failed to install prometheus Helm chart", err)
-	}
+	require.NoError(t, err, "failed to install prometheus Helm chart")
 
 	return ctx
 }
@@ -97,9 +86,8 @@ func DoSlurmOperatorCRDInstall(ctx context.Context, t *testing.T, config *envcon
 		helm.WithChart(Basepath+"helm/slurm-operator-crds"),
 		helm.WithWait(),
 		helm.WithTimeout("10m"))
-	if err != nil {
-		t.Fatal("failed to invoke helm install slurm-operator-crds due to an error", err)
-	}
+	require.NoError(t, err, "failed to invoke helm install slurm-operator-crds due to an error")
+
 	return ctx
 }
 
@@ -117,9 +105,8 @@ func DoSlurmOperatorInstall(ctx context.Context, t *testing.T, config *envconf.C
 		helm.WithTimeout("10m"),
 		helm.WithArgs(setOperatorImage),
 		helm.WithArgs(setWebhookImage))
-	if err != nil {
-		t.Fatal("failed to invoke helm install slurm-operator due to an error", err)
-	}
+	require.NoError(t, err, "failed to invoke helm install slurm-operator due to an error")
+
 	return ctx
 }
 
@@ -127,8 +114,6 @@ func DoSlurmInstall(ctx context.Context, t *testing.T, config *envconf.Config, s
 	manager := helm.New(config.KubeconfigFile())
 
 	setValuesFile := fmt.Sprintf("--values %s/helm/slurm/values.yaml", Basepath)
-
-	var err error
 
 	opts := []helm.Option{}
 	opts = append(
@@ -161,11 +146,8 @@ func DoSlurmInstall(ctx context.Context, t *testing.T, config *envconf.Config, s
 		opts = append(opts, helm.WithArgs("--set 'nodesets.slinky.slurmd.image.repository=ghcr.io/slinkyproject/slurmd-pyxis'"))
 	}
 
-	err = manager.RunInstall(opts...)
-
-	if err != nil {
-		t.Fatal("failed to invoke helm install operation due to an error", err)
-	}
+	err := manager.RunInstall(opts...)
+	require.NoError(t, err, "failed to invoke helm install operation due to an error")
 
 	return ctx
 }
@@ -180,9 +162,7 @@ func CheckDeploymentStatus(ctx context.Context, t *testing.T, config *envconf.Co
 	err := wait.For(conditions.New(config.Client().Resources()).ResourceScaled(deployment, func(object k8s.Object) int32 {
 		return object.(*appsv1.Deployment).Status.ReadyReplicas
 	}, 1))
-	if err != nil {
-		t.Fatalf("failed waiting for the %s deployment to reach a ready state", deploymentName)
-	}
+	require.NoError(t, err, "failed waiting for the %s deployment to reach a ready state", deploymentName)
 
 	return ctx
 }
@@ -196,10 +176,7 @@ func DoUninstallHelmChart(ctx context.Context, t *testing.T, config *envconf.Con
 		helm.WithWait(),
 		helm.WithTimeout("5m"),
 	)
-
-	if err != nil {
-		t.Fatalf("failed to invoke helm uninstall %s due to an error: %v", chartName, err)
-	}
+	require.NoError(t, err, "failed to invoke helm uninstall %s due to an error", chartName)
 
 	return ctx
 }

--- a/test/e2e/e2e_component_utils.go
+++ b/test/e2e/e2e_component_utils.go
@@ -11,6 +11,7 @@ import (
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
 	"github.com/SlinkyProject/slurm-operator/test"
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/api/v1alpha1"
+	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -33,16 +34,12 @@ func checkMariaDBHealth(crClient crclient.Client, ctx context.Context, t *testin
 	}
 
 	err := crClient.Get(ctx, mariadbKey, mariadb)
-	if err != nil {
-		t.Fatal("failed to Get() mariadb using controller-runtime client")
-	}
+	require.NoError(t, err, "failed to Get() mariadb using controller-runtime client")
 
 	// Get every StatefulSet
 	statefulSetList := appsv1.StatefulSetList{}
 	err = crClient.List(ctx, &statefulSetList)
-	if err != nil {
-		t.Fatal("failed to List() StatefulSets using controller-runtime client")
-	}
+	require.NoError(t, err, "failed to List() StatefulSets using controller-runtime client")
 
 	// Build a list of StatefulSets owned by this MariaDB CR
 	ownedStatefulSets := appsv1.StatefulSetList{}
@@ -59,9 +56,7 @@ func checkMariaDBHealth(crClient crclient.Client, ctx context.Context, t *testin
 		err = wait.For(conditions.New(config.Client().Resources()).ResourceScaled(&statefulSet, func(object k8s.Object) int32 {
 			return object.(*appsv1.StatefulSet).Status.ReadyReplicas
 		}, *statefulSet.Spec.Replicas))
-		if err != nil {
-			t.Fatalf("timed out waiting for StatefulSet %v to reach a ready state", statefulSet.Name)
-		}
+		require.NoError(t, err, "timed out waiting for StatefulSet %v to reach a ready state", statefulSet.Name)
 	}
 
 	return ctx
@@ -79,9 +74,7 @@ func checkControllerHealth(crClient crclient.Client, ctx context.Context, t *tes
 	}
 
 	err := crClient.Get(ctx, controllerKey, controller)
-	if err != nil {
-		t.Fatal("failed to Get() controller using controller-runtime client")
-	}
+	require.NoError(t, err, "failed to Get() controller using controller-runtime client")
 
 	controllerUID := controller.UID
 
@@ -89,24 +82,18 @@ func checkControllerHealth(crClient crclient.Client, ctx context.Context, t *tes
 	statefulSetKey := controller.Key()
 	statefulSet := &appsv1.StatefulSet{}
 	err = crClient.Get(ctx, statefulSetKey, statefulSet)
-	if err != nil {
-		t.Fatal("failed to Get() statefulset using controller-runtime client")
-	}
+	require.NoError(t, err, "failed to Get() statefulset using controller-runtime client")
 
 	// Confirm ownership of controller statefulset
 	for _, owner := range statefulSet.OwnerReferences {
-		if owner.UID != controllerUID {
-			t.Fatalf("dubious ownership of statefulset: %v", statefulSet)
-		}
+		require.Equal(t, controllerUID, owner.UID, "dubious ownership of statefulset: %v", statefulSet)
 	}
 
 	// Wait for controller statefulset to become ready
 	err = wait.For(conditions.New(config.Client().Resources()).ResourceScaled(statefulSet, func(object k8s.Object) int32 {
 		return object.(*appsv1.StatefulSet).Status.ReadyReplicas
 	}, *statefulSet.Spec.Replicas))
-	if err != nil {
-		t.Fatalf("timed out waiting for StatefulSet %v to reach a ready state", statefulSet.Name)
-	}
+	require.NoError(t, err, "timed out waiting for StatefulSet %v to reach a ready state", statefulSet.Name)
 }
 
 func checkRestAPIHealth(crClient crclient.Client, ctx context.Context, t *testing.T, config *envconf.Config) {
@@ -119,9 +106,7 @@ func checkRestAPIHealth(crClient crclient.Client, ctx context.Context, t *testin
 	}
 
 	err := crClient.Get(ctx, restapiKey, restapi)
-	if err != nil {
-		t.Fatal("failed to Get() restapi using controller-runtime client")
-	}
+	require.NoError(t, err, "failed to Get() restapi using controller-runtime client")
 
 	restapiUID := restapi.UID
 
@@ -129,24 +114,18 @@ func checkRestAPIHealth(crClient crclient.Client, ctx context.Context, t *testin
 	deploymentKey := restapi.Key()
 	deployment := &appsv1.Deployment{}
 	err = crClient.Get(ctx, deploymentKey, deployment)
-	if err != nil {
-		t.Fatal("failed to Get() deployment using controller-runtime client")
-	}
+	require.NoError(t, err, "failed to Get() deployment using controller-runtime client")
 
 	// Confirm ownership of RestAPI deployment
 	for _, owner := range deployment.OwnerReferences {
-		if owner.UID != restapiUID {
-			t.Fatalf("dubious ownership of deployment: %v", deployment)
-		}
+		require.Equal(t, restapiUID, owner.UID, "dubious ownership of deployment: %v", deployment)
 	}
 
 	// Check whether RestAPI deployment is healthy
 	err = wait.For(conditions.New(config.Client().Resources()).ResourceScaled(deployment, func(object k8s.Object) int32 {
 		return object.(*appsv1.Deployment).Status.ReadyReplicas
 	}, *deployment.Spec.Replicas))
-	if err != nil {
-		t.Fatalf("timed out waiting for Deployment %v to reach a ready state", deployment.Name)
-	}
+	require.NoError(t, err, "timed out waiting for Deployment %v to reach a ready state", deployment.Name)
 }
 
 func checkNodeSetReplicas(crClient crclient.Client, ctx context.Context, t *testing.T, config *envconf.Config, nodesetKey crclient.ObjectKey) {
@@ -155,9 +134,7 @@ func checkNodeSetReplicas(crClient crclient.Client, ctx context.Context, t *test
 	for retry := range 16 {
 
 		err := crClient.Get(ctx, nodesetKey, nodeset)
-		if err != nil {
-			t.Fatal("failed to Get() NodeSet using controller-runtime client")
-		}
+		require.NoError(t, err, "failed to Get() NodeSet using controller-runtime client")
 
 		if *nodeset.Spec.Replicas == nodeset.Status.AvailableReplicas {
 			break
@@ -181,9 +158,7 @@ func checkAccountingHealth(crClient crclient.Client, ctx context.Context, t *tes
 	}
 
 	err := crClient.Get(ctx, accountingKey, accounting)
-	if err != nil {
-		t.Fatal("failed to Get() accounting using accounting-runtime client")
-	}
+	require.NoError(t, err, "failed to Get() accounting using accounting-runtime client")
 
 	accountingUID := accounting.UID
 
@@ -191,23 +166,17 @@ func checkAccountingHealth(crClient crclient.Client, ctx context.Context, t *tes
 	statefulSetKey := accounting.Key()
 	statefulSet := &appsv1.StatefulSet{}
 	err = crClient.Get(ctx, statefulSetKey, statefulSet)
-	if err != nil {
-		t.Fatal("failed to Get() statefulset using controller-runtime client")
-	}
+	require.NoError(t, err, "failed to Get() statefulset using controller-runtime client")
 
 	// Confirm ownership of controller statefulset
 	for _, owner := range statefulSet.OwnerReferences {
-		if owner.UID != accountingUID {
-			t.Fatalf("dubious ownership of statefulset: %v", statefulSet)
-		}
+		require.Equal(t, accountingUID, owner.UID, "dubious ownership of statefulset: %v", statefulSet)
 	}
 
 	err = wait.For(conditions.New(config.Client().Resources()).ResourceScaled(statefulSet, func(object k8s.Object) int32 {
 		return object.(*appsv1.StatefulSet).Status.ReadyReplicas
 	}, *statefulSet.Spec.Replicas))
-	if err != nil {
-		t.Fatalf("timed out waiting for StatefulSet %v to reach a ready state", statefulSet.Name)
-	}
+	require.NoError(t, err, "timed out waiting for StatefulSet %v to reach a ready state", statefulSet.Name)
 }
 
 func checkLoginSetHealth(crClient crclient.Client, ctx context.Context, t *testing.T, config *envconf.Config) {
@@ -220,9 +189,7 @@ func checkLoginSetHealth(crClient crclient.Client, ctx context.Context, t *testi
 	}
 
 	err := crClient.Get(ctx, loginSetKey, loginSet)
-	if err != nil {
-		t.Fatal("failed to Get() loginSet using controller-runtime client")
-	}
+	require.NoError(t, err, "failed to Get() loginSet using controller-runtime client")
 
 	loginSetUID := loginSet.UID
 
@@ -230,22 +197,16 @@ func checkLoginSetHealth(crClient crclient.Client, ctx context.Context, t *testi
 	deploymentKey := loginSet.Key()
 	deployment := &appsv1.Deployment{}
 	err = crClient.Get(ctx, deploymentKey, deployment)
-	if err != nil {
-		t.Fatal("failed to Get() deployment using controller-runtime client")
-	}
+	require.NoError(t, err, "failed to Get() deployment using controller-runtime client")
 
 	// Confirm ownership of loginSet deployment
 	for _, owner := range deployment.OwnerReferences {
-		if owner.UID != loginSetUID {
-			t.Fatalf("dubious ownership of deployment: %v", deployment)
-		}
+		require.Equal(t, loginSetUID, owner.UID, "dubious ownership of deployment: %v", deployment)
 	}
 
 	// Check whether loginSet deployment is healthy
 	err = wait.For(conditions.New(config.Client().Resources()).ResourceScaled(deployment, func(object k8s.Object) int32 {
 		return object.(*appsv1.Deployment).Status.ReadyReplicas
 	}, *deployment.Spec.Replicas))
-	if err != nil {
-		t.Fatalf("timed out waiting for Deployment %v to reach a ready state", deployment.Name)
-	}
+	require.NoError(t, err, "timed out waiting for Deployment %v to reach a ready state", deployment.Name)
 }

--- a/test/e2e/e2e_installation_utils.go
+++ b/test/e2e/e2e_installation_utils.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/SlinkyProject/slurm-operator/test"
+	"github.com/stretchr/testify/require"
 
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
@@ -53,17 +54,13 @@ func applyMariaDBYaml() types.Feature {
 
 			cmd := exec.Command("kubectl", "apply", "-f", path)
 			_, err := cmd.Output()
-			if err != nil {
-				t.Fatalf("failed running 'kubectl apply -f %s /hack/resources/mariadb.yaml: %v", test.Basepath, err)
-			}
+			require.NoError(t, err, "failed running 'kubectl apply -f %s /hack/resources/mariadb.yaml'", test.Basepath)
 
 			return ctx
 		}).
 		Assess("Pod mariadb-0 running successfully", func(ctx context.Context, t *testing.T, config *envconf.Config) context.Context {
 			crClient, err := GetControllerRuntimeClient(config)
-			if err != nil {
-				t.Fatalf("Failed to get new controller-runtime client: %v", err)
-			}
+			require.NoError(t, err, "Failed to get new controller-runtime client")
 
 			checkMariaDBHealth(crClient, ctx, t, config)
 
@@ -88,9 +85,7 @@ func installSlurm(slurmConfig test.SlurmInstallationConfig) types.Feature {
 		}).
 		Assess("Slurm Cluster Is Running Successfully", func(ctx context.Context, t *testing.T, config *envconf.Config) context.Context {
 			crClient, err := GetControllerRuntimeClient(config)
-			if err != nil {
-				t.Fatalf("Failed to get new controller-runtime client: %v", err)
-			}
+			require.NoError(t, err, "Failed to get new controller-runtime client")
 
 			checkControllerHealth(crClient, ctx, t, config)
 			checkRestAPIHealth(crClient, ctx, t, config)

--- a/test/e2e/e2e_test_utils.go
+++ b/test/e2e/e2e_test_utils.go
@@ -13,6 +13,7 @@ import (
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
 	"github.com/SlinkyProject/slurm-operator/test"
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/api/v1alpha1"
+	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
@@ -151,9 +152,7 @@ func testSlurmNodeSet() types.Feature {
 		Assess("NodeSet scale-up functions", func(ctx context.Context, t *testing.T, config *envconf.Config) context.Context {
 
 			crClient, err := GetControllerRuntimeClient(config)
-			if err != nil {
-				t.Fatalf("Failed to get new controller-runtime client: %v", err)
-			}
+			require.NoError(t, err, "Failed to get new controller-runtime client")
 
 			nodesetKey := crclient.ObjectKey{
 				Namespace: test.SlurmNamespace,
@@ -161,17 +160,13 @@ func testSlurmNodeSet() types.Feature {
 			}
 			nodeset := &slinkyv1beta1.NodeSet{}
 			err = crClient.Get(ctx, nodesetKey, nodeset)
-			if err != nil {
-				t.Fatal("failed to Get() NodeSet using controller-runtime client")
-			}
+			require.NoError(t, err, "failed to Get() NodeSet using controller-runtime client")
 
 			var replicas int32 = 2
 			nodeset.Spec.Replicas = &replicas
 
 			err = crClient.Update(ctx, nodeset)
-			if err != nil {
-				t.Fatal("failed to Update() NodeSet using controller-runtime client")
-			}
+			require.NoError(t, err, "failed to Update() NodeSet using controller-runtime client")
 
 			checkNodeSetReplicas(crClient, ctx, t, config, nodesetKey)
 
@@ -217,9 +212,7 @@ func testSlurmNodeSet() types.Feature {
 		Assess("NodeSet scale-down functions", func(ctx context.Context, t *testing.T, config *envconf.Config) context.Context {
 
 			crClient, err := GetControllerRuntimeClient(config)
-			if err != nil {
-				t.Fatalf("Failed to get new controller-runtime client: %v", err)
-			}
+			require.NoError(t, err, "Failed to get new controller-runtime client")
 
 			nodesetKey := crclient.ObjectKey{
 				Namespace: test.SlurmNamespace,
@@ -227,17 +220,13 @@ func testSlurmNodeSet() types.Feature {
 			}
 			nodeset := &slinkyv1beta1.NodeSet{}
 			err = crClient.Get(ctx, nodesetKey, nodeset)
-			if err != nil {
-				t.Fatal("failed to Get() NodeSet using controller-runtime client")
-			}
+			require.NoError(t, err, "failed to Get() NodeSet using controller-runtime client")
 
 			var replicas int32 = 1
 			nodeset.Spec.Replicas = &replicas
 
 			err = crClient.Update(ctx, nodeset)
-			if err != nil {
-				t.Fatal("failed to Update() NodeSet using controller-runtime client")
-			}
+			require.NoError(t, err, "failed to Update() NodeSet using controller-runtime client")
 
 			checkNodeSetReplicas(crClient, ctx, t, config, nodesetKey)
 
@@ -270,13 +259,8 @@ func testSlurmAccounting() types.Feature {
 
 			cmd := exec.Command(command, args...)
 			output, err := cmd.Output()
-			if err != nil {
-				t.Fatal("sacctmgr show cluster returned non-zero error code")
-			}
-
-			if strings.TrimSpace(string(output)) != "slurm_slurm" {
-				t.Fatalf("Clustername in slurmdbd %s does not match expected slurm_slurm", string(output))
-			}
+			require.NoError(t, err, "sacctmgr show cluster returned non-zero error code")
+			require.Equal(t, "slurm_slurm", strings.TrimSpace(string(output)), "clustername in slurmdbd does not match expected slurm_slurm")
 
 			return ctx
 		}).
@@ -287,20 +271,13 @@ func testSlurmAccounting() types.Feature {
 
 			cmd := exec.Command(command, args...)
 			_, err := cmd.Output()
-			if err != nil {
-				t.Fatal("sacctmgr add account returned non-zero error code")
-			}
+			require.NoError(t, err, "sacctmgr add account returned non-zero error code")
 
 			args = []string{"exec", "-n", test.SlurmNamespace, "slurm-controller-0", "--", "sacctmgr", "show", "account", "name=test", "-n", "format=account"}
 			cmd = exec.Command(command, args...)
 			output, err := cmd.Output()
-			if err != nil {
-				t.Fatal("sacctmgr show account returned non-zero error code")
-			}
-
-			if strings.TrimSpace(string(output)) != "test" {
-				t.Fatal("Account test does not exist in slurmdbd")
-			}
+			require.NoError(t, err, "sacctmgr show account returned non-zero error code")
+			require.Equal(t, "test", strings.TrimSpace(string(output)), "account test does not exist in slurmdbd")
 
 			return ctx
 		}).
@@ -311,20 +288,13 @@ func testSlurmAccounting() types.Feature {
 
 			cmd := exec.Command(command, args...)
 			_, err := cmd.Output()
-			if err != nil {
-				t.Fatal("sacctmgr add user returned non-zero error code")
-			}
+			require.NoError(t, err, "sacctmgr add user returned non-zero error code")
 
 			args = []string{"exec", "-n", test.SlurmNamespace, "slurm-controller-0", "--", "sacctmgr", "show", "user", "name=testuser", "-n", "format=user"}
 			cmd = exec.Command(command, args...)
 			output, err := cmd.Output()
-			if err != nil {
-				t.Fatal("sacctmgr show user returned non-zero error code")
-			}
-
-			if strings.TrimSpace(string(output)) != "testuser" {
-				t.Fatal("User testuser does not exist in slurmdbd")
-			}
+			require.NoError(t, err, "sacctmgr show user returned non-zero error code")
+			require.Equal(t, "testuser", strings.TrimSpace(string(output)), "user testuser does not exist in slurmdbd")
 
 			return ctx
 		}).
@@ -335,20 +305,13 @@ func testSlurmAccounting() types.Feature {
 
 			cmd := exec.Command(command, args...)
 			_, err := cmd.Output()
-			if err != nil {
-				t.Fatal("sacctmgr add account returned non-zero error code")
-			}
+			require.NoError(t, err, "sacctmgr add account returned non-zero error code")
 
 			args = []string{"exec", "-n", test.SlurmNamespace, "slurm-controller-0", "--", "sacctmgr", "show", "account", "name=test", "-n", "format=account"}
 			cmd = exec.Command(command, args...)
 			output, err := cmd.Output()
-			if err != nil {
-				t.Fatal("sacctmgr show account returned non-zero error code")
-			}
-
-			if strings.TrimSpace(string(output)) == "test" {
-				t.Fatal("Account test was not deleted from slurmdbd")
-			}
+			require.NoError(t, err, "sacctmgr show account returned non-zero error code")
+			require.NotEqual(t, "test", strings.TrimSpace(string(output)), "account test was not deleted from slurmdbd")
 
 			return ctx
 		}).Feature()

--- a/test/test_utils.go
+++ b/test/test_utils.go
@@ -18,6 +18,7 @@ import (
 
 	dockerbuild "github.com/docker/docker/api/types/build"
 	dockerclient "github.com/docker/docker/client"
+	"github.com/stretchr/testify/require"
 	ptr "k8s.io/utils/ptr"
 
 	"github.com/moby/go-archive"
@@ -115,9 +116,7 @@ func RetryCommand(ctx context.Context, t *testing.T, command string, args []stri
 		}
 
 		if retry == retries-retry {
-			if err != nil {
-				t.Fatalf("failed running '%v %v': %v", command, args, err)
-			}
+			require.NoError(t, err, "failed running %v %v", command, args)
 			if string(output) != "" {
 				t.Fatalf("assertion failed. wants: %v, got: %v", wants, string(output))
 			}

--- a/test/test_utils.go
+++ b/test/test_utils.go
@@ -20,8 +20,6 @@ import (
 	dockerclient "github.com/docker/docker/client"
 	"github.com/stretchr/testify/require"
 	ptr "k8s.io/utils/ptr"
-
-	"github.com/moby/go-archive"
 )
 
 // getBasePath returns the fully qualified path of the slurm-operator repo within the context in which `go test` is called


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->

## Summary

Leveraging testify/require in order to improve dev experience and readability of the test suite.

The PR touches a portion of tests to keep it reviewable. Namely, the refactored tests are from:

- cmd
- internal/builder
- internal/clientmap
- internal/clientmap
- internal/defaults
- internal/clientmap
- internal/syncsteps
- internal/utils
- internal/webhook
- pkg
- test/e2e

The `internal/controller` package is intentially moved out of this PR (so it's coming in a followup PR).

## Checklist

- [ ] I have read
  [CONTRIBUTING.md](https://github.com/SlinkyProject/slurm-operator/blob/main/CONTRIBUTING.md)
  and the
  [Code of Conduct](https://github.com/SlinkyProject/slurm-operator/blob/main/CODE_OF_CONDUCT.md).
- [ ] New or existing tests cover these changes (where applicable).
- [ ] Documentation is updated if user-visible behavior changes.

## Breaking Changes

<!--
Does this cause any breaking changes to users?
Explain why the breakage has to happen.
-->

## Testing Notes

```bash
make test
```

<img width="900" height="715" alt="Screenshot 2026-06-10 at 15 38 08" src="https://github.com/user-attachments/assets/89a2be68-9ad5-45d7-aaca-ee5fb2c5604d" />

## Additional Context

<!--
Any other context for reviewers.
-->
