### PR TITLE
fix(nodeset): count unavailable pods against rolling update maxUnavailable

### DIFF
--- a/internal/controller/nodeset/nodeset_sync.go
+++ b/internal/controller/nodeset/nodeset_sync.go
@@ -1527,7 +1527,7 @@ func (r *NodeSetReconciler) syncRollingUpdate(
 
 	_, oldPods := findUpdatedPods(pods, hash)
 
-	unhealthyPods, healthyPods := nodesetutils.SplitUnhealthyPods(oldPods)
+	unhealthyPods, _ := nodesetutils.SplitUnhealthyPods(oldPods)
 	if len(unhealthyPods) > 0 {
 		logger.Info("Delete unhealthy pods for Rolling Update",
 			"unhealthyPods", len(unhealthyPods))
@@ -1538,7 +1538,7 @@ func (r *NodeSetReconciler) syncRollingUpdate(
 		}
 	}
 
-	podsToDelete, _ := r.splitUpdatePods(ctx, nodeset, healthyPods, hash)
+	podsToDelete, _ := r.splitUpdatePods(ctx, nodeset, pods, hash)
 	if len(podsToDelete) > 0 {
 		logger.Info("Scale-in pods for Rolling Update",
 			"delete", len(podsToDelete))
@@ -1553,6 +1553,9 @@ func (r *NodeSetReconciler) syncRollingUpdate(
 }
 
 // splitUpdatePods returns two pod lists based on UpdateStrategy type.
+// For RollingUpdate, unavailable new pods and replica slots with no live pod
+// count against maxUnavailable, while unhealthy old pods neither consume the
+// budget nor become deletion candidates (callers condemn them separately).
 func (r *NodeSetReconciler) splitUpdatePods(
 	ctx context.Context,
 	nodeset *slinkyv1beta1.NodeSet,
@@ -1566,8 +1569,21 @@ func (r *NodeSetReconciler) splitUpdatePods(
 		fallthrough
 	case slinkyv1beta1.RollingUpdateNodeSetStrategyType:
 		newPods, oldPods := findUpdatedPods(pods, hash)
+		_, healthyOldPods := nodesetutils.SplitUnhealthyPods(oldPods)
 
+		total := int(ptr.Deref(nodeset.Spec.Replicas, defaults.DefaultNodeSetReplicas))
+		if nodeset.Spec.ScalingMode == slinkyv1beta1.ScalingModeDaemonset {
+			total = len(pods)
+		}
+
+		// Replica slots with no live pod at either revision (e.g. a
+		// terminating pod awaiting its replacement) are unavailable capacity.
+		// In daemonset mode the node set is not bounded by Replicas, so
+		// remnants on removed nodes must not consume the budget.
 		var numUnavailable int
+		if nodeset.Spec.ScalingMode != slinkyv1beta1.ScalingModeDaemonset {
+			numUnavailable = mathutils.Clamp(total-len(newPods)-len(oldPods), 0, total)
+		}
 		now := metav1.Now()
 		for _, pod := range newPods {
 			if !podutil.IsPodAvailable(pod, nodeset.Spec.MinReadySeconds, now) {
@@ -1575,13 +1591,9 @@ func (r *NodeSetReconciler) splitUpdatePods(
 			}
 		}
 
-		total := int(ptr.Deref(nodeset.Spec.Replicas, defaults.DefaultNodeSetReplicas))
-		if nodeset.Spec.ScalingMode == slinkyv1beta1.ScalingModeDaemonset {
-			total = len(pods)
-		}
 		maxUnavailable := mathutils.GetScaledValueFromIntOrPercent(nodeset.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable, total, true, 1)
 		remainingUnavailable := mathutils.Clamp((maxUnavailable - numUnavailable), 0, maxUnavailable)
-		podsToDelete, remainingOldPods := nodesetutils.SplitActivePods(oldPods, remainingUnavailable)
+		podsToDelete, remainingOldPods := nodesetutils.SplitActivePods(healthyOldPods, remainingUnavailable)
 
 		remainingPods := make([]*corev1.Pod, len(newPods))
 		copy(remainingPods, newPods)

--- a/internal/controller/nodeset/nodeset_sync_test.go
+++ b/internal/controller/nodeset/nodeset_sync_test.go
@@ -196,6 +196,11 @@ func makePodHealthy(pod *corev1.Pod) *corev1.Pod {
 	return pod
 }
 
+func makePodRunningNotReady(pod *corev1.Pod) *corev1.Pod {
+	pod.Status.Phase = corev1.PodRunning
+	return pod
+}
+
 func extractSlurmdPreStopReason(pod *corev1.Pod) string {
 	for _, c := range pod.Spec.Containers {
 		if c.Name != labels.WorkerApp {
@@ -2834,10 +2839,13 @@ func TestNodeSetReconciler_syncRollingUpdate(t *testing.T) {
 		hash    string
 	}
 	type testCaseFields struct {
-		name    string
-		fields  fields
-		args    args
-		wantErr bool
+		name            string
+		fields          fields
+		args            args
+		wantErr         bool
+		wantCordoned    []*corev1.Pod
+		wantNotCordoned []*corev1.Pod
+		wantDeleted     []*corev1.Pod
 	}
 	tests := []testCaseFields{
 		func() testCaseFields {
@@ -2880,7 +2888,8 @@ func TestNodeSetReconciler_syncRollingUpdate(t *testing.T) {
 					pods:    []*corev1.Pod{pod1, pod2},
 					hash:    hash,
 				},
-				wantErr: false,
+				wantErr:      false,
+				wantCordoned: []*corev1.Pod{pod2},
 			}
 		}(),
 		func() testCaseFields {
@@ -2962,12 +2971,151 @@ func TestNodeSetReconciler_syncRollingUpdate(t *testing.T) {
 				wantErr: false,
 			}
 		}(),
+		func() testCaseFields {
+			nodeset := newNodeSet("foo", controller.Name, 2)
+			nodeset.Spec.UpdateStrategy.Type = slinkyv1beta1.RollingUpdateNodeSetStrategyType
+			nodeset.Spec.UpdateStrategy.RollingUpdate = slinkyv1beta1.RollingUpdateNodeSetStrategy{
+				MaxUnavailable: ptr.To(intstr.FromInt32(1)),
+			}
+			pod1 := nodesetutils.NewNodeSetStatefulSetPod(fake.NewFakeClient(), nodeset, controller, 0, hash)
+			makePodRunningNotReady(pod1)
+			pod2 := nodesetutils.NewNodeSetStatefulSetPod(fake.NewFakeClient(), nodeset, controller, 1, "")
+			makePodHealthy(pod2)
+			k8sclient := fake.NewFakeClient(nodeset, pod1, pod2)
+			slurmNodeList := &slurmtypes.V0044NodeList{
+				Items: []slurmtypes.V0044Node{
+					*newNodeSetPodSlurmNode(pod1),
+					*newNodeSetPodSlurmNode(pod2),
+				},
+			}
+			slurmClient := newFakeClientList(sinterceptor.Funcs{}, slurmNodeList)
+			return testCaseFields{
+				name: "throttled by unavailable new pod",
+				fields: fields{
+					Client:    k8sclient,
+					ClientMap: newClientMap(controller.Name, slurmClient),
+				},
+				args: args{
+					ctx:     context.TODO(),
+					nodeset: nodeset,
+					pods:    []*corev1.Pod{pod1, pod2},
+					hash:    hash,
+				},
+				wantErr:         false,
+				wantNotCordoned: []*corev1.Pod{pod2},
+			}
+		}(),
+		func() testCaseFields {
+			nodeset := newNodeSet("foo", controller.Name, 3)
+			nodeset.Spec.UpdateStrategy.Type = slinkyv1beta1.RollingUpdateNodeSetStrategyType
+			nodeset.Spec.UpdateStrategy.RollingUpdate = slinkyv1beta1.RollingUpdateNodeSetStrategy{
+				MaxUnavailable: ptr.To(intstr.FromInt32(1)),
+			}
+			pod1 := nodesetutils.NewNodeSetStatefulSetPod(fake.NewFakeClient(), nodeset, controller, 0, hash)
+			makePodRunningNotReady(pod1)
+			pod2 := nodesetutils.NewNodeSetStatefulSetPod(fake.NewFakeClient(), nodeset, controller, 1, "")
+			makePodCreated(pod2)
+			pod3 := nodesetutils.NewNodeSetStatefulSetPod(fake.NewFakeClient(), nodeset, controller, 2, "")
+			makePodHealthy(pod3)
+			k8sclient := fake.NewFakeClient(nodeset, pod1, pod2, pod3)
+			// pod2 is deliberately absent: an unhealthy pod that never
+			// registered with Slurm.
+			slurmNodeList := &slurmtypes.V0044NodeList{
+				Items: []slurmtypes.V0044Node{
+					*newNodeSetPodSlurmNode(pod1),
+					*newNodeSetPodSlurmNode(pod3),
+				},
+			}
+			slurmClient := newFakeClientList(sinterceptor.Funcs{}, slurmNodeList)
+			return testCaseFields{
+				name: "unhealthy old pod deleted while budget exhausted",
+				fields: fields{
+					Client:    k8sclient,
+					ClientMap: newClientMap(controller.Name, slurmClient),
+				},
+				args: args{
+					ctx:     context.TODO(),
+					nodeset: nodeset,
+					pods:    []*corev1.Pod{pod1, pod2, pod3},
+					hash:    hash,
+				},
+				wantErr:         false,
+				wantNotCordoned: []*corev1.Pod{pod3},
+				wantDeleted:     []*corev1.Pod{pod2},
+			}
+		}(),
+		func() testCaseFields {
+			nodeset := newNodeSet("foo", controller.Name, 3)
+			nodeset.Spec.UpdateStrategy.Type = slinkyv1beta1.RollingUpdateNodeSetStrategyType
+			nodeset.Spec.UpdateStrategy.RollingUpdate = slinkyv1beta1.RollingUpdateNodeSetStrategy{
+				MaxUnavailable: ptr.To(intstr.FromInt32(2)),
+			}
+			pod1 := nodesetutils.NewNodeSetStatefulSetPod(fake.NewFakeClient(), nodeset, controller, 0, hash)
+			makePodRunningNotReady(pod1)
+			pod2 := nodesetutils.NewNodeSetStatefulSetPod(fake.NewFakeClient(), nodeset, controller, 1, "")
+			makePodCreated(pod2)
+			pod3 := nodesetutils.NewNodeSetStatefulSetPod(fake.NewFakeClient(), nodeset, controller, 2, "")
+			makePodHealthy(pod3)
+			k8sclient := fake.NewFakeClient(nodeset, pod1, pod2, pod3)
+			// pod2 is deliberately absent: an unhealthy pod that never
+			// registered with Slurm.
+			slurmNodeList := &slurmtypes.V0044NodeList{
+				Items: []slurmtypes.V0044Node{
+					*newNodeSetPodSlurmNode(pod1),
+					*newNodeSetPodSlurmNode(pod3),
+				},
+			}
+			slurmClient := newFakeClientList(sinterceptor.Funcs{}, slurmNodeList)
+			return testCaseFields{
+				name: "unhealthy old pod does not consume the budget",
+				fields: fields{
+					Client:    k8sclient,
+					ClientMap: newClientMap(controller.Name, slurmClient),
+				},
+				args: args{
+					ctx:     context.TODO(),
+					nodeset: nodeset,
+					pods:    []*corev1.Pod{pod1, pod2, pod3},
+					hash:    hash,
+				},
+				wantErr:      false,
+				wantCordoned: []*corev1.Pod{pod3},
+				wantDeleted:  []*corev1.Pod{pod2},
+			}
+		}(),
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := newNodeSetController(tt.fields.Client, tt.fields.ClientMap)
 			if err := r.syncRollingUpdate(tt.args.ctx, tt.args.nodeset, tt.args.pods, tt.args.hash); (err != nil) != tt.wantErr {
 				t.Errorf("NodeSetReconciler.syncRollingUpdate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			for _, pod := range tt.wantCordoned {
+				gotPod := &corev1.Pod{}
+				if err := r.Get(tt.args.ctx, client.ObjectKeyFromObject(pod), gotPod); err != nil {
+					t.Fatalf("Get pod: %v", err)
+				}
+				if got, want := podutils.IsPodCordon(gotPod), true; got != want {
+					t.Errorf("IsPodCordon(%s) = %v, want %v", pod.Name, got, want)
+				}
+			}
+			for _, pod := range tt.wantNotCordoned {
+				gotPod := &corev1.Pod{}
+				if err := r.Get(tt.args.ctx, client.ObjectKeyFromObject(pod), gotPod); err != nil {
+					t.Fatalf("Get pod: %v", err)
+				}
+				if got, want := podutils.IsPodCordon(gotPod), false; got != want {
+					t.Errorf("IsPodCordon(%s) = %v, want %v", pod.Name, got, want)
+				}
+			}
+			for _, pod := range tt.wantDeleted {
+				gotPod := &corev1.Pod{}
+				err := r.Get(tt.args.ctx, client.ObjectKeyFromObject(pod), gotPod)
+				if err == nil {
+					t.Errorf("expected pod %s to be deleted, but it still exists", pod.Name)
+				} else if !apierrors.IsNotFound(err) {
+					t.Errorf("Client.Get() unexpected error = %v", err)
+				}
 			}
 		})
 	}
@@ -3055,7 +3203,7 @@ func TestNodeSetReconciler_syncScheduledUpdate(t *testing.T) {
 		}(),
 		func() testCaseFields {
 			nodeset := newNodeSet("foo", controller.Name, 2)
-			nodeset.Spec.UpdateStrategy.Type = slinkyv1beta1.RollingUpdateNodeSetStrategyType
+			nodeset.Spec.UpdateStrategy.Type = slinkyv1beta1.ScheduledUpdateNodeSetStrategyType
 			startTime := time.Now()
 			endTime := startTime.Add(time.Hour)
 			nodeset.Spec.UpdateStrategy.ScheduledUpdate = slinkyv1beta1.ScheduledUpdateNodeSetStrategy{
@@ -3111,7 +3259,7 @@ func TestNodeSetReconciler_syncScheduledUpdate(t *testing.T) {
 		}(),
 		func() testCaseFields {
 			nodeset := newNodeSet("foo", controller.Name, 2)
-			nodeset.Spec.UpdateStrategy.Type = slinkyv1beta1.RollingUpdateNodeSetStrategyType
+			nodeset.Spec.UpdateStrategy.Type = slinkyv1beta1.ScheduledUpdateNodeSetStrategyType
 			startTime := time.Now()
 			endTime := startTime.Add(time.Hour)
 
@@ -3292,6 +3440,197 @@ func TestNodeSetReconciler_splitUpdatePods(t *testing.T) {
 			},
 			wantPodsToDelete: []string{},
 			wantPodsToKeep:   []string{"pod-0", "pod-1"},
+		},
+		{
+			name: "RollingUpdate throttled by terminating pod",
+			fields: fields{
+				Client: fake.NewFakeClient(),
+			},
+			args: args{
+				ctx: context.TODO(),
+				nodeset: func() *slinkyv1beta1.NodeSet {
+					nodeset := newNodeSet("foo", controller.Name, 2)
+					nodeset.Spec.UpdateStrategy.Type = slinkyv1beta1.RollingUpdateNodeSetStrategyType
+					nodeset.Spec.UpdateStrategy.RollingUpdate = slinkyv1beta1.RollingUpdateNodeSetStrategy{
+						MaxUnavailable: ptr.To(intstr.FromInt32(1)),
+					}
+					return nodeset
+				}(),
+				pods: []*corev1.Pod{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:              "pod-0",
+							DeletionTimestamp: &now,
+							Labels: map[string]string{
+								history.ControllerRevisionHashLabel: "",
+							},
+						},
+						Status: corev1.PodStatus{
+							Phase: corev1.PodRunning,
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "pod-1",
+							Labels: map[string]string{
+								history.ControllerRevisionHashLabel: "",
+							},
+						},
+						Status: corev1.PodStatus{
+							Phase: corev1.PodRunning,
+							Conditions: []corev1.PodCondition{
+								{
+									Type:               corev1.PodReady,
+									Status:             corev1.ConditionTrue,
+									LastTransitionTime: now,
+								},
+							},
+						},
+					},
+				},
+				hash: hash,
+			},
+			wantPodsToDelete: []string{},
+			wantPodsToKeep:   []string{"pod-1"},
+		},
+		{
+			name: "RollingUpdate ignores scale-in remnants",
+			fields: fields{
+				Client: fake.NewFakeClient(),
+			},
+			args: args{
+				ctx: context.TODO(),
+				nodeset: func() *slinkyv1beta1.NodeSet {
+					nodeset := newNodeSet("foo", controller.Name, 1)
+					nodeset.Spec.UpdateStrategy.Type = slinkyv1beta1.RollingUpdateNodeSetStrategyType
+					nodeset.Spec.UpdateStrategy.RollingUpdate = slinkyv1beta1.RollingUpdateNodeSetStrategy{
+						MaxUnavailable: ptr.To(intstr.FromInt32(1)),
+					}
+					return nodeset
+				}(),
+				pods: []*corev1.Pod{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "pod-0",
+							Labels: map[string]string{
+								history.ControllerRevisionHashLabel: "",
+							},
+						},
+						Status: corev1.PodStatus{
+							Phase: corev1.PodRunning,
+							Conditions: []corev1.PodCondition{
+								{
+									Type:               corev1.PodReady,
+									Status:             corev1.ConditionTrue,
+									LastTransitionTime: now,
+								},
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:              "pod-1",
+							DeletionTimestamp: &now,
+							Labels: map[string]string{
+								history.ControllerRevisionHashLabel: "",
+							},
+						},
+						Status: corev1.PodStatus{
+							Phase: corev1.PodRunning,
+						},
+					},
+				},
+				hash: hash,
+			},
+			wantPodsToDelete: []string{"pod-0"},
+			wantPodsToKeep:   []string{},
+		},
+		{
+			name: "RollingUpdate percentage budget",
+			fields: fields{
+				Client: fake.NewFakeClient(),
+			},
+			args: args{
+				ctx: context.TODO(),
+				nodeset: func() *slinkyv1beta1.NodeSet {
+					nodeset := newNodeSet("foo", controller.Name, 4)
+					nodeset.Spec.UpdateStrategy.Type = slinkyv1beta1.RollingUpdateNodeSetStrategyType
+					nodeset.Spec.UpdateStrategy.RollingUpdate = slinkyv1beta1.RollingUpdateNodeSetStrategy{
+						MaxUnavailable: ptr.To(intstr.FromString("50%")),
+					}
+					return nodeset
+				}(),
+				pods: []*corev1.Pod{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "pod-0",
+							Labels: map[string]string{
+								history.ControllerRevisionHashLabel: hash,
+							},
+						},
+						Status: corev1.PodStatus{
+							Phase: corev1.PodRunning,
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "pod-1",
+							Labels: map[string]string{
+								history.ControllerRevisionHashLabel: "",
+							},
+						},
+						Status: corev1.PodStatus{
+							Phase: corev1.PodRunning,
+							Conditions: []corev1.PodCondition{
+								{
+									Type:               corev1.PodReady,
+									Status:             corev1.ConditionTrue,
+									LastTransitionTime: now,
+								},
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "pod-2",
+							Labels: map[string]string{
+								history.ControllerRevisionHashLabel: "",
+							},
+						},
+						Status: corev1.PodStatus{
+							Phase: corev1.PodRunning,
+							Conditions: []corev1.PodCondition{
+								{
+									Type:               corev1.PodReady,
+									Status:             corev1.ConditionTrue,
+									LastTransitionTime: now,
+								},
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "pod-3",
+							Labels: map[string]string{
+								history.ControllerRevisionHashLabel: "",
+							},
+						},
+						Status: corev1.PodStatus{
+							Phase: corev1.PodRunning,
+							Conditions: []corev1.PodCondition{
+								{
+									Type:               corev1.PodReady,
+									Status:             corev1.ConditionTrue,
+									LastTransitionTime: now,
+								},
+							},
+						},
+					},
+				},
+				hash: hash,
+			},
+			wantPodsToDelete: []string{"pod-3"},
+			wantPodsToKeep:   []string{"pod-0", "pod-1", "pod-2"},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

During a RollingUpdate, `syncRollingUpdate` passed only the healthy old-revision pods to `splitUpdatePods`, so the `newPods` split inside it was always empty and `numUnavailable` was always zero. Every reconcile therefore condemned a fresh `maxUnavailable`-sized batch of old pods regardless of whether any replacement was ready, and a slow or broken image pull could drain a whole NodeSet to zero available workers. 

Reproduced on a kind cluster with `replicas=3` and `maxUnavailable=1` and an unpullable image: the operator logged 43 condemnation events in under three minutes and Slurm capacity dropped to 1 of 3 nodes in service where the budget guarantees 2, with visible cordon/uncordon flapping because `doPodProcessing` (which receives the full pod list) and `syncRollingUpdate` disagreed about the same pods.

Both callers now pass the full pod list and the accounting lives in `splitUpdatePods`: unhealthy old pods keep their replica slot without consuming the budget and are excluded from the deletion candidates. Daemonset mode keeps the previous seed because its pod set is not bounded by `Replicas`, so terminating remnants on nodes that left the eligible set must not stall the update.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/SlinkyProject/slurm-operator/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/SlinkyProject/slurm-operator/blob/main/CODE_OF_CONDUCT.md).
- [x] New or existing tests cover these changes (where applicable).
- [x] Documentation is updated if user-visible behavior changes.

## Breaking Changes

N/A

## Testing Notes

New unit tests cover the throttle (an unavailable new pod blocks further condemnation), the 8281235 exemption in both directions (an unhealthy old pod is deleted while the budget is exhausted, and it does not consume budget that a healthy old pod needs), terminating pods, scale-in remnants, and percentage budgets, with cordon and deletion assertions against the fake client, and the pre-existing update case now asserts that a ready new pod lets the next old pod be condemned; three of the new cases fail against the previous code.

Live on kind with the fixed operator (`replicas=3`, `maxUnavailable=1`): an update to an unpullable image condemned exactly one pod, the wedged replacement stayed the only unavailability, and the two remaining workers stayed Ready and idle in Slurm with no further condemnations while the pull kept failing. A subsequent valid update combined with a concurrent scale-down from 3 to 1 replicas converged to a single updated Ready pod, with the last old pod condemned for update while a scale-in remnant was still terminating, confirming remnants do not consume the budget.