### PR TITLE
helm: fix vendor.dcgm.enabled: false has no effect

### DIFF
--- a/helm/slurm/templates/vendor/nvidia/dcgm/_helpers.tpl
+++ b/helm/slurm/templates/vendor/nvidia/dcgm/_helpers.tpl
@@ -9,7 +9,9 @@ Check if DCGM integration is enabled
 */}}
 {{- define "vendor.dcgm.enabled" -}}
 {{- $vendor := .Values.vendor | default dict -}}
-{{- ($vendor | dig "nvidia" "dcgm" "enabled" false) | ternary "true" "" -}}
+{{- if ($vendor | dig "nvidia" "dcgm" "enabled" false) -}}
+true
+{{- end -}}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
Fixes #210

## Root Cause

The `vendor.dcgm.enabled` helper in `_helpers.tpl` used Sprig's `ternary` function via a pipeline:

```go-template
{{- ($vendor | dig "nvidia" "dcgm" "enabled" false) | ternary "true" "" -}}
```

When `vendor.nvidia.dcgm.enabled: false` is set, `dig` returns a Go `bool(false)`. Sprig's `ternary` reflects this value and can evaluate it as truthy, causing DCGM prolog/epilog ConfigMap refs to always be injected into the Controller CR.

This breaks CPU-only deployments (minikube, non-GPU nodes) because the operator tries to reconcile DCGM prolog scripts that were never created.

## Fix

Replace `ternary` with a native Go template `if` block, which correctly evaluates boolean `false` as falsy in all Helm versions:

```go-template
{{- if ($vendor | dig "nvidia" "dcgm" "enabled" false) -}}
true
{{- end -}}
```

The rendered output is unchanged: `"true"` when enabled, `""` when disabled.