### PR TITLE
fix(nodeset): refresh dynamic node records on registration changes

### DIFF
--- a/CHANGELOG/CHANGELOG-1.2.md
+++ b/CHANGELOG/CHANGELOG-1.2.md
@@ -4,6 +4,12 @@
 
 - Added optional PodDisruptionBudget for RestAPI.
 
+### Fixed
+
+- Recreate dynamic Slurm node records when registration-derived NodeSet
+  parameters change, preventing stale values such as `MemSpecLimit` after a
+  rolling update.
+
 ## v1.2.0-rc1
 
 ### Added

--- a/api/v1beta1/well_known.go
+++ b/api/v1beta1/well_known.go
@@ -17,6 +17,17 @@ const (
 	// AnnotationPodCordon indicates NodeSet Pods that should be DRAIN[ING|ED] in Slurm.
 	AnnotationPodCordon = NodeSetPrefix + "pod-cordon"
 
+	// AnnotationPodRegistrationHash identifies the inputs used by slurmd to
+	// register its dynamic Slurm node record.
+	// NOTE: Set by the NodeSet controller.
+	AnnotationPodRegistrationHash = NodeSetPrefix + "registration-hash"
+
+	// AnnotationNodeSetPendingNodeRecordRefresh stores the Slurm node names
+	// whose pods must stop before their dynamic node records are deleted and
+	// recreated during a NodeSet update.
+	// NOTE: Set by the NodeSet controller.
+	AnnotationNodeSetPendingNodeRecordRefresh = NodeSetPrefix + "pending-node-record-refresh"
+
 	// LabelPodDeletionCost can be used to set to an int32 that represent the cost of deleting a pod compared to other
 	// pods belonging to the same ReplicaSet. Pods with lower deletion cost are preferred to be deleted before pods
 	// with higher deletion cost.

--- a/internal/builder/workerbuilder/worker_app.go
+++ b/internal/builder/workerbuilder/worker_app.go
@@ -6,6 +6,7 @@ package workerbuilder
 import (
 	"context"
 	_ "embed"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strconv"
@@ -81,7 +82,52 @@ func (b *WorkerBuilder) BuildWorkerPodTemplate(nodeset *slinkyv1beta1.NodeSet, c
 		Merge: template.PodSpec,
 	}
 
-	return b.CommonBuilder.BuildPodTemplate(opts)
+	podTemplate := b.CommonBuilder.BuildPodTemplate(opts)
+	if podTemplate.Annotations == nil {
+		podTemplate.Annotations = make(map[string]string)
+	}
+	delete(podTemplate.Annotations, slinkyv1beta1.AnnotationNodeSetPendingNodeRecordRefresh)
+	podTemplate.Annotations[slinkyv1beta1.AnnotationPodRegistrationHash] = registrationHash(podTemplate.Spec)
+	return podTemplate
+}
+
+// registrationHash returns a stable digest of the pod inputs that affect the
+// dynamic node record created by slurmd -Z. Deliberately excluded fields such
+// as the image and probes can roll without rebuilding the Slurm node record.
+func registrationHash(podSpec corev1.PodSpec) string {
+	type registrationInputs struct {
+		Args            []string                  `json:"args,omitempty"`
+		Env             []corev1.EnvVar           `json:"env,omitempty"`
+		ContainerLimits corev1.ResourceList       `json:"containerLimits,omitempty"`
+		PodLimits       corev1.ResourceList       `json:"podLimits,omitempty"`
+		ResourceClaims  []corev1.PodResourceClaim `json:"resourceClaims,omitempty"`
+	}
+
+	inputs := registrationInputs{
+		ResourceClaims: podSpec.ResourceClaims,
+	}
+	if podSpec.Resources != nil {
+		inputs.PodLimits = podSpec.Resources.Limits
+	}
+	for _, container := range podSpec.Containers {
+		if container.Name != labels.WorkerApp {
+			continue
+		}
+		inputs.Args = container.Args
+		inputs.ContainerLimits = container.Resources.Limits
+		for _, env := range container.Env {
+			if env.Name == "POD_CPUS" || env.Name == "POD_MEMORY" {
+				inputs.Env = append(inputs.Env, env)
+			}
+		}
+		break
+	}
+
+	data, err := json.Marshal(inputs)
+	if err != nil {
+		panic(fmt.Sprintf("failed to marshal slurmd registration inputs: %v", err))
+	}
+	return crypto.CheckSum(data)
 }
 
 func nodesetVolumes(nodeset *slinkyv1beta1.NodeSet, controller *slinkyv1beta1.Controller) []corev1.Volume {

--- a/internal/builder/workerbuilder/worker_app_test.go
+++ b/internal/builder/workerbuilder/worker_app_test.go
@@ -90,6 +90,60 @@ func TestBuilder_BuildWorkerPodTemplate(t *testing.T) {
 	}
 }
 
+func TestRegistrationHash(t *testing.T) {
+	base := corev1.PodSpec{
+		Containers: []corev1.Container{
+			{
+				Name:  labels.WorkerApp,
+				Image: "slurmd:v1",
+				Args:  []string{"-Z", "--conf", "RealMemory=1024"},
+				Env: []corev1.EnvVar{
+					{Name: "POD_CPUS", Value: "4"},
+					{Name: "POD_MEMORY", Value: "1024"},
+				},
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+					},
+				},
+			},
+		},
+	}
+
+	t.Run("ignores image-only changes", func(t *testing.T) {
+		changed := base.DeepCopy()
+		changed.Containers[0].Image = "slurmd:v2"
+		require.Equal(t, registrationHash(base), registrationHash(*changed))
+	})
+
+	t.Run("ignores request-only changes", func(t *testing.T) {
+		changed := base.DeepCopy()
+		changed.Containers[0].Resources.Requests = corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
+		}
+		require.Equal(t, registrationHash(base), registrationHash(*changed))
+	})
+
+	t.Run("changes with memory registration inputs", func(t *testing.T) {
+		changed := base.DeepCopy()
+		changed.Containers[0].Env[1].Value = "2048"
+		changed.Containers[0].Resources.Limits[corev1.ResourceMemory] = resource.MustParse("2Gi")
+		require.NotEqual(t, registrationHash(base), registrationHash(*changed))
+	})
+
+	t.Run("changes with slurmd conf", func(t *testing.T) {
+		changed := base.DeepCopy()
+		changed.Containers[0].Args[2] = "RealMemory=2048"
+		require.NotEqual(t, registrationHash(base), registrationHash(*changed))
+	})
+
+	t.Run("changes with device resources", func(t *testing.T) {
+		changed := base.DeepCopy()
+		changed.Containers[0].Resources.Limits[corev1.ResourceName("nvidia.com/gpu")] = resource.MustParse("1")
+		require.NotEqual(t, registrationHash(base), registrationHash(*changed))
+	})
+}
+
 func BenchmarkBuilder_BuildWorkerPodTemplate(b *testing.B) {
 	type fields struct {
 		client client.Client

--- a/internal/controller/nodeset/nodeset_controller.go
+++ b/internal/controller/nodeset/nodeset_controller.go
@@ -62,6 +62,8 @@ const (
 	SlurmNodeNotRegisteredReason = "SlurmNodeNotRegistered"
 	// DefunctSlurmNodePrunedReason is added to an event when a defunct Slurm node is pruned.
 	DefunctSlurmNodePrunedReason = "DefunctSlurmNodePruned"
+	// SlurmNodeRecordRefreshReason is added to an event when a dynamic Slurm node record is refreshed for an update.
+	SlurmNodeRecordRefreshReason = "SlurmNodeRecordRefresh"
 	// RollingUpdateReason is added to an event when pods are being replaced during a rolling update.
 	RollingUpdateReason = "RollingUpdate"
 	// ControllerRefFailedReason is added to an event when the referenced Controller CR cannot be fetched.

--- a/internal/controller/nodeset/nodeset_node_record_refresh.go
+++ b/internal/controller/nodeset/nodeset_node_record_refresh.go
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: Copyright (C) SchedMD LLC.
+// SPDX-License-Identifier: Apache-2.0
+
+package nodeset
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
+	"k8s.io/utils/set"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	nodesetutils "github.com/SlinkyProject/slurm-operator/internal/controller/nodeset/utils"
+	"github.com/SlinkyProject/slurm-operator/internal/utils/objectutils"
+)
+
+func pendingNodeRecordRefreshes(nodeset *slinkyv1beta1.NodeSet) set.Set[string] {
+	pending := set.New[string]()
+	for nodeName := range strings.SplitSeq(nodeset.Annotations[slinkyv1beta1.AnnotationNodeSetPendingNodeRecordRefresh], ",") {
+		if nodeName != "" {
+			pending.Insert(nodeName)
+		}
+	}
+	return pending
+}
+
+func setPendingNodeRecordRefreshes(nodeset *slinkyv1beta1.NodeSet, pending set.Set[string]) {
+	if nodeset.Annotations == nil {
+		nodeset.Annotations = make(map[string]string)
+	}
+	if pending.Len() == 0 {
+		delete(nodeset.Annotations, slinkyv1beta1.AnnotationNodeSetPendingNodeRecordRefresh)
+		return
+	}
+	nodeset.Annotations[slinkyv1beta1.AnnotationNodeSetPendingNodeRecordRefresh] = strings.Join(pending.SortedList(), ",")
+}
+
+// markPendingNodeRecordRefreshes records nodes whose registration-derived
+// configuration changed. The marker survives pod deletion and operator
+// restarts, allowing the controller to remove the stale Slurm record before it
+// creates the replacement pod.
+func (r *NodeSetReconciler) markPendingNodeRecordRefreshes(
+	ctx context.Context,
+	nodeset *slinkyv1beta1.NodeSet,
+	pods []*corev1.Pod,
+	hash string,
+) error {
+	pending := pendingNodeRecordRefreshes(nodeset)
+	before := pending.Clone()
+
+	for _, pod := range pods {
+		desired, err := r.newReplacementPod(ctx, nodeset, pod, hash)
+		if err != nil {
+			return err
+		}
+		currentHash := pod.Annotations[slinkyv1beta1.AnnotationPodRegistrationHash]
+		desiredHash := desired.Annotations[slinkyv1beta1.AnnotationPodRegistrationHash]
+		nodeName := nodesetutils.GetSlurmNodeName(pod)
+		if currentHash != desiredHash {
+			pending.Insert(nodeName)
+		} else {
+			pending.Delete(nodeName)
+		}
+	}
+
+	if pending.Equal(before) {
+		return nil
+	}
+	return objectutils.PatchObject(r.Client, ctx, nodeset, func(nodeset *slinkyv1beta1.NodeSet) error {
+		setPendingNodeRecordRefreshes(nodeset, pending)
+		return nil
+	})
+}
+
+func (r *NodeSetReconciler) newReplacementPod(
+	ctx context.Context,
+	nodeset *slinkyv1beta1.NodeSet,
+	pod *corev1.Pod,
+	hash string,
+) (*corev1.Pod, error) {
+	if nodeset.Spec.ScalingMode == slinkyv1beta1.ScalingModeDaemonset {
+		return r.newNodeSetPodDaemon(r.Client, ctx, nodeset, pod.Spec.NodeName, hash)
+	}
+	return r.newNodeSetPodOrdinal(r.Client, ctx, nodeset, nodesetutils.GetOrdinal(pod), hash)
+}
+
+// syncPendingNodeRecordRefreshes waits until the old pod is absent or terminal,
+// proving that its slurmd can no longer re-register, then removes the stale
+// dynamic Slurm node record. NodeSet pod creation runs only after this step
+// succeeds.
+func (r *NodeSetReconciler) syncPendingNodeRecordRefreshes(
+	ctx context.Context,
+	nodeset *slinkyv1beta1.NodeSet,
+	pods []*corev1.Pod,
+) error {
+	pending := pendingNodeRecordRefreshes(nodeset)
+	if pending.Len() == 0 {
+		return nil
+	}
+	controllerKey := types.NamespacedName{Namespace: nodeset.Namespace, Name: nodeset.Spec.ControllerRef.Name}
+	if r.ClientMap == nil || !r.ClientMap.Has(controllerKey) {
+		return fmt.Errorf("cannot refresh dynamic Slurm node records without a client for controller %s/%s",
+			nodeset.Namespace, nodeset.Spec.ControllerRef.Name)
+	}
+
+	liveNodeNames := set.New[string]()
+	for _, pod := range pods {
+		if pod.DeletionTimestamp != nil && podutil.IsPodTerminal(pod) {
+			continue
+		}
+		liveNodeNames.Insert(nodesetutils.GetSlurmNodeName(pod))
+	}
+
+	logger := log.FromContext(ctx)
+	for _, nodeName := range pending.SortedList() {
+		if liveNodeNames.Has(nodeName) {
+			continue
+		}
+		logger.Info("Deleting stale dynamic Slurm node record before pod replacement", "node", nodeName)
+		if err := r.slurmControl.DeleteNode(ctx, nodeset, nodeName); err != nil {
+			return fmt.Errorf("failed to delete stale dynamic Slurm node record %s: %w", nodeName, err)
+		}
+		pending.Delete(nodeName)
+		r.eventRecorder.Eventf(nodeset, nil, corev1.EventTypeNormal, SlurmNodeRecordRefreshReason, "Delete",
+			"Deleted stale dynamic Slurm node record %s before creating its replacement pod", nodeName)
+	}
+
+	if err := objectutils.PatchObject(r.Client, ctx, nodeset, func(nodeset *slinkyv1beta1.NodeSet) error {
+		setPendingNodeRecordRefreshes(nodeset, pending)
+		return nil
+	}); err != nil {
+		return err
+	}
+	klog.FromContext(ctx).V(2).Info("Synchronized pending dynamic Slurm node record refreshes", "remaining", pending.Len())
+	return nil
+}

--- a/internal/controller/nodeset/nodeset_node_record_refresh_test.go
+++ b/internal/controller/nodeset/nodeset_node_record_refresh_test.go
@@ -1,0 +1,130 @@
+// SPDX-FileCopyrightText: Copyright (C) SchedMD LLC.
+// SPDX-License-Identifier: Apache-2.0
+
+package nodeset
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/set"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	slurmclient "github.com/SlinkyProject/slurm-client/pkg/client"
+	sinterceptor "github.com/SlinkyProject/slurm-client/pkg/client/interceptor"
+	slurmobject "github.com/SlinkyProject/slurm-client/pkg/object"
+
+	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	nodesetutils "github.com/SlinkyProject/slurm-operator/internal/controller/nodeset/utils"
+)
+
+func TestNodeSetReconciler_registrationChangeRefreshesNodeRecordAfterPodStops(t *testing.T) {
+	ctx := context.Background()
+	controller := &slinkyv1beta1.Controller{ObjectMeta: metav1.ObjectMeta{
+		Namespace: corev1.NamespaceDefault,
+		Name:      "slurm",
+	}}
+
+	oldNodeSet := newNodeSet("foo", controller.Name, 1)
+	oldNodeSet.Spec.Slurmd.Resources.Limits = corev1.ResourceList{
+		corev1.ResourceMemory: resource.MustParse("1Gi"),
+	}
+	oldPod := nodesetutils.NewNodeSetStatefulSetPod(fake.NewFakeClient(), oldNodeSet, controller, 0, "old-revision")
+
+	nodeset := oldNodeSet.DeepCopy()
+	nodeset.Spec.Slurmd.Resources.Limits[corev1.ResourceMemory] = resource.MustParse("2Gi")
+	kubeClient := fake.NewFakeClient(controller, nodeset)
+
+	deleteCalls := 0
+	deletedNode := ""
+	slurmClient := newFakeClientList(sinterceptor.Funcs{
+		Delete: func(_ context.Context, obj slurmobject.Object, _ ...slurmclient.DeleteOption) error {
+			deleteCalls++
+			deletedNode = string(obj.GetKey())
+			return nil
+		},
+	})
+	r := newNodeSetController(kubeClient, newClientMap(controller.Name, slurmClient))
+
+	if err := r.markPendingNodeRecordRefreshes(ctx, nodeset, []*corev1.Pod{oldPod}, "new-revision"); err != nil {
+		t.Fatalf("markPendingNodeRecordRefreshes() error = %v", err)
+	}
+	nodeName := nodesetutils.GetSlurmNodeName(oldPod)
+	if !pendingNodeRecordRefreshes(nodeset).Has(nodeName) {
+		t.Fatalf("pending refreshes = %v, want %q", pendingNodeRecordRefreshes(nodeset), nodeName)
+	}
+
+	// The old pod still exists, so its slurmd can re-register and the record
+	// must not be deleted yet.
+	if err := r.syncPendingNodeRecordRefreshes(ctx, nodeset, []*corev1.Pod{oldPod}); err != nil {
+		t.Fatalf("syncPendingNodeRecordRefreshes() with live pod error = %v", err)
+	}
+	if deleteCalls != 0 {
+		t.Fatalf("DeleteNode() calls with live pod = %d, want 0", deleteCalls)
+	}
+
+	// Once the pod is terminating and terminal, slurmd has stopped. Delete the
+	// stale record and clear the persisted marker before a replacement starts.
+	now := metav1.Now()
+	oldPod.DeletionTimestamp = &now
+	oldPod.Status.Phase = corev1.PodFailed
+	if err := r.syncPendingNodeRecordRefreshes(ctx, nodeset, []*corev1.Pod{oldPod}); err != nil {
+		t.Fatalf("syncPendingNodeRecordRefreshes() after pod stopped error = %v", err)
+	}
+	if deleteCalls != 1 || deletedNode != nodeName {
+		t.Fatalf("DeleteNode() = (%d, %q), want (1, %q)", deleteCalls, deletedNode, nodeName)
+	}
+	if pendingNodeRecordRefreshes(nodeset).Len() != 0 {
+		t.Fatalf("pending refreshes = %v, want empty", pendingNodeRecordRefreshes(nodeset))
+	}
+}
+
+func TestNodeSetReconciler_imageChangeDoesNotRefreshNodeRecord(t *testing.T) {
+	ctx := context.Background()
+	controller := &slinkyv1beta1.Controller{ObjectMeta: metav1.ObjectMeta{
+		Namespace: corev1.NamespaceDefault,
+		Name:      "slurm",
+	}}
+	oldNodeSet := newNodeSet("foo", controller.Name, 1)
+	oldPod := nodesetutils.NewNodeSetStatefulSetPod(fake.NewFakeClient(), oldNodeSet, controller, 0, "old-revision")
+
+	nodeset := oldNodeSet.DeepCopy()
+	nodeset.Spec.Slurmd.Image = "different-image"
+	kubeClient := fake.NewFakeClient(controller, nodeset)
+	r := newNodeSetController(kubeClient, newClientMap(controller.Name, newFakeClientList(sinterceptor.Funcs{})))
+
+	if err := r.markPendingNodeRecordRefreshes(ctx, nodeset, []*corev1.Pod{oldPod}, "new-revision"); err != nil {
+		t.Fatalf("markPendingNodeRecordRefreshes() error = %v", err)
+	}
+	if pendingNodeRecordRefreshes(nodeset).Len() != 0 {
+		t.Fatalf("pending refreshes = %v, want empty", pendingNodeRecordRefreshes(nodeset))
+	}
+}
+
+func TestNodeSetReconciler_nodeRecordDeleteFailureKeepsRefreshPending(t *testing.T) {
+	ctx := context.Background()
+	controller := &slinkyv1beta1.Controller{ObjectMeta: metav1.ObjectMeta{
+		Namespace: corev1.NamespaceDefault,
+		Name:      "slurm",
+	}}
+	nodeset := newNodeSet("foo", controller.Name, 1)
+	setPendingNodeRecordRefreshes(nodeset, set.New("foo-0"))
+	kubeClient := fake.NewFakeClient(nodeset)
+	slurmClient := newFakeClientList(sinterceptor.Funcs{
+		Delete: func(_ context.Context, _ slurmobject.Object, _ ...slurmclient.DeleteOption) error {
+			return errors.New("node is part of a reservation")
+		},
+	})
+	r := newNodeSetController(kubeClient, newClientMap(controller.Name, slurmClient))
+
+	if err := r.syncPendingNodeRecordRefreshes(ctx, nodeset, nil); err == nil {
+		t.Fatal("syncPendingNodeRecordRefreshes() error = nil, want deletion error")
+	}
+	if !pendingNodeRecordRefreshes(nodeset).Has("foo-0") {
+		t.Fatalf("pending refreshes = %v, want foo-0 retained", pendingNodeRecordRefreshes(nodeset))
+	}
+}

--- a/internal/controller/nodeset/nodeset_sync.go
+++ b/internal/controller/nodeset/nodeset_sync.go
@@ -395,6 +395,14 @@ func (r *NodeSetReconciler) sync(
 			},
 		},
 		{
+			Name: "SlurmNodeRecordRefreshes",
+			SyncFn: func(ctx context.Context, nodeset *slinkyv1beta1.NodeSet) error {
+				return r.syncPendingNodeRecordRefreshes(ctx, nodeset, pods)
+			},
+			// A replacement must not start against the stale record if deletion fails.
+			StopOnError: true,
+		},
+		{
 			Name: "NodeSetPods",
 			SyncFn: func(ctx context.Context, nodeset *slinkyv1beta1.NodeSet) error {
 				return r.syncNodeSetPods(ctx, nodeset, pods, hash)
@@ -1529,6 +1537,11 @@ func (r *NodeSetReconciler) syncUpdate(
 	pods []*corev1.Pod,
 	hash string,
 ) error {
+	_, oldPods := findUpdatedPods(pods, hash)
+	if err := r.markPendingNodeRecordRefreshes(ctx, nodeset, oldPods, hash); err != nil {
+		return err
+	}
+
 	switch nodeset.Spec.UpdateStrategy.Type {
 	default:
 		fallthrough

--- a/internal/controller/nodeset/nodeset_sync_test.go
+++ b/internal/controller/nodeset/nodeset_sync_test.go
@@ -2657,7 +2657,8 @@ func TestNodeSetReconciler_makePodUncordon(t *testing.T) {
 func TestNodeSetReconciler_syncUpdate(t *testing.T) {
 	controller := &slinkyv1beta1.Controller{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "slurm",
+			Namespace: corev1.NamespaceDefault,
+			Name:      "slurm",
 		},
 	}
 	const hash = "12345"
@@ -2683,7 +2684,7 @@ func TestNodeSetReconciler_syncUpdate(t *testing.T) {
 			nodeset.Spec.UpdateStrategy.Type = slinkyv1beta1.OnDeleteNodeSetStrategyType
 			pod1 := nodesetutils.NewNodeSetStatefulSetPod(fake.NewFakeClient(), nodeset, controller, 0, hash)
 			pod2 := nodesetutils.NewNodeSetStatefulSetPod(fake.NewFakeClient(), nodeset, controller, 1, "")
-			k8sclient := fake.NewFakeClient(nodeset, pod1, pod2)
+			k8sclient := fake.NewFakeClient(controller, nodeset, pod1, pod2)
 			slurmNodeList := &slurmtypes.V0044NodeList{
 				Items: []slurmtypes.V0044Node{
 					{
@@ -2724,7 +2725,7 @@ func TestNodeSetReconciler_syncUpdate(t *testing.T) {
 			}
 			pod1 := nodesetutils.NewNodeSetStatefulSetPod(fake.NewFakeClient(), nodeset, controller, 0, hash)
 			pod2 := nodesetutils.NewNodeSetStatefulSetPod(fake.NewFakeClient(), nodeset, controller, 1, "")
-			k8sclient := fake.NewFakeClient(nodeset, pod1, pod2)
+			k8sclient := fake.NewFakeClient(controller, nodeset, pod1, pod2)
 			slurmNodeList := &slurmtypes.V0044NodeList{
 				Items: []slurmtypes.V0044Node{
 					{
@@ -2767,7 +2768,7 @@ func TestNodeSetReconciler_syncUpdate(t *testing.T) {
 			}
 			pod1 := nodesetutils.NewNodeSetStatefulSetPod(fake.NewFakeClient(), nodeset, controller, 0, hash)
 			pod2 := nodesetutils.NewNodeSetStatefulSetPod(fake.NewFakeClient(), nodeset, controller, 1, "")
-			k8sclient := fake.NewFakeClient(nodeset, pod1, pod2)
+			k8sclient := fake.NewFakeClient(controller, nodeset, pod1, pod2)
 			slurmNodeList := &slurmtypes.V0044NodeList{
 				Items: []slurmtypes.V0044Node{
 					{


### PR DESCRIPTION
## Summary

- fingerprint the pod inputs used by `slurmd -Z` dynamic-node registration
- distinguish registration-sensitive NodeSet updates from ordinary pod-only updates
- persist pending node-record refreshes across reconciles and operator restarts
- wait until the old worker pod is absent or terminal before deleting its dynamic Slurm node record
- block replacement creation when record deletion fails, allowing Slurm reservation safety checks to remain authoritative

## Problem

NodeSet resource changes correctly roll worker pods and update values such as `POD_MEMORY`, but the replacement `slurmd` currently registers against the existing dynamic node record. Registration-derived fields such as `MemSpecLimit` can therefore remain stale until an administrator manually deletes both the Slurm node record and worker pod.

## Implementation

Worker pods now carry a hash covering registration-relevant inputs: `slurmd` arguments, `POD_CPUS`, `POD_MEMORY`, container and pod limits, and resource claims. Image and request-only changes are deliberately excluded.

When that hash changes, the NodeSet controller records the affected Slurm node name before starting the existing drain-aware rollout. After the old pod is gone or terminal, and thus cannot re-register, the controller deletes the stale dynamic node record. Normal reconciliation then creates the replacement pod, whose `slurmd -Z` registration creates a fresh record under the same stable node name.

If Slurm rejects deletion, for example because the node belongs to a reservation, the pending marker is retained and replacement creation is stopped until the deletion can succeed.

## Validation

- `make test` — passed, 74.9% total coverage
- focused worker-builder and NodeSet-controller tests with Kubernetes envtest — passed
- `go vet ./internal/builder/workerbuilder ./internal/controller/nodeset` — passed
- `golangci-lint run --new-from-rev upstream/main` — 0 issues

The new tests cover memory/config/device registration changes, image- and request-only changes, stop-before-delete ordering, marker cleanup, and deletion failure retention.
