### PR TITLE
docs(github): tidy issue/PR templates and fix typos

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,29 +8,28 @@ assignees: ''
 
 <!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
 
-**Describe the bug** A clear and concise description of what the bug is.
+**Describe the bug**
 
-**Steps/Code to reproduce bug** Follow
-[this guide](http://matthewrocklin.com/blog/work/2018/02/28/minimal-bug-reports)
-to craft a minimal bug report. This helps us reproduce the issue you're having
-and resolve the issue more quickly.
+A clear and concise description of what the bug is.
 
-**Expected behavior** A clear and concise description of what you expected to
-happen.
+**Steps/Code to reproduce bug**
+
+Follow [this guide](http://matthewrocklin.com/blog/work/2018/02/28/minimal-bug-reports) to craft a minimal bug report. This helps us reproduce the issue you're having and resolve the issue more quickly.
+
+**Expected behavior**
+
+A clear and concise description of what you expected to happen.
 
 **Environment details (please complete the following information):**
 
-- Environment location: [Bare-metal, Docker, Cloud(specify cloud provider)]
-- Install / deployment method: \[Docker, Helm or Kubernetes manifests, from
-  source, or other\]
-  - If using containers, provide relevant `docker pull` / `docker run` or Helm
-    values as applicable
+- Environment location: [Bare-metal, Docker, Cloud (specify cloud provider)]
+- Install / deployment method: [Docker, Helm or Kubernetes manifests, from source, or other]
+  - If using containers, provide relevant `docker pull` / `docker run` or Helm values as applicable
 
-**Additional context** Add any other context about the problem here.
+**Additional context**
+
+Add any other context about the problem here.
 
 ______________________________________________________________________
 
-By submitting this issue, you agree to follow our
-[code of conduct](https://github.com/SlinkyProject/slurm-operator/blob/main/CODE_OF_CONDUCT.md)
-and our
-[contributing guidelines](https://github.com/SlinkyProject/slurm-operator/blob/main/CONTRIBUTING.md).
+By submitting this issue, you agree to follow our [code of conduct](https://github.com/SlinkyProject/slurm-operator/blob/main/CODE_OF_CONDUCT.md) and our [contributing guidelines](https://github.com/SlinkyProject/slurm-operator/blob/main/CONTRIBUTING.md).

--- a/.github/ISSUE_TEMPLATE/documentation-request.md
+++ b/.github/ISSUE_TEMPLATE/documentation-request.md
@@ -12,34 +12,38 @@ assignees: ''
 
 ## Report incorrect documentation
 
-**Location of incorrect documentation** Provide links and line numbers if
-applicable.
+**Location of incorrect documentation**
 
-**Describe the problems or issues found in the documentation** A clear and
-concise description of what you found to be incorrect.
+Provide links and line numbers if applicable.
 
-**Steps taken to verify documentation is incorrect** List any steps you have
-taken:
+**Describe the problems or issues found in the documentation**
 
-**Suggested fix for documentation** Detail proposed changes to fix the
-documentation if you have any.
+A clear and concise description of what you found to be incorrect.
+
+**Steps taken to verify documentation is incorrect**
+
+List any steps you have taken:
+
+**Suggested fix for documentation**
+
+Detail proposed changes to fix the documentation if you have any.
 
 ______________________________________________________________________
 
 ## Report needed documentation
 
-**Report needed documentation** A clear and concise description of what
-documentation you believe it is needed and why.
+**Report needed documentation**
 
-**Describe the documentation you'd like** A clear and concise description of
-what you want to happen.
+A clear and concise description of what documentation you believe it is needed and why.
 
-**Steps taken to search for needed documentation** List any steps you have
-taken:
+**Describe the documentation you'd like**
+
+A clear and concise description of what you want to happen.
+
+**Steps taken to search for needed documentation**
+
+List any steps you have taken:
 
 ______________________________________________________________________
 
-By submitting this issue, you agree to follow our
-[code of conduct](https://github.com/SlinkyProject/slurm-operator/blob/main/CODE_OF_CONDUCT.md)
-and our
-[contributing guidelines](https://github.com/SlinkyProject/slurm-operator/blob/main/CONTRIBUTING.md).
+By submitting this issue, you agree to follow our [code of conduct](https://github.com/SlinkyProject/slurm-operator/blob/main/CODE_OF_CONDUCT.md) and our [contributing guidelines](https://github.com/SlinkyProject/slurm-operator/blob/main/CONTRIBUTING.md).

--- a/.github/ISSUE_TEMPLATE/documentation_request_correction.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_request_correction.yml
@@ -67,5 +67,5 @@ body:
         - label: I agree to follow Slurm Operator's Code of Conduct
           required: true
         - label: I have searched the [open documentation issues](https://github.com/SlinkyProject/slurm-operator/issues?q=is%3Aopen+is%3Aissue+label%3Adoc)
-            and have found no duplicates for this bug report
+            and have found no duplicates for this documentation request
           required: true

--- a/.github/ISSUE_TEMPLATE/documentation_request_new.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_request_new.yml
@@ -59,5 +59,5 @@ body:
       options:
         - label: I agree to follow Slurm Operator's Code of Conduct
           required: true
-        - label: I have searched the project's documentation and have found no duplicates for this bug report
+        - label: I have searched the project's documentation and have found no duplicates for this documentation request
           required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,22 +8,22 @@ assignees: ''
 
 <!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
 
-**Is your feature request related to a problem? Please describe.** A clear and
-concise description of what the problem is. Ex. I wish I could use Slurm
-Operator to do [...]
+**Is your feature request related to a problem? Please describe.**
 
-**Describe the solution you'd like** A clear and concise description of what you
-want to happen.
+A clear and concise description of what the problem is. Ex. I wish I could use Slurm Operator to do [...]
 
-**Describe alternatives you've considered** A clear and concise description of
-any alternative solutions or features you've considered.
+**Describe the solution you'd like**
 
-**Additional context** Add any other context, code examples, or references to
-existing implementations about the feature request here.
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+
+Add any other context, code examples, or references to existing implementations about the feature request here.
 
 ______________________________________________________________________
 
-By submitting this issue, you agree to follow our
-[code of conduct](https://github.com/SlinkyProject/slurm-operator/blob/main/CODE_OF_CONDUCT.md)
-and our
-[contributing guidelines](https://github.com/SlinkyProject/slurm-operator/blob/main/CONTRIBUTING.md).
+By submitting this issue, you agree to follow our [code of conduct](https://github.com/SlinkyProject/slurm-operator/blob/main/CODE_OF_CONDUCT.md) and our [contributing guidelines](https://github.com/SlinkyProject/slurm-operator/blob/main/CONTRIBUTING.md).

--- a/.github/ISSUE_TEMPLATE/feature_request_form.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request_form.yml
@@ -62,12 +62,12 @@ body:
       description: Please provide clear description of the feature you request (refer to [User Story format](https://www.atlassian.com/agile/project-management/user-stories#:~:text=User%20story%20template%20and%20examples)
         and [EARS format](https://ieeexplore.ieee.org/document/5328509))
       placeholder: >
-        For new feature request, please use one of the following format to describe the feature
+        For new feature request, please use one of the following formats to describe the feature
           1. From End-user perspective, use the following user story format
               As a <persona>, I <want to>, <so that>.
           2. From System perspective, use the following EARS format
-              <Pre-Condition> <System> shall  <process> <object to be process> <condition>
-        For changing or improving existing feature, it's recommended to provide the previoius Feature Request ID.
+              <Pre-Condition> <System> shall <process> <object to be processed> <condition>
+        For changing or improving existing feature, it's recommended to provide the previous Feature Request ID.
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/submit-question.md
+++ b/.github/ISSUE_TEMPLATE/submit-question.md
@@ -12,7 +12,4 @@ assignees: ''
 
 ______________________________________________________________________
 
-By submitting this issue, you agree to follow our
-[code of conduct](https://github.com/SlinkyProject/slurm-operator/blob/main/CODE_OF_CONDUCT.md)
-and our
-[contributing guidelines](https://github.com/SlinkyProject/slurm-operator/blob/main/CONTRIBUTING.md).
+By submitting this issue, you agree to follow our [code of conduct](https://github.com/SlinkyProject/slurm-operator/blob/main/CODE_OF_CONDUCT.md) and our [contributing guidelines](https://github.com/SlinkyProject/slurm-operator/blob/main/CONTRIBUTING.md).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,10 +15,7 @@ Link relevant issues which this addresses (e.g. closes #123).
 
 ## Checklist
 
-- [ ] I have read
-  [CONTRIBUTING.md](https://github.com/SlinkyProject/slurm-operator/blob/main/CONTRIBUTING.md)
-  and the
-  [Code of Conduct](https://github.com/SlinkyProject/slurm-operator/blob/main/CODE_OF_CONDUCT.md).
+- [ ] I have read the [CONTRIBUTING.md](https://github.com/SlinkyProject/slurm-operator/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/SlinkyProject/slurm-operator/blob/main/CODE_OF_CONDUCT.md).
 - [ ] New or existing tests cover these changes (where applicable).
 - [ ] Documentation is updated if user-visible behavior changes.
 


### PR DESCRIPTION
## Summary

Cleans up the issue and pull request templates under `.github/` for readability and fixes a few typos.

- Formatting: bold field headings now sit on their own line with the description below, and mid-sentence / mid-link line wraps were unwrapped so links and sentences render on a single line (`pull_request_template.md`, `bug_report.md`, `feature_request.md`, `submit-question.md`, `documentation-request.md`).
- Typos in `feature_request_form.yml`: `previoius` -> `previous`, `one of the following format` -> `formats`, `object to be process` -> `object to be processed`, and removed a double space in `shall  <process>`.
- Copy-paste fix in `documentation_request_new.yml` and `documentation_request_correction.yml`: the Code of Conduct checkbox referred to "this bug report" and now reads "this documentation request".

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/SlinkyProject/slurm-operator/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/SlinkyProject/slurm-operator/blob/main/CODE_OF_CONDUCT.md).
- [ ] New or existing tests cover these changes (where applicable).
- [ ] Documentation is updated if user-visible behavior changes.

## Breaking Changes

None. Documentation/template-only changes with no effect on operator behavior.

## Testing Notes

No functional changes; verified the templates render as expected on GitHub.

## Additional Context

Follow-up cleanup of the GitHub issue/PR templates.