### PR TITLE
test(e2e): enable the worker topology the assertions expect

### DIFF
--- a/test/component_utils.go
+++ b/test/component_utils.go
@@ -122,6 +122,10 @@ func DoSlurmInstall(ctx context.Context, t *testing.T, config *envconf.Config, s
 		helm.WithNamespace(SlurmNamespace),
 		helm.WithChart(Basepath+"helm/slurm"),
 		helm.WithArgs(setValuesFile),
+		// enabling the slinky nodeset, its partition, and a default partition expected by the e2e assertions
+		helm.WithArgs("--set 'nodesets.slinky.enabled=true'"),
+		helm.WithArgs("--set 'nodesets.slinky.partition.enabled=true'"),
+		helm.WithArgs("--set 'partitions.all.enabled=true'"),
 		helm.WithWait(),
 		helm.WithTimeout("10m"),
 	)


### PR DESCRIPTION
## Summary

The e2e scenarios assert a fixed worker topology: a NodeSet named `slurm-worker-slinky` (`checkNodeSetReplicas` at `test/e2e/e2e_installation_utils.go:92`, the scale up/down assessments), a Slurm partition named `slinky` (`sinfo -N -n slinky-0 -p slinky` at `test/e2e/e2e_test_utils.go:142`), and a default partition for a job submitted without `-p` (`srun ... hostname` at `test/e2e/e2e_test_utils.go:109`).

With the chart now defaulting to `nodesets: {}`, `DoSlurmInstall` installs a cluster with no NodeSet at all, so every non-Pyxis scenario fails deterministically at the first `checkNodeSetReplicas` Get with NotFound against a perfectly healthy operator. The Pyxis scenario escapes only because its `--set nodesets.slinky.slurmd.image.repository=...` incidentally creates the `nodesets.slinky` entry.

This PR makes `DoSlurmInstall` enable the topology the assertions expect: `nodesets.slinky.enabled=true`, `nodesets.slinky.partition.enabled=true`, and `partitions.all.enabled=true`. The last flag is needed because the operator writes the per-NodeSet partition line without `Default` (`buildNodeSetConf` in `internal/builder/controllerbuilder/controller_config.go`), so the bare `srun` needs the chart's `all` partition, which carries `Default=YES`.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/SlinkyProject/slurm-operator/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/SlinkyProject/slurm-operator/blob/main/CODE_OF_CONDUCT.md).
- [x] New or existing tests cover these changes (where applicable).
- [x] Documentation is updated if user-visible behavior changes.

## Breaking Changes

N/A

## Testing Notes

`go vet` and `go build` pass on `test/...`.

Verified live on a kind cluster by reproducing the exact helm invocation `DoSlurmInstall` performs, before and after. With the current arguments the release deploys and the Controller CR exists, but zero NodeSet CRs are created, which is precisely the NotFound that aborts every scenario. With the three added flags the NodeSet `slurm-worker-slinky` is created with `replicas=1` and `spec.partition.enabled=true`, the stack comes up (controller, restapi, worker all Ready), and the suite's assertions pass verbatim when run inside the pods: `sinfo` lists partitions `slinky` and `all` both up and idle, `sinfo -N -n slinky-0 -p slinky --Format=StateLong -h` returns `idle`, and `srun --immediate=10 -K -Q --time=0:15 hostname` executes on `slinky-0` via the default partition.

## Additional Context

`nodesets.slinky.enabled=true` is technically redundant today because `nodesetDefaults.enabled: true` is merged into every `nodesets.*` entry once the key exists. It is kept deliberately: this failure was caused by silent chart-default drift, so the harness now pins the topology it depends on explicitly rather than deriving it from defaults, mirroring how the same function already sets `loginsets.slinky.enabled=true` explicitly.