### PR TITLE
fix(controllers): return non-nil list from refResolver on List error

### DIFF
--- a/internal/controller/loginset/eventhandler/eventhandler_secret.go
+++ b/internal/controller/loginset/eventhandler/eventhandler_secret.go
@@ -96,6 +96,7 @@ func (e *SecretEventHandler) enqueueRequest(
 		loginsetList, err := e.refResolver.GetLoginSetsForController(ctx, &controller)
 		if err != nil {
 			logger.Error(err, "failed to list LoginSet CRs")
+			continue
 		}
 
 		for _, loginset := range loginsetList.Items {

--- a/internal/controller/nodeset/eventhandler/eventhandler_secret.go
+++ b/internal/controller/nodeset/eventhandler/eventhandler_secret.go
@@ -94,6 +94,7 @@ func (e *SecretEventHandler) enqueueRequest(
 		nodesetList, err := e.refResolver.GetNodeSetsForController(ctx, &controller)
 		if err != nil {
 			logger.Error(err, "failed to list NodeSet CRs")
+			continue
 		}
 
 		for _, nodeset := range nodesetList.Items {

--- a/internal/controller/restapi/eventhandler/eventhandler_controller.go
+++ b/internal/controller/restapi/eventhandler/eventhandler_controller.go
@@ -156,7 +156,8 @@ func (e *secretEventHandler) enqueueRequest(
 
 		restapiList, err := e.refResolver.GetRestapisForController(ctx, &controller)
 		if err != nil {
-			logger.Error(err, "failed to list LoginSet CRs")
+			logger.Error(err, "failed to list RestApi CRs")
+			continue
 		}
 
 		for _, restapi := range restapiList.Items {

--- a/internal/controller/restapi/eventhandler/eventhandler_secret.go
+++ b/internal/controller/restapi/eventhandler/eventhandler_secret.go
@@ -93,7 +93,8 @@ func (e *SecretEventHandler) enqueueRequest(
 
 		restapiList, err := e.refResolver.GetRestapisForController(ctx, &controller)
 		if err != nil {
-			logger.Error(err, "failed to list LoginSet CRs")
+			logger.Error(err, "failed to list RestApi CRs")
+			continue
 		}
 
 		for _, restapi := range restapiList.Items {

--- a/internal/utils/refresolver/refresolver.go
+++ b/internal/utils/refresolver/refresolver.go
@@ -56,7 +56,7 @@ func (r *RefResolver) GetNodeSetsForController(ctx context.Context, controller *
 
 	list := &slinkyv1beta1.NodeSetList{}
 	if err := r.reader.List(ctx, list, client.InNamespace(controller.Namespace)); err != nil {
-		return nil, err
+		return &slinkyv1beta1.NodeSetList{}, err
 	}
 
 	out := &slinkyv1beta1.NodeSetList{}
@@ -80,7 +80,7 @@ func (r *RefResolver) GetLoginSetsForController(ctx context.Context, controller 
 
 	list := &slinkyv1beta1.LoginSetList{}
 	if err := r.reader.List(ctx, list, client.InNamespace(controller.Namespace)); err != nil {
-		return nil, err
+		return &slinkyv1beta1.LoginSetList{}, err
 	}
 
 	out := &slinkyv1beta1.LoginSetList{}
@@ -104,7 +104,7 @@ func (r *RefResolver) GetRestapisForController(ctx context.Context, controller *
 
 	list := &slinkyv1beta1.RestApiList{}
 	if err := r.reader.List(ctx, list, client.InNamespace(controller.Namespace)); err != nil {
-		return nil, err
+		return &slinkyv1beta1.RestApiList{}, err
 	}
 
 	out := &slinkyv1beta1.RestApiList{}
@@ -128,7 +128,7 @@ func (r *RefResolver) GetControllersForAccounting(ctx context.Context, accountin
 
 	list := &slinkyv1beta1.ControllerList{}
 	if err := r.reader.List(ctx, list, client.InNamespace(accounting.Namespace)); err != nil {
-		return nil, err
+		return &slinkyv1beta1.ControllerList{}, err
 	}
 
 	out := &slinkyv1beta1.ControllerList{}

--- a/internal/utils/refresolver/refresolver.go
+++ b/internal/utils/refresolver/refresolver.go
@@ -56,7 +56,7 @@ func (r *RefResolver) GetNodeSetsForController(ctx context.Context, controller *
 
 	list := &slinkyv1beta1.NodeSetList{}
 	if err := r.reader.List(ctx, list, client.InNamespace(controller.Namespace)); err != nil {
-		return &slinkyv1beta1.NodeSetList{}, err
+		return nil, err
 	}
 
 	out := &slinkyv1beta1.NodeSetList{}
@@ -80,7 +80,7 @@ func (r *RefResolver) GetLoginSetsForController(ctx context.Context, controller 
 
 	list := &slinkyv1beta1.LoginSetList{}
 	if err := r.reader.List(ctx, list, client.InNamespace(controller.Namespace)); err != nil {
-		return &slinkyv1beta1.LoginSetList{}, err
+		return nil, err
 	}
 
 	out := &slinkyv1beta1.LoginSetList{}
@@ -104,7 +104,7 @@ func (r *RefResolver) GetRestapisForController(ctx context.Context, controller *
 
 	list := &slinkyv1beta1.RestApiList{}
 	if err := r.reader.List(ctx, list, client.InNamespace(controller.Namespace)); err != nil {
-		return &slinkyv1beta1.RestApiList{}, err
+		return nil, err
 	}
 
 	out := &slinkyv1beta1.RestApiList{}
@@ -128,7 +128,7 @@ func (r *RefResolver) GetControllersForAccounting(ctx context.Context, accountin
 
 	list := &slinkyv1beta1.ControllerList{}
 	if err := r.reader.List(ctx, list, client.InNamespace(accounting.Namespace)); err != nil {
-		return &slinkyv1beta1.ControllerList{}, err
+		return nil, err
 	}
 
 	out := &slinkyv1beta1.ControllerList{}

--- a/internal/utils/refresolver/refresolver_test.go
+++ b/internal/utils/refresolver/refresolver_test.go
@@ -291,7 +291,7 @@ func TestRefResolver_GetNodeSetsForController(t *testing.T) {
 
 			if tt.wantErr {
 				require.Error(t, err)
-				require.NotNil(t, got)
+				require.Nil(t, got)
 				return
 			}
 
@@ -406,7 +406,7 @@ func TestRefResolver_GetLoginSetsForController(t *testing.T) {
 
 			if tt.wantErr {
 				require.Error(t, err)
-				require.NotNil(t, got)
+				require.Nil(t, got)
 				return
 			}
 
@@ -521,7 +521,7 @@ func TestRefResolver_GetRestapisForController(t *testing.T) {
 
 			if tt.wantErr {
 				require.Error(t, err)
-				require.NotNil(t, got)
+				require.Nil(t, got)
 				return
 			}
 
@@ -636,7 +636,7 @@ func TestRefResolver_GetControllersForAccounting(t *testing.T) {
 
 			if tt.wantErr {
 				require.Error(t, err)
-				require.NotNil(t, got)
+				require.Nil(t, got)
 				return
 			}
 

--- a/internal/utils/refresolver/refresolver_test.go
+++ b/internal/utils/refresolver/refresolver_test.go
@@ -5,6 +5,7 @@ package refresolver
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
@@ -17,6 +18,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 var scheme = runtime.NewScheme()
@@ -257,6 +259,30 @@ func TestRefResolver_GetNodeSetsForController(t *testing.T) {
 			},
 			want: 1,
 		},
+		{
+			name: "list error",
+			fields: fields{
+				reader: fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithInterceptorFuncs(interceptor.Funcs{
+						List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
+							return errors.New("list failed")
+						},
+					}).
+					Build(),
+			},
+			args: args{
+				ctx: context.TODO(),
+				controller: &slinkyv1beta1.Controller{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "slurm",
+						Namespace: metav1.NamespaceDefault,
+					},
+				},
+			},
+			want:    0,
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -265,6 +291,7 @@ func TestRefResolver_GetNodeSetsForController(t *testing.T) {
 
 			if tt.wantErr {
 				require.Error(t, err)
+				require.NotNil(t, got)
 				return
 			}
 
@@ -347,6 +374,30 @@ func TestRefResolver_GetLoginSetsForController(t *testing.T) {
 			},
 			want: 1,
 		},
+		{
+			name: "list error",
+			fields: fields{
+				reader: fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithInterceptorFuncs(interceptor.Funcs{
+						List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
+							return errors.New("list failed")
+						},
+					}).
+					Build(),
+			},
+			args: args{
+				ctx: context.TODO(),
+				controller: &slinkyv1beta1.Controller{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "slurm",
+						Namespace: metav1.NamespaceDefault,
+					},
+				},
+			},
+			want:    0,
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -355,6 +406,7 @@ func TestRefResolver_GetLoginSetsForController(t *testing.T) {
 
 			if tt.wantErr {
 				require.Error(t, err)
+				require.NotNil(t, got)
 				return
 			}
 
@@ -437,6 +489,30 @@ func TestRefResolver_GetRestapisForController(t *testing.T) {
 			},
 			want: 1,
 		},
+		{
+			name: "list error",
+			fields: fields{
+				reader: fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithInterceptorFuncs(interceptor.Funcs{
+						List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
+							return errors.New("list failed")
+						},
+					}).
+					Build(),
+			},
+			args: args{
+				ctx: context.TODO(),
+				controller: &slinkyv1beta1.Controller{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "slurm",
+						Namespace: metav1.NamespaceDefault,
+					},
+				},
+			},
+			want:    0,
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -445,6 +521,7 @@ func TestRefResolver_GetRestapisForController(t *testing.T) {
 
 			if tt.wantErr {
 				require.Error(t, err)
+				require.NotNil(t, got)
 				return
 			}
 
@@ -527,6 +604,30 @@ func TestRefResolver_GetControllersForAccounting(t *testing.T) {
 			},
 			want: 1,
 		},
+		{
+			name: "list error",
+			fields: fields{
+				reader: fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithInterceptorFuncs(interceptor.Funcs{
+						List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
+							return errors.New("list failed")
+						},
+					}).
+					Build(),
+			},
+			args: args{
+				ctx: context.TODO(),
+				accounting: &slinkyv1beta1.Accounting{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "slurm",
+						Namespace: metav1.NamespaceDefault,
+					},
+				},
+			},
+			want:    0,
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -535,6 +636,7 @@ func TestRefResolver_GetControllersForAccounting(t *testing.T) {
 
 			if tt.wantErr {
 				require.Error(t, err)
+				require.NotNil(t, got)
 				return
 			}
 


### PR DESCRIPTION
## Summary

The four `refResolver.Get*ForController` / `GetControllersForAccounting` list helpers (`internal/utils/refresolver/refresolver.go`) returned `(nil, err)` when the underlying `List` failed, even though they return a non-nil empty list for their nil-argument guard branch. Several event handlers log that error and then range over the returned list to enqueue work, so on a transient List failure (cache not yet synced at startup, or an apiserver blip) they dereferenced the nil list and panicked in the informer event path. Affected handlers: the NodeSet, RestApi, and LoginSet Secret event handlers, and the RestApi controller event handler.

This fixes the problem at the source: all four resolver methods now return a non-nil empty list alongside the error, matching their own nil-argument branch, so every caller is panic-safe.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/SlinkyProject/slurm-operator/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/SlinkyProject/slurm-operator/blob/main/CODE_OF_CONDUCT.md).
- [x] New or existing tests cover these changes (where applicable).
- [x] Documentation is updated if user-visible behavior changes

## Breaking Changes

N/A

## Testing Notes

Unit: the List-error case is folded into each of the four per-method resolver tests as a "list error" row that injects a failing `List` via `WithInterceptorFuncs`, asserting a non-nil list is returned with the error. These rows fail against the previous implementation (the returned list is nil) and pass with the fix. `go test ./internal/utils/refresolver/... ./internal/controller/{nodeset,restapi,loginset}/eventhandler/...` and `golangci-lint run` are clean.

Live (kind): built the operator from this branch, deployed it over a running Slurm cluster, and rotated the referenced auth secret. The Secret event handler correctly enqueued and reconciled the RestApi, Controller, and NodeSet, with zero panics and no operator restarts. The error path itself (a transient cache List failure) is not reliably reproducible on a live cluster, so the unit test is the deterministic proof; the live run confirms no regression on the normal enqueue path.