### PR TITLE
fix(nodeset): partition SplitUnhealthyPods by health, not creation time

### DIFF
--- a/internal/controller/nodeset/utils/sort.go
+++ b/internal/controller/nodeset/utils/sort.go
@@ -173,19 +173,19 @@ func (o PodsByCreationTimestamp) Less(i, j int) bool {
 
 // SplitUnhealthyPods returns lists of healthy and unhealthy pods.
 func SplitUnhealthyPods(pods []*corev1.Pod) (unhealthyPods, healthyPods []*corev1.Pod) {
-	var numUnhealthy int
+	unhealthyPods = make([]*corev1.Pod, 0, len(pods))
+	healthyPods = make([]*corev1.Pod, 0, len(pods))
+
 	for _, pod := range pods {
-		if !podutils.IsHealthy(pod) {
-			numUnhealthy++
+		if podutils.IsHealthy(pod) {
+			healthyPods = append(healthyPods, pod)
+		} else {
+			unhealthyPods = append(unhealthyPods, pod)
 		}
 	}
 
-	unhealthyPods = make([]*corev1.Pod, numUnhealthy)
-	healthyPods = make([]*corev1.Pod, len(pods)-numUnhealthy)
-
-	sort.Sort(PodsByCreationTimestamp(pods))
-	copy(unhealthyPods, pods[:numUnhealthy])
-	copy(healthyPods, pods[numUnhealthy:])
+	sort.Sort(PodsByCreationTimestamp(unhealthyPods))
+	sort.Sort(PodsByCreationTimestamp(healthyPods))
 
 	return unhealthyPods, healthyPods
 }

--- a/internal/controller/nodeset/utils/sort_test.go
+++ b/internal/controller/nodeset/utils/sort_test.go
@@ -513,6 +513,8 @@ func TestSplitUnhealthyPods(t *testing.T) {
 	type args struct {
 		pods []*corev1.Pod
 	}
+	now := metav1.Now()
+	then := metav1.Time{Time: now.AddDate(0, -1, 0)}
 	tests := []struct {
 		name              string
 		args              args
@@ -555,6 +557,57 @@ func TestSplitUnhealthyPods(t *testing.T) {
 			wantHealthyPods: []*corev1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "pod2"},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+						Conditions: []corev1.PodCondition{
+							{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+						},
+					},
+				},
+			},
+		},
+		{
+			// Regression: partition by health, not age — a newer unhealthy pod
+			// must still be classified as unhealthy.
+			name: "healthy pod older than unhealthy pod (partition by health, not age)",
+			args: args{
+				pods: []*corev1.Pod{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:              "pod-unhealthy",
+							CreationTimestamp: now,
+						},
+						Status: corev1.PodStatus{Phase: corev1.PodPending},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:              "pod-healthy",
+							CreationTimestamp: then,
+						},
+						Status: corev1.PodStatus{
+							Phase: corev1.PodRunning,
+							Conditions: []corev1.PodCondition{
+								{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+							},
+						},
+					},
+				},
+			},
+			wantUnhealthyPods: []*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "pod-unhealthy",
+						CreationTimestamp: now,
+					},
+					Status: corev1.PodStatus{Phase: corev1.PodPending},
+				},
+			},
+			wantHealthyPods: []*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "pod-healthy",
+						CreationTimestamp: then,
+					},
 					Status: corev1.PodStatus{
 						Phase: corev1.PodRunning,
 						Conditions: []corev1.PodCondition{


### PR DESCRIPTION
## Summary

`SplitUnhealthyPods` (internal/controller/nodeset/utils/sort.go) is supposed to split a NodeSet's old pods into an "unhealthy" group and a "healthy" group so that unhealthy pods do not count against `maxUnavailable` during an update.

The implementation counted how many pods were unhealthy, sorted the **entire** slice by creation timestamp, then sliced by that count:

```go
sort.Sort(PodsByCreationTimestamp(pods))
copy(unhealthyPods, pods[:numUnhealthy])
copy(healthyPods, pods[numUnhealthy:])
```

This returns the N oldest pods as "unhealthy" regardless of their actual health. Membership is correct only when the unhealthy pods happen to be the oldest.

## Checklist

- [x] I have read CONTRIBUTING.md and the Code of Conduct.
- [x] New or existing tests cover these changes (where applicable).
- [x] Documentation is updated if user-visible behavior changes

## Breaking Changes

N/A

## Testing Notes

Unit test: added a regression case to `TestSplitUnhealthyPods` with a healthy pod created before an unhealthy pod. It fails against the previous implementation (the healthy older pod is returned as unhealthy) and passes with the fix.

Live cluster (kind): deployed the operator built from this branch plus a Slurm cluster with a 2-replica NodeSet.

- Forced the exact bug condition: the newer slurmd pod made NotReady (SIGSTOP on slurmd → /readyz fails).
- Triggered a rolling update. Operator logs show the unhealthy branch selected the correct pod:

Delete unhealthy pods for Rolling Update  unhealthyPods=1
Cordon Pod, pending deletion              pod=slurm-worker-slinky-0  (newer, NotReady)
Scale-in pods for Rolling Update          delete=1
Cordon Pod, pending deletion              pod=slurm-worker-slinky-1  (older, healthy)
