### PR TITLE
fix(nodeset): aggregate syncNodeSetPodStatus errors in syncStatus

### DIFF
--- a/internal/controller/nodeset/nodeset_sync_status.go
+++ b/internal/controller/nodeset/nodeset_sync_status.go
@@ -62,7 +62,7 @@ func (r *NodeSetReconciler) syncStatus(
 	}
 
 	if err := r.syncNodeSetPodStatus(ctx, nodeset, pods); err != nil {
-		return err
+		errors = append(errors, err)
 	}
 
 	return utilerrors.NewAggregate(errors)


### PR DESCRIPTION
## Summary

In `syncStatus` (`internal/controller/nodeset/nodeset_sync_status.go`), the first three steps (`RefreshNodeCache`, `syncSlurmStatus`, and `syncNodeSetStatus`) append failures to a shared `errors` slice and return `utilerrors.NewAggregate(errors)` at the end. The final step, `syncNodeSetPodStatus`, returned its error directly instead, so when that step also failed, errors from the earlier steps were silently discarded.

This appends the final step's error to the same slice and falls through to `utilerrors.NewAggregate(errors)`, matching the sibling steps.

## Checklist

- [x] I have read  [CONTRIBUTING.md](https://github.com/SlinkyProject/slurm-operator/blob/main/CONTRIBUTING.md)  and the  [Code of Conduct](https://github.com/SlinkyProject/slurm-operator/blob/main/CODE_OF_CONDUCT.md).
- [ ] New or existing tests cover these changes (where applicable).
- [ ] Documentation is updated if user-visible behavior changes.

## Breaking Changes

None. This only preserves errors that were already being collected but dropped when the final sync step failed.

## Testing Notes

`go test ./internal/controller/nodeset/...`

## Additional Context

One-line fix; no user-visible behavior change beyond more complete error reporting on reconcile failure.