### PR TITLE
Expose validating webhook namespaceSelector

### DIFF
--- a/helm/slurm-operator/README.md
+++ b/helm/slurm-operator/README.md
@@ -99,4 +99,5 @@ Kubernetes: `>= 1.29.0-0`
 | webhook.topologySpreadConstraints | list | `[]` | Topology spread constraints for pod assignment. Prefer scheduling replicas across failure domains (nodes, zones, ...) when running in HA. Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/ |
 | webhook.validating.failurePolicy | string | `"Fail"` | Action taken when the validating admission webhook is unreachable or returns an error. Ref: https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#failure-policy |
 | webhook.validating.matchPolicy | string | `"Equivalent"` | How the rules listed in the validating webhook are matched against incoming requests. Ref: https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-matchpolicy |
+| webhook.validating.namespaceSelector | object | `{}` | Full override for the validating webhooks' namespaceSelector, rendered verbatim when set. Replaces `webhook.namespaces` and the default kube-system/kube-node-lease exclusions for these webhooks. |
 

--- a/helm/slurm-operator/templates/_webhook.tpl
+++ b/helm/slurm-operator/templates/_webhook.tpl
@@ -49,3 +49,35 @@ Define operator webhook imagePullPolicy
 {{- define "slurm-operator.webhook.imagePullPolicy" -}}
 {{ .Values.webhook.imagePullPolicy | default .Values.imagePullPolicy }}
 {{- end }}
+
+{{/*
+Render a webhook namespaceSelector.
+Args (dict):
+  root          - root context
+  override      - a namespaceSelector to render verbatim (optional)
+  extraExcludes - extra namespaces to add to the NotIn exclusions (optional)
+When override is set it is rendered verbatim. Otherwise the selector is built from
+webhook.namespaces (In) and the kube-system/kube-node-lease exclusions (NotIn), plus
+any extraExcludes.
+*/}}
+{{- define "slurm-operator.webhook.namespaceSelector" -}}
+{{- $root := .root -}}
+{{- $override := .override -}}
+{{- $extraExcludes := .extraExcludes | default list -}}
+{{- if $override -}}
+{{- toYaml $override -}}
+{{- else -}}
+matchExpressions:
+{{- $namespaceList := nospace $root.Values.webhook.namespaces | splitList "," -}}
+{{- if $root.Values.webhook.namespaces }}
+  - key: kubernetes.io/metadata.name
+    operator: In
+    values:
+      {{- $namespaceList | toYaml | nindent 6 }}
+{{- end }}
+  - key: kubernetes.io/metadata.name
+    operator: NotIn
+    values:
+      {{- concat (list "kube-system" "kube-node-lease") $extraExcludes | toYaml | nindent 6 }}
+{{- end -}}
+{{- end -}}

--- a/helm/slurm-operator/templates/webhook/webhook.yaml
+++ b/helm/slurm-operator/templates/webhook/webhook.yaml
@@ -40,18 +40,7 @@ metadata:
 webhooks:
   - name: accounting-v1beta1.kb.io
     namespaceSelector:
-      matchExpressions:
-        {{- $namespaceList := nospace .Values.webhook.namespaces | splitList "," -}}
-        {{- if .Values.webhook.namespaces }}
-        - key: kubernetes.io/metadata.name
-          operator: In
-          values:
-            {{- $namespaceList | toYaml | nindent 12 }}
-        {{- end }}
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values:
-            - kube-system
+      {{- include "slurm-operator.webhook.namespaceSelector" (dict "root" $ "override" $.Values.webhook.validating.namespaceSelector) | nindent 6 }}
     rules:
       - apiGroups:
           - {{ include "slurm-operator.apiGroup" . }}
@@ -81,18 +70,7 @@ webhooks:
     sideEffects: None
   - name: controller-v1beta1.kb.io
     namespaceSelector:
-      matchExpressions:
-        {{- $namespaceList := nospace .Values.webhook.namespaces | splitList "," -}}
-        {{- if .Values.webhook.namespaces }}
-        - key: kubernetes.io/metadata.name
-          operator: In
-          values:
-            {{- $namespaceList | toYaml | nindent 12 }}
-        {{- end }}
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values:
-            - kube-system
+      {{- include "slurm-operator.webhook.namespaceSelector" (dict "root" $ "override" $.Values.webhook.validating.namespaceSelector) | nindent 6 }}
     rules:
       - apiGroups:
           - {{ include "slurm-operator.apiGroup" . }}
@@ -122,18 +100,7 @@ webhooks:
     sideEffects: None
   - name: loginset-v1beta1.kb.io
     namespaceSelector:
-      matchExpressions:
-        {{- $namespaceList := nospace .Values.webhook.namespaces | splitList "," -}}
-        {{- if .Values.webhook.namespaces }}
-        - key: kubernetes.io/metadata.name
-          operator: In
-          values:
-            {{- $namespaceList | toYaml | nindent 12 }}
-        {{- end }}
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values:
-            - kube-system
+      {{- include "slurm-operator.webhook.namespaceSelector" (dict "root" $ "override" $.Values.webhook.validating.namespaceSelector) | nindent 6 }}
     rules:
       - apiGroups:
           - {{ include "slurm-operator.apiGroup" . }}
@@ -163,18 +130,7 @@ webhooks:
     sideEffects: None
   - name: nodeset-v1beta1.kb.io
     namespaceSelector:
-      matchExpressions:
-        {{- $namespaceList := nospace .Values.webhook.namespaces | splitList "," -}}
-        {{- if .Values.webhook.namespaces }}
-        - key: kubernetes.io/metadata.name
-          operator: In
-          values:
-            {{- $namespaceList | toYaml | nindent 12 }}
-        {{- end }}
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values:
-            - kube-system
+      {{- include "slurm-operator.webhook.namespaceSelector" (dict "root" $ "override" $.Values.webhook.validating.namespaceSelector) | nindent 6 }}
     rules:
       - apiGroups:
           - {{ include "slurm-operator.apiGroup" . }}
@@ -204,18 +160,7 @@ webhooks:
     sideEffects: None
   - name: restapi-v1beta1.kb.io
     namespaceSelector:
-      matchExpressions:
-        {{- $namespaceList := nospace .Values.webhook.namespaces | splitList "," -}}
-        {{- if .Values.webhook.namespaces }}
-        - key: kubernetes.io/metadata.name
-          operator: In
-          values:
-            {{- $namespaceList | toYaml | nindent 12 }}
-        {{- end }}
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values:
-            - kube-system
+      {{- include "slurm-operator.webhook.namespaceSelector" (dict "root" $ "override" $.Values.webhook.validating.namespaceSelector) | nindent 6 }}
     rules:
       - apiGroups:
           - {{ include "slurm-operator.apiGroup" . }}
@@ -245,18 +190,7 @@ webhooks:
     sideEffects: None
   - name: token-v1beta1.kb.io
     namespaceSelector:
-      matchExpressions:
-        {{- $namespaceList := nospace .Values.webhook.namespaces | splitList "," -}}
-        {{- if .Values.webhook.namespaces }}
-        - key: kubernetes.io/metadata.name
-          operator: In
-          values:
-            {{- $namespaceList | toYaml | nindent 12 }}
-        {{- end }}
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values:
-            - kube-system
+      {{- include "slurm-operator.webhook.namespaceSelector" (dict "root" $ "override" $.Values.webhook.validating.namespaceSelector) | nindent 6 }}
     rules:
       - apiGroups:
           - {{ include "slurm-operator.apiGroup" . }}
@@ -299,19 +233,7 @@ metadata:
 webhooks:
   - name: podsbinding-v1.kb.io
     namespaceSelector:
-      matchExpressions:
-        {{- $namespaceList := nospace .Values.webhook.namespaces | splitList "," -}}
-        {{- if .Values.webhook.namespaces }}
-        - key: kubernetes.io/metadata.name
-          operator: In
-          values:
-            {{- $namespaceList | toYaml | nindent 12 }}
-        {{- end }}
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values:
-            - kube-system
-            - {{ include "slurm-operator.namespace" . }}
+      {{- include "slurm-operator.webhook.namespaceSelector" (dict "root" $ "extraExcludes" (list (include "slurm-operator.namespace" $))) | nindent 6 }}
     admissionReviewVersions:
       - v1
     clientConfig:

--- a/helm/slurm-operator/tests/__snapshot__/webhook_webhook_test.yaml.snap
+++ b/helm/slurm-operator/tests/__snapshot__/webhook_webhook_test.yaml.snap
@@ -31,6 +31,7 @@ default manifest should match snapshot:
               operator: NotIn
               values:
                 - kube-system
+                - kube-node-lease
         rules:
           - apiGroups:
               - slinky.slurm.net
@@ -60,6 +61,7 @@ default manifest should match snapshot:
               operator: NotIn
               values:
                 - kube-system
+                - kube-node-lease
         rules:
           - apiGroups:
               - slinky.slurm.net
@@ -89,6 +91,7 @@ default manifest should match snapshot:
               operator: NotIn
               values:
                 - kube-system
+                - kube-node-lease
         rules:
           - apiGroups:
               - slinky.slurm.net
@@ -118,6 +121,7 @@ default manifest should match snapshot:
               operator: NotIn
               values:
                 - kube-system
+                - kube-node-lease
         rules:
           - apiGroups:
               - slinky.slurm.net
@@ -147,6 +151,7 @@ default manifest should match snapshot:
               operator: NotIn
               values:
                 - kube-system
+                - kube-node-lease
         rules:
           - apiGroups:
               - slinky.slurm.net
@@ -176,6 +181,7 @@ default manifest should match snapshot:
               operator: NotIn
               values:
                 - kube-system
+                - kube-node-lease
         rules:
           - apiGroups:
               - slinky.slurm.net
@@ -221,6 +227,7 @@ default manifest should match snapshot:
               operator: NotIn
               values:
                 - kube-system
+                - kube-node-lease
                 - test-namespace
         rules:
           - apiGroups:

--- a/helm/slurm-operator/tests/values/webhook_namespaceselector.yaml
+++ b/helm/slurm-operator/tests/values/webhook_namespaceselector.yaml
@@ -1,0 +1,6 @@
+---
+webhook:
+  validating:
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: slurm

--- a/helm/slurm-operator/tests/webhook_webhook_test.yaml
+++ b/helm/slurm-operator/tests/webhook_webhook_test.yaml
@@ -103,6 +103,7 @@ tests:
             operator: NotIn
             values:
               - kube-system
+              - kube-node-lease
       - documentSelector:
           path: kind
           value: MutatingWebhookConfiguration
@@ -124,7 +125,70 @@ tests:
             operator: NotIn
             values:
               - kube-system
+              - kube-node-lease
               - test-namespace
+
+  - it: should render the validating namespaceSelector override verbatim and leave the binding webhook scoped
+    values:
+      - values/webhook_namespaceselector.yaml
+    asserts:
+      - documentSelector:
+          path: kind
+          value: ValidatingWebhookConfiguration
+        equal:
+          path: webhooks[*].namespaceSelector
+          value:
+            matchLabels:
+              kubernetes.io/metadata.name: slurm
+      - documentSelector:
+          path: kind
+          value: MutatingWebhookConfiguration
+        equal:
+          path: webhooks[0].namespaceSelector
+          value:
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - kube-node-lease
+                  - test-namespace
+
+  - it: should keep the binding webhook scoped via webhook.namespaces when a validating override is set
+    set:
+      webhook:
+        namespaces: slurm,compute
+        validating:
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: slurm
+    asserts:
+      - documentSelector:
+          path: kind
+          value: ValidatingWebhookConfiguration
+        equal:
+          path: webhooks[*].namespaceSelector
+          value:
+            matchLabels:
+              kubernetes.io/metadata.name: slurm
+      - documentSelector:
+          path: kind
+          value: MutatingWebhookConfiguration
+        equal:
+          path: webhooks[0].namespaceSelector
+          value:
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: In
+                values:
+                  - slurm
+                  - compute
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - kube-node-lease
+                  - test-namespace
 
   - it: should inject caBundle and render TLS secret when certManager is disabled
     set:

--- a/helm/slurm-operator/values.yaml
+++ b/helm/slurm-operator/values.yaml
@@ -163,6 +163,10 @@ webhook:
     # -- How the rules listed in the validating webhook are matched against incoming requests.
     # Ref: https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-matchpolicy
     matchPolicy: Equivalent
+    # -- Full override for the validating webhooks' namespaceSelector, rendered verbatim
+    # when set. Replaces `webhook.namespaces` and the default kube-system/kube-node-lease
+    # exclusions for these webhooks.
+    namespaceSelector: {}
   # Mutating webhook configuration.
   mutating:
     # -- Action taken when the mutating admission webhook is unreachable or returns an error.
@@ -171,6 +175,9 @@ webhook:
     # -- How the rules listed in the mutating webhook are matched against incoming requests.
     # Ref: https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-matchpolicy
     matchPolicy: Equivalent
+    # NOTE: the pods/binding webhook has no namespaceSelector override; scope it via
+    # `webhook.namespaces`, which also scopes the controller cache so the webhook can
+    # read the pods it intercepts.
   # -- Affinity for pod assignment.
   # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
   affinity: {}


### PR DESCRIPTION
## Summary

Expose namespace scoping for the operator's admission webhooks and make the default exclusions safe.

- Add `webhook.validating.namespaceSelector`: when set it is rendered verbatim on the six validating (CRD) webhooks; when unset the existing computed selector (the `webhook.namespaces` In-list plus the system-namespace NotIn exclusions) is used. Follows cert-manager's pass-through `namespaceSelector` pattern on its stateless CRD webhooks.
- Add `kube-node-lease` to the default `NotIn` exclusions for every webhook, per the [Kubernetes admission webhook good practices](https://kubernetes.io/docs/concepts/cluster-administration/admission-webhooks-good-practices/)
- The `pods/binding` mutating webhook is intentionally not given an override: its handler reads the bound Pod from a namespace-scoped cache (`--namespaces` -> controller-runtime `Cache.DefaultNamespaces`), so its scope stays single-sourced via `webhook.namespaces` (which already drives both the cache and the selector)
- Refactor the seven duplicated inline `namespaceSelector` blocks into a `slurm-operator.webhook.namespaceSelector` helper.

## Checklist

- [x] I have read CONTRIBUTING.md and the Code of Conduct.
- [x] New or existing tests cover these changes (where applicable).
- [x] Documentation is updated if user-visible behavior changes.

## Breaking Changes

None. Behavior is unchanged except that every webhook now also excludes the `kube-node-lease` namespace (an additive safety exclusion; no Slurm-managed resources live there). `webhook.validating.namespaceSelector` defaults to `{}`, so there is no change unless an operator sets it.

## Testing Notes

- `helm unittest --strict` on the `slurm-operator` chart: 104 pass (12 snapshots), including new cases asserting the validating override renders verbatim and does not leak into the `pods/binding` webhook.
- `helm lint --strict`: passes.
- Regenerated `tests/__snapshot__/webhook_webhook_test.yaml.snap` and the chart `README.md` (`make helm-docs`); the snapshot diff is only the added `kube-node-lease` lines.
- Live-verified on a kind cluster (K8s v1.35) by applying the rendered webhook configurations to a real API server and reading them back:
  - default: validating `NotIn [kube-system, kube-node-lease]`; binding `NotIn [kube-system, kube-node-lease, <operator-ns>]`
  - `webhook.validating.namespaceSelector` set: validating renders the override verbatim; binding unchanged
  - `webhook.namespaces=slurm,compute`: both add `In [slurm, compute]`

## Additional Context

`objectSelector` is deliberately not exposed