### PR TITLE
fix(nodeset): make ActivePods.Less cordon step antisymmetric

### DIFF
--- a/internal/controller/nodeset/utils/sort.go
+++ b/internal/controller/nodeset/utils/sort.go
@@ -71,7 +71,7 @@ func (o ActivePods) Less(i, j int) bool {
 	// Step: cordon < not cordon
 	podCordon1, _ := structutils.GetBoolFromAnnotations(pod1.Annotations, slinkyv1beta1.AnnotationPodCordon)
 	podCordon2, _ := structutils.GetBoolFromAnnotations(pod2.Annotations, slinkyv1beta1.AnnotationPodCordon)
-	if podCordon1 || podCordon2 {
+	if podCordon1 != podCordon2 {
 		return podCordon1
 	}
 

--- a/internal/controller/nodeset/utils/sort_test.go
+++ b/internal/controller/nodeset/utils/sort_test.go
@@ -183,6 +183,21 @@ func TestSortingActivePods(t *testing.T) {
 			},
 		},
 		{
+			name: "Sort cordon by ordinal",
+			pods: []corev1.Pod{
+				newRunningPod("cordon-0", map[string]string{
+					slinkyv1beta1.AnnotationPodCordon: "True",
+				}),
+				newRunningPod("cordon-1", map[string]string{
+					slinkyv1beta1.AnnotationPodCordon: "True",
+				}),
+			},
+			wantOrder: []string{
+				"cordon-1",
+				"cordon-0",
+			},
+		},
+		{
 			name: "Sort deadlines",
 			pods: []corev1.Pod{
 				newRunningPod("noDeadline", nil),


### PR DESCRIPTION
## Summary

`ActivePods.Less` (`internal/controller/nodeset/utils/sort.go`) orders a NodeSet's pods to decide which to remove first during scale-in and rolling updates. It is a tiebreaker chain: each step decides only when the two pods differ on that step and otherwise falls through to the next step (phase, readiness, deletion-cost, deadline, cordon, ordinal, age).

The cordon step did not follow that shape. It read `if podCordon1 || podCordon2 { return podCordon1 }`, which decides whenever either pod is cordoned. When both pods are cordoned that returns `true` for both `Less(i, j)` and `Less(j, i)`, which violates the strict weak ordering `sort.Interface` requires and short circuits the ordinal and age tiebreakers. The result is that equally-cordoned pods are ordered arbitrarily (dependent on input order), so which of several cordoned pods gets deleted first is non-deterministic.

The fix changes the guard to `if podCordon1 != podCordon2 { return podCordon1 }`, matching every other step in the function (and the upstream Kubernetes comparator this file is derived from). Cordoned-versus-uncordoned ordering is unchanged (cordoned pods are still preferred for deletion); two equally-cordoned pods now fall through to the ordinal tiebreaker and are ordered deterministically (higher ordinal first), the same preference used for all other pods.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/SlinkyProject/slurm-operator/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/SlinkyProject/slurm-operator/blob/main/CODE_OF_CONDUCT.md).
- [x] New or existing tests cover these changes (where applicable).
- [x] Documentation is updated if user-visible behavior changes. 

## Breaking Changes

N/A

Behavior changes only for two equally-cordoned pods: their relative order becomes deterministic (by the ordinal, then age tiebreakers) instead of arbitrary. The previous order was non-deterministic, so no correct behavior could depend on it, and the `cordoned-before-uncordoned` preference is preserved exactly.

## Testing Notes

Unit: added a "Sort cordon by ordinal" case to TestSortingActivePods with two cordoned pods of different ordinals. The existing runner shuffles the input and sorts it 20 times per case, so a non-antisymmetric comparator produces a wrong order on some permutation and fails. Verified the case fails against the previous `||` implementation (repeatedly, across runs) and passes with the fix; the full `go test ./internal/controller/nodeset/...` suite and `golangci-lint run` are clean.

Live (kind): deployed the operator built from this branch and scaled the NodeSet down by one to exercise the `ActivePods` sort path. The operator selected the higher-ordinal pod for deletion (the ordinal tiebreaker the cordon step now falls through to), converged, and logged no panics or restarts. The specific equally-cordoned ordering is non-deterministic by nature and not cleanly reproducible on a live cluster, so the unit test is the deterministic proof; the live run confirms no regression in the sort and scale-in path.