### PR TITLE
fix(nodeset): report PVC creation events with the create outcome

### DIFF
--- a/internal/controller/nodeset/podcontrol/podcontrol.go
+++ b/internal/controller/nodeset/podcontrol/podcontrol.go
@@ -296,7 +296,8 @@ func (r *realPodControl) createPersistentVolumeClaims(ctx context.Context, nodes
 		err := r.Get(ctx, pvcId, pvc)
 		switch {
 		case apierrors.IsNotFound(err):
-			if err := r.Create(ctx, &claim); err != nil {
+			err := r.Create(ctx, &claim)
+			if err != nil {
 				errs = append(errs, fmt.Errorf("failed to create PVC %s: %w", claim.Name, err))
 			}
 			if err == nil || !apierrors.IsAlreadyExists(err) {

--- a/internal/controller/nodeset/podcontrol/podcontrol_test.go
+++ b/internal/controller/nodeset/podcontrol/podcontrol_test.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -29,6 +31,7 @@ import (
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
 	nodesetutils "github.com/SlinkyProject/slurm-operator/internal/controller/nodeset/utils"
 	"github.com/SlinkyProject/slurm-operator/internal/utils/podcontrol"
+	"github.com/SlinkyProject/slurm-operator/internal/utils/testutils"
 )
 
 func init() {
@@ -628,7 +631,7 @@ func Test_realPodControl_createPersistentVolumeClaims(t *testing.T) {
 	pvc := newPVC("datadir-foo-0")
 	type fields struct {
 		Client   client.Client
-		recorder events.EventRecorder
+		recorder *events.FakeRecorder
 	}
 	type args struct {
 		ctx     context.Context
@@ -636,10 +639,11 @@ func Test_realPodControl_createPersistentVolumeClaims(t *testing.T) {
 		pod     *corev1.Pod
 	}
 	tests := []struct {
-		name    string
-		fields  fields
-		args    args
-		wantErr bool
+		name      string
+		fields    fields
+		args      args
+		wantErr   bool
+		wantEvent string
 	}{
 		{
 			name: "Create",
@@ -652,7 +656,8 @@ func Test_realPodControl_createPersistentVolumeClaims(t *testing.T) {
 				nodeset: nodeset.DeepCopy(),
 				pod:     pod.DeepCopy(),
 			},
-			wantErr: false,
+			wantErr:   false,
+			wantEvent: "Normal SuccessfulCreate",
 		},
 		{
 			name: "Already Exists",
@@ -703,7 +708,8 @@ func Test_realPodControl_createPersistentVolumeClaims(t *testing.T) {
 				nodeset: nodeset.DeepCopy(),
 				pod:     pod.DeepCopy(),
 			},
-			wantErr: true,
+			wantErr:   true,
+			wantEvent: "Warning FailedCreate",
 		},
 		{
 			name: "Create Error",
@@ -712,6 +718,27 @@ func Test_realPodControl_createPersistentVolumeClaims(t *testing.T) {
 					WithInterceptorFuncs(interceptor.Funcs{
 						Create: func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
 							return http.ErrServerClosed
+						},
+					}).
+					WithRuntimeObjects(nodeset.DeepCopy()).
+					Build(),
+				recorder: events.NewFakeRecorder(10),
+			},
+			args: args{
+				ctx:     context.TODO(),
+				nodeset: nodeset.DeepCopy(),
+				pod:     pod.DeepCopy(),
+			},
+			wantErr:   true,
+			wantEvent: "failed: http: Server closed",
+		},
+		{
+			name: "Create Already Exists",
+			fields: fields{
+				Client: fake.NewClientBuilder().
+					WithInterceptorFuncs(interceptor.Funcs{
+						Create: func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+							return apierrors.NewAlreadyExists(corev1.Resource("persistentvolumeclaims"), "datadir-foo-0")
 						},
 					}).
 					WithRuntimeObjects(nodeset.DeepCopy()).
@@ -732,6 +759,13 @@ func Test_realPodControl_createPersistentVolumeClaims(t *testing.T) {
 			if err := r.createPersistentVolumeClaims(tt.args.ctx, tt.args.nodeset, tt.args.pod); (err != nil) != tt.wantErr {
 				t.Errorf("realPodControl.createPersistentVolumeClaims() error = %v, wantErr %v", err, tt.wantErr)
 			}
+			if tt.wantEvent != "" {
+				event := testutils.ReadOneEvent(t, tt.fields.recorder)
+				if !strings.Contains(event, tt.wantEvent) {
+					t.Errorf("realPodControl.createPersistentVolumeClaims() event = %v, want substring %q", event, tt.wantEvent)
+				}
+			}
+			testutils.AssertNoEvents(t, tt.fields.recorder)
 		})
 	}
 }

--- a/internal/syncsteps/syncsteps_test.go
+++ b/internal/syncsteps/syncsteps_test.go
@@ -12,27 +12,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/tools/events"
+
+	"github.com/SlinkyProject/slurm-operator/internal/utils/testutils"
 )
-
-func readOneEvent(t *testing.T, rec *events.FakeRecorder) string {
-	t.Helper()
-	select {
-	case ev := <-rec.Events:
-		return ev
-	default:
-		t.Fatal("expected one event on channel")
-		return ""
-	}
-}
-
-func assertNoEvents(t *testing.T, rec *events.FakeRecorder) {
-	t.Helper()
-	select {
-	case ev := <-rec.Events:
-		t.Fatalf("unexpected event: %q", ev)
-	default:
-	}
-}
 
 func TestSync_AllStepsSucceed_ReturnsNil(t *testing.T) {
 	t.Parallel()
@@ -44,7 +26,7 @@ func TestSync_AllStepsSucceed_ReturnsNil(t *testing.T) {
 		{Name: "b", SyncFn: func(context.Context, *corev1.ConfigMap) error { return nil }},
 	}
 	require.NoError(t, Sync(ctx, rec, obj, steps))
-	assertNoEvents(t, rec)
+	testutils.AssertNoEvents(t, rec)
 }
 
 func TestSync_EmptySteps_ReturnsNil(t *testing.T) {
@@ -53,7 +35,7 @@ func TestSync_EmptySteps_ReturnsNil(t *testing.T) {
 	rec := events.NewFakeRecorder(10)
 	obj := &corev1.ConfigMap{}
 	require.NoError(t, Sync(ctx, rec, obj, nil))
-	assertNoEvents(t, rec)
+	testutils.AssertNoEvents(t, rec)
 }
 
 func TestSync_SingleFailure_OneEventAndWrappedError(t *testing.T) {
@@ -69,11 +51,11 @@ func TestSync_SingleFailure_OneEventAndWrappedError(t *testing.T) {
 	err := Sync(ctx, rec, obj, steps)
 	require.ErrorIs(t, err, wantErr)
 	require.ErrorContains(t, err, `failed "bad" step`)
-	ev := readOneEvent(t, rec)
+	ev := testutils.ReadOneEvent(t, rec)
 	require.Contains(t, ev, "Warning")
 	require.Contains(t, ev, failedReason)
 	require.Contains(t, ev, `Failed "bad" step`)
-	assertNoEvents(t, rec)
+	testutils.AssertNoEvents(t, rec)
 }
 
 func TestSync_TwoFailuresWithoutStop_BothRecordedAndContinues(t *testing.T) {
@@ -95,10 +77,10 @@ func TestSync_TwoFailuresWithoutStop_BothRecordedAndContinues(t *testing.T) {
 	require.ErrorAs(t, err, &agg)
 	require.Len(t, agg.Errors(), 3)
 	require.True(t, thirdRan, "expected third step to Sync when StopOnError is false")
-	readOneEvent(t, rec)
-	readOneEvent(t, rec)
-	readOneEvent(t, rec)
-	assertNoEvents(t, rec)
+	testutils.ReadOneEvent(t, rec)
+	testutils.ReadOneEvent(t, rec)
+	testutils.ReadOneEvent(t, rec)
+	testutils.AssertNoEvents(t, rec)
 }
 
 func TestSync_StopOnError_SkipsFollowingSteps(t *testing.T) {
@@ -120,8 +102,8 @@ func TestSync_StopOnError_SkipsFollowingSteps(t *testing.T) {
 	var agg utilerrors.Aggregate
 	require.ErrorAs(t, err, &agg)
 	require.Len(t, agg.Errors(), 1)
-	readOneEvent(t, rec)
-	assertNoEvents(t, rec)
+	testutils.ReadOneEvent(t, rec)
+	testutils.AssertNoEvents(t, rec)
 }
 
 func TestSync_NilRecorder_NoPanicStillAggregates(t *testing.T) {
@@ -146,6 +128,6 @@ func TestSync_FirstSucceedsSecondFails_OneError(t *testing.T) {
 	}
 	err := Sync(ctx, rec, obj, steps)
 	require.Error(t, err)
-	readOneEvent(t, rec)
-	assertNoEvents(t, rec)
+	testutils.ReadOneEvent(t, rec)
+	testutils.AssertNoEvents(t, rec)
 }

--- a/internal/utils/testutils/events.go
+++ b/internal/utils/testutils/events.go
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: Copyright (C) SchedMD LLC.
+// SPDX-License-Identifier: Apache-2.0
+
+package testutils
+
+import (
+	"testing"
+
+	"k8s.io/client-go/tools/events"
+)
+
+// ReadOneEvent returns the next event buffered on rec, failing t if there is none.
+func ReadOneEvent(t *testing.T, rec *events.FakeRecorder) string {
+	t.Helper()
+	select {
+	case ev := <-rec.Events:
+		return ev
+	default:
+		t.Fatal("expected one event on channel")
+		return ""
+	}
+}
+
+// AssertNoEvents fails t if rec has any buffered events.
+func AssertNoEvents(t *testing.T, rec *events.FakeRecorder) {
+	t.Helper()
+	select {
+	case ev := <-rec.Events:
+		t.Fatalf("unexpected event: %q", ev)
+	default:
+	}
+}


### PR DESCRIPTION
## Summary

In `createPersistentVolumeClaims`, the PVC create error was declared in the if statement header (`if err := r.Create(ctx, &claim); err != nil`), so the event condition below it kept evaluating the outer `r.Get` error, which in the `IsNotFound` case branch is always non-nil. As a result every successful PVC creation emitted a `Warning FailedCreate` event claiming the claim was not found, the `AlreadyExists` event suppression on the next line was dead code, and genuine create failures were reported with the stale NotFound text instead of the actual error. Reproduced on a kind cluster with the published `ghcr.io/slinkyproject/slurm-operator:1.2.0-rc1` image: creating a NodeSet with a `volumeClaimTemplate` produced the event `Warning FailedCreate create Claim: scratch-slurm-worker-pvc-0 for Pod slurm-worker-pvc-0 failed: PersistentVolumeClaim "scratch-slurm-worker-pvc-0" not found` while that same PVC had just been created successfully.

The fix restores that form: `err := r.Create(ctx, &claim)` at case block scope, so the error aggregation and the event condition both observe the create result. Successful creations now emit `Normal SuccessfulCreate`, a create that races with another creator and gets `AlreadyExists` emits no event (the error is still aggregated and returned, matching upstream), and real create failures are reported with the real error.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/SlinkyProject/slurm-operator/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/SlinkyProject/slurm-operator/blob/main/CODE_OF_CONDUCT.md).
- [x] New or existing tests cover these changes (where applicable).
- [x] Documentation is updated if user-visible behavior changes.

## Breaking Changes

N/A

## Testing Notes

The `createPersistentVolumeClaims` table test now asserts recorded events in every case: successful creation emits `Normal SuccessfulCreate`, a failing Get and a failing Create each emit `Warning FailedCreate` with the real error in the message, an `AlreadyExists` create is suppressed (new case, with the error still returned), and every case asserts no further events remain buffered. Three of these cases fail against the previous code, which emitted the stale NotFound warning in all of them. The full test suite passes.

Live on kind: with the published `1.2.0-rc1` operator image, a NodeSet with a `volumeClaimTemplate` produced the misleading `Warning FailedCreate ... not found` event for a successfully created PVC; after swapping only the operator image to this branch's build and recreating the same NodeSet, the identical scenario produced `Normal SuccessfulCreate create Claim: scratch-slurm-worker-pvc-0 Pod slurm-worker-pvc-0`.