### PR TITLE
fix: correct cmd main reference

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,6 +2,6 @@ package main
 
 // This main.go is required by kubebuilder go.kubebuilder.io/v4 layout to scaffold APIs and controllers.
 // See:
-// - cmd/controller/main.go
+// - cmd/manager/main.go
 // - https://github.com/kubernetes-sigs/kubebuilder/issues/932
 func main() {}


### PR DESCRIPTION
## Summary

Updates the `cmd/main.go` placeholder comment to reference the actual manager entrypoint, `cmd/manager/main.go`, instead of the non-existent `cmd/controller/main.go`.

No related issue found in the existing issue/PR search.

## Checklist

- [x] I have read
  [CONTRIBUTING.md](https://github.com/SlinkyProject/slurm-operator/blob/main/CONTRIBUTING.md)
  and the
  [Code of Conduct](https://github.com/SlinkyProject/slurm-operator/blob/main/CODE_OF_CONDUCT.md).
- [x] New or existing tests cover these changes (where applicable).
- [x] Documentation is updated if user-visible behavior changes.

## Breaking Changes

None.

## Testing Notes

- `git diff --check`

No Go tests were run because this is a comment-only correction.

## Additional Context

The repository builds and generates RBAC around `cmd/manager/...`; `cmd/controller/main.go` is not present.
