### PR TITLE
fix(nodeset): sanitize Slurm drain reason from Node annotation

### DIFF
--- a/internal/controller/nodeset/nodeset_sync.go
+++ b/internal/controller/nodeset/nodeset_sync.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -457,6 +458,33 @@ func (r *NodeSetReconciler) syncClusterWorkerService(ctx context.Context, nodese
 //
 // When the Kubernetes node is cordoned, the NodeSet pods on that node should have their Slurm node drained.
 // Conversely, when the Kubernetes node is uncordoned, the NodeSet pods on that node should have their Slurm node be undrained.
+// maxSlurmReasonLength bounds the length of a Slurm node Reason string derived
+// from untrusted input (e.g. a Kubernetes Node annotation).
+const maxSlurmReasonLength = 256
+
+// sanitizeSlurmReason makes an untrusted string safe to use as a Slurm node
+// Reason. It strips control characters (including newlines/tabs, which could be
+// used for log or reason spoofing), collapses surrounding whitespace, and
+// truncates the result to a bounded length.
+func sanitizeSlurmReason(reason string) string {
+	sanitized := strings.Map(func(r rune) rune {
+		if r == '\t' || r == '\n' || r == '\r' {
+			return ' '
+		}
+		if unicode.IsControl(r) {
+			return -1
+		}
+		return r
+	}, reason)
+	sanitized = strings.TrimSpace(sanitized)
+
+	if runes := []rune(sanitized); len(runes) > maxSlurmReasonLength {
+		sanitized = strings.TrimSpace(string(runes[:maxSlurmReasonLength]))
+	}
+
+	return sanitized
+}
+
 // Otherwise the pods' pod-cordon label intent is propagated -- have the Slurm node drained or undrained.
 func (r *NodeSetReconciler) syncCordon(
 	ctx context.Context,
@@ -511,9 +539,13 @@ func (r *NodeSetReconciler) syncCordon(
 			}
 
 			if value, ok := node.Annotations[slinkyv1beta1.AnnotationNodeCordonReason]; ok {
+				// The annotation is user-controlled; anyone able to annotate the
+				// Node could otherwise inject arbitrary/control characters into the
+				// Slurm node Reason. Sanitize and truncate before use.
+				sanitized := sanitizeSlurmReason(value)
 				logger.V(1).Info("Slurm node drain reason overridden by Kubernetes node annotation",
-					"reason", value)
-				reason = value
+					"reason", sanitized)
+				reason = sanitized
 			} else {
 				var reasons []string
 				for _, condType := range r.propagatedNodeConditions {

--- a/internal/controller/nodeset/nodeset_sync_test.go
+++ b/internal/controller/nodeset/nodeset_sync_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/google/go-cmp/cmp"
 	appsv1 "k8s.io/api/apps/v1"
@@ -4643,6 +4644,82 @@ func TestNodeSetReconciler_syncSlurmNodeRecords(t *testing.T) {
 				if err := sclient.Get(context.Background(), slurmclient.ObjectKey(name), &slurmtypes.V0044Node{}); err == nil {
 					t.Fatalf("expected Slurm node %q to be pruned, it still exists", name)
 				}
+			}
+		})
+	}
+}
+
+func Test_sanitizeSlurmReason(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "empty string",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "plain reason unchanged",
+			input: "Node was cordoned by admin",
+			want:  "Node was cordoned by admin",
+		},
+		{
+			name:  "leading and trailing whitespace trimmed",
+			input: "  needs maintenance  ",
+			want:  "needs maintenance",
+		},
+		{
+			name:  "newlines replaced with spaces to prevent log spoofing",
+			input: "line1\nline2",
+			want:  "line1 line2",
+		},
+		{
+			name:  "carriage return and tab replaced with spaces",
+			input: "a\r\tb",
+			want:  "a  b",
+		},
+		{
+			name:  "carriage return newline injection is neutralized",
+			input: "drained\r\nFATAL fake log entry",
+			want:  "drained  FATAL fake log entry",
+		},
+		{
+			name:  "control characters stripped",
+			input: "bad\x00\x07reason",
+			want:  "badreason",
+		},
+		{
+			name:  "ansi escape sequence stripped",
+			input: "reason\x1b[31mred\x1b[0m",
+			want:  "reason[31mred[0m",
+		},
+		{
+			name:  "multibyte characters preserved",
+			input: "café draining",
+			want:  "café draining",
+		},
+		{
+			name:  "truncated to max length",
+			input: strings.Repeat("a", maxSlurmReasonLength+50),
+			want:  strings.Repeat("a", maxSlurmReasonLength),
+		},
+		{
+			name:  "truncation does not split multibyte runes",
+			input: strings.Repeat("é", maxSlurmReasonLength+10),
+			want:  strings.Repeat("é", maxSlurmReasonLength),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeSlurmReason(tt.input)
+			if got != tt.want {
+				t.Errorf("sanitizeSlurmReason() = %q, want %q", got, tt.want)
+			}
+			if utf8.RuneCountInString(got) > maxSlurmReasonLength {
+				t.Errorf("sanitizeSlurmReason() returned %d runes, exceeds max %d",
+					utf8.RuneCountInString(got), maxSlurmReasonLength)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

The `AnnotationNodeCordonReason` value on a Kubernetes Node is user-controlled and was used verbatim as the Slurm node `Reason` in `internal/controller/nodeset/nodeset_sync.go`. Anyone able to annotate a Node could inject arbitrary or control characters (e.g. newlines) into the Slurm node Reason, enabling log/reason spoofing.

This sanitizes the annotation before use via a new `sanitizeSlurmReason` helper, which strips control characters, replaces newlines/tabs with spaces, trims whitespace, and truncates to a bounded, rune-safe length.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/SlinkyProject/slurm-operator/blob/main/CONTRIBUTING.md)  and the  [Code of Conduct](https://github.com/SlinkyProject/slurm-operator/blob/main/CODE_OF_CONDUCT.md).
- [x] New or existing tests cover these changes (where applicable).
- [ ] Documentation is updated if user-visible behavior changes.

## Breaking Changes

None. The sanitization only affects malformed/malicious reason strings; well-formed reasons are unchanged.

## Testing Notes

`go test ./internal/controller/nodeset/ -run Test_sanitizeSlurmReason`

Adds table-driven tests covering the sanitization behavior (control characters, newlines/tabs, trimming, and length truncation).

## Additional Context

Hardening fix against log/reason spoofing via user-controlled Node annotations.