### PR TITLE
fix(restapi): restrict slurmrestd openapi plugins when accounting is disabled

### DIFF
--- a/internal/builder/restapibuilder/restapi_app.go
+++ b/internal/builder/restapibuilder/restapi_app.go
@@ -11,7 +11,6 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
@@ -78,7 +77,7 @@ func (b *RestapiBuilder) restapiPodTemplate(restapi *slinkyv1beta1.RestApi) (cor
 		return corev1.PodTemplateSpec{}, err
 	}
 
-	hasAccounting := !apiequality.Semantic.DeepEqual(controller.Spec.AccountingRef, corev1.LocalObjectReference{})
+	hasAccounting := controller.Spec.AccountingRef != nil
 
 	objectMeta := metadata.NewBuilder(key).
 		WithAnnotations(restapi.Annotations).

--- a/internal/builder/restapibuilder/restapi_app_test.go
+++ b/internal/builder/restapibuilder/restapi_app_test.go
@@ -26,10 +26,11 @@ func TestBuilder_BuildRestapi(t *testing.T) {
 		restapi *slinkyv1beta1.RestApi
 	}
 	tests := []struct {
-		name    string
-		fields  fields
-		args    args
-		wantErr bool
+		name     string
+		fields   fields
+		args     args
+		wantErr  bool
+		wantArgs []string
 	}{
 		{
 			name: "default",
@@ -54,6 +55,37 @@ func TestBuilder_BuildRestapi(t *testing.T) {
 					},
 				},
 			},
+			wantArgs: []string{"-s", "openapi/slurmctld", "0.0.0.0:6820"},
+		},
+		{
+			name: "with accounting",
+			fields: fields{
+				client: fake.NewClientBuilder().
+					WithObjects(&slinkyv1beta1.Controller{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "slurm",
+						},
+						Spec: slinkyv1beta1.ControllerSpec{
+							AccountingRef: &corev1.LocalObjectReference{
+								Name: "slurm",
+							},
+						},
+					}).
+					Build(),
+			},
+			args: args{
+				restapi: &slinkyv1beta1.RestApi{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "slurm",
+					},
+					Spec: slinkyv1beta1.RestApiSpec{
+						ControllerRef: corev1.LocalObjectReference{
+							Name: "slurm",
+						},
+					},
+				},
+			},
+			wantArgs: []string{"0.0.0.0:6820"},
 		},
 		{
 			name: "failure",
@@ -88,6 +120,7 @@ func TestBuilder_BuildRestapi(t *testing.T) {
 			require.Equal(t, labels.RestapiApp, got.Spec.Template.Spec.Containers[0].Name)
 			require.Equal(t, labels.RestapiApp, got.Spec.Template.Spec.Containers[0].Ports[0].Name)
 			require.Equal(t, int32(SlurmrestdPort), got.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort)
+			require.Equal(t, tt.wantArgs, got.Spec.Template.Spec.Containers[0].Args)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

`restapiPodTemplate` decides whether to restrict slurmrestd's openapi plugins by comparing `controller.Spec.AccountingRef` against an empty `corev1.LocalObjectReference{}` with `apiequality.Semantic.DeepEqual`. Since `AccountingRef` is a `*corev1.LocalObjectReference`, the pinned apimachinery's `DeepEqual` returns false for any pointer value because the two arguments have different dynamic types (`third_party/forked/golang/reflect/deep_equal.go` returns false whenever `v1.Type() != v2.Type()`), so `hasAccounting` was always true and `slurmrestdArgs` never emitted the intended `-s openapi/slurmctld` for clusters without accounting.


## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/SlinkyProject/slurm-operator/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/SlinkyProject/slurm-operator/blob/main/CODE_OF_CONDUCT.md).
- [x] New or existing tests cover these changes (where applicable).
- [x] Documentation is updated if user-visible behavior changes.

## Breaking Changes

On clusters whose Controller has no `accountingRef`, the rendered restapi Deployment gains `-s openapi/slurmctld`, which triggers one rollout of the restapi pod on upgrade. I verified on a kind cluster that this does not change the served endpoint surface there: with `AccountingStorageType=accounting_storage/none` in slurm.conf, the slurmrestd 26.05 image already disables its slurmdbd openapi plugin on its own, so `GET /slurmdb/v0.0.44/diag` returned 404 and `/openapi/v3` listed no `/slurmdb/` paths in both the restricted and the unrestricted configuration. The fix makes that restriction explicit in the container args as originally intended instead of relying on slurmrestd's runtime self-disable.

A cluster that wires accounting through `spec.extraConf` instead of an `accountingRef` now runs slurmrestd restricted to the slurmctld plugin, so `/slurmdb/` REST routes will no longer be served there. `accountingRef` is the supported way to signal accounting to the operator.

## Testing Notes

Unit: `TestBuilder_BuildRestapi` now asserts the slurmrestd container args. The existing no-accounting case expects `["-s","openapi/slurmctld","0.0.0.0:6820"]` and a new "with accounting" case expects `["0.0.0.0:6820"]`. Without the fix the no-accounting expectation fails with actual `["0.0.0.0:6820"]`, so the tests discriminate against the bug.

Live on a kind cluster with a Controller that has no `accountingRef`: an operator built without the fix rendered the restapi Deployment args as `["0.0.0.0:6820"]`, and after swapping in an operator built from this branch the Deployment was re-rendered to `["-s","openapi/slurmctld","0.0.0.0:6820"]` and the rolled restapi pod reached Ready. Patching `accountingRef` onto the Controller reverted the args to `["0.0.0.0:6820"]` and removing it restored the restriction, confirming the flag tracks reference presence in both directions.

HTTP checks with a token from `scontrol token`, issued from inside the restapi pod: the restricted pod answered `GET /slurm/v0.0.44/ping` with 200 OK and `GET /slurmdb/v0.0.44/diag` with 404 NOT FOUND, and its `/openapi/v3` spec contained no `/slurmdb/` paths. The unrestricted pod in the same accounting-less cluster returned identical results, see Breaking Changes above.

## Additional Context

The nil check gates on reference presence, consistent with `BuildControllerConfig`, which nil-checks `AccountingRef` before resolving the Accounting CR and tolerates a missing target. An `accountingRef` that points to a nonexistent Accounting CR therefore still yields an unrestricted slurmrestd, which is the same behavior as before this fix; validating that the reference resolves would be webhook work and is out of scope here.