### PR TITLE
fix(token): grant secrets/finalizers RBAC to token-controller

### DIFF
--- a/config/rbac/manager/role.yaml
+++ b/config/rbac/manager/role.yaml
@@ -38,6 +38,12 @@ rules:
   - patch
   - update
 - apiGroups:
+  - ""
+  resources:
+  - secrets/finalizers
+  verbs:
+  - update
+- apiGroups:
   - apps
   resources:
   - controllerrevisions

--- a/helm/slurm-operator/files/operator_rbac_rules.yaml
+++ b/helm/slurm-operator/files/operator_rbac_rules.yaml
@@ -33,6 +33,12 @@ rules:
       - patch
       - update
   - apiGroups:
+      - ""
+    resources:
+      - secrets/finalizers
+    verbs:
+      - update
+  - apiGroups:
       - apps
     resources:
       - controllerrevisions

--- a/internal/controller/token/token_controller.go
+++ b/internal/controller/token/token_controller.go
@@ -61,6 +61,7 @@ type TokenReconciler struct {
 // +kubebuilder:rbac:groups=slinky.slurm.net,resources=tokens/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=slinky.slurm.net,resources=tokens/finalizers,verbs=update
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups="",resources=secrets/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->

## Summary

Fixes #223.

Since v1.2.0 (commit `4109850`, "do not allow Token CR to reference secrets in
other namespaces"), a `Token`'s JWT key secret must live in the same namespace
as the `Token`. As a result, `BuildTokenSecret()`
(`internal/builder/common/token_secret.go`) now always hits the branch in
`BuildSecret()` where `owner.GetNamespace() == out.GetNamespace()`, and calls
`controllerutil.SetControllerReference(jwtSecret, tokenSecret, ...)` — making
the JWT key `Secret` the controller-owner of the generated auth-token
`Secret`.

Setting an ownerReference with `blockOwnerDeletion: true` requires `update`
permission on the owner's `finalizers` subresource. The `token-controller`'s
RBAC only granted access to the `secrets` resource itself, not
`secrets/finalizers`, causing:

```
Warning   SyncFailed   token/slurm-bridge-token   Failed "Secret" step: failed to sync object (slurm/slurm-bridge-token): error creating slurm/slurm-bridge-token: secrets "slurm-bridge-token" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
```

This adds the missing `+kubebuilder:rbac` marker for `secrets/finalizers` on
the `token-controller` and regenerates manifests (`make manifests`), updating:

- `config/rbac/manager/role.yaml`
- `helm/slurm-operator/files/operator_rbac_rules.yaml`

## Checklist

- [x] I have read
  [CONTRIBUTING.md](https://github.com/SlinkyProject/slurm-operator/blob/main/CONTRIBUTING.md)
  and the
  [Code of Conduct](https://github.com/SlinkyProject/slurm-operator/blob/main/CODE_OF_CONDUCT.md).
- [x] New or existing tests cover these changes (where applicable).
- [ ] Documentation is updated if user-visible behavior changes.

## Breaking Changes

None. This only adds a permission the controller already needed after the
v1.2.0 namespace-scoping fix; it does not change any user-facing behavior or
API.

## Testing Notes

1. Deploy slurm-operator v1.2.0 (or this branch) via Helm.
2. Apply a `Token` CR whose `jwtKeyRef` secret lives in the same namespace as
   the `Token` (e.g. `slurm-bridge`'s `hack/token.yaml`).
3. Before this change: the `Token` object emits a `SyncFailed` event and the
   auth-token `Secret` is never created.
4. After this change: the auth-token `Secret` is created successfully, owned
   by the JWT key `Secret`.

Ran `make manifests` to regenerate the RBAC yaml; `go build ./...` and
existing builder unit tests (`go test ./internal/builder/...`) pass.
(The token-controller's envtest suite requires `etcd`/kubebuilder test
binaries not available in this sandbox, so it was not run here.)

## Additional Context

See #223 for the full root-cause analysis.
