### PR TITLE
fix(nodeset): delay deletion until job state is safe

### DIFF
--- a/api/v1beta1/well_known.go
+++ b/api/v1beta1/well_known.go
@@ -93,5 +93,6 @@ const (
 const (
 	// FinalizerNodeSetReservation
 	// NOTE: Set by the NodeSet controller.
-	FinalizerNodeSetReservation = NodeSetPrefix + "reservation"
+	FinalizerNodeSetReservation        = NodeSetPrefix + "reservation"
+	FinalizerNodeSetJobStateProtection = NodeSetPrefix + "job-state-protection"
 )

--- a/internal/builder/controllerbuilder/controller_config.go
+++ b/internal/builder/controllerbuilder/controller_config.go
@@ -14,6 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
 	"github.com/SlinkyProject/slurm-operator/internal/builder/common"
@@ -307,6 +308,10 @@ func buildNodeSetConf(nodesetList *slinkyv1beta1.NodeSetList) string {
 		return nodesetList.Items[i].Name < nodesetList.Items[j].Name
 	})
 	for _, nodeset := range nodesetList.Items {
+		if !shouldIncludeNodeSetInSlurmConf(nodeset) {
+			continue
+		}
+
 		name := common.GetSlurmNodeSetName(&nodeset)
 		nodesetLine := []string{
 			fmt.Sprintf("NodeSet=%v", name),
@@ -328,6 +333,17 @@ func buildNodeSetConf(nodesetList *slinkyv1beta1.NodeSetList) string {
 	}
 
 	return conf.WithFinalNewline(false).Build()
+}
+
+func shouldIncludeNodeSetInSlurmConf(nodeset slinkyv1beta1.NodeSet) bool {
+	if nodeset.DeletionTimestamp.IsZero() {
+		return true
+	}
+
+	return controllerutil.ContainsFinalizer(
+		&nodeset,
+		slinkyv1beta1.FinalizerNodeSetJobStateProtection,
+	)
 }
 
 // https://slurm.schedmd.com/cgroup.conf.html

--- a/internal/controller/nodeset/nodeset_sync.go
+++ b/internal/controller/nodeset/nodeset_sync.go
@@ -131,9 +131,45 @@ type SyncFinalizer struct {
 	Sync func(ctx context.Context, nodeset *slinkyv1beta1.NodeSet) error
 }
 
+func (r *NodeSetReconciler) syncJobStateProtectionFinalizer(
+	ctx context.Context,
+	nodeset *slinkyv1beta1.NodeSet,
+) error {
+	if nodeset.DeletionTimestamp.IsZero() {
+		if !controllerutil.ContainsFinalizer(nodeset, slinkyv1beta1.FinalizerNodeSetJobStateProtection) {
+			finalizers := slices.Concat(nodeset.Finalizers, []string{
+				slinkyv1beta1.FinalizerNodeSetJobStateProtection,
+			})
+			return r.updateNodeSetFinalizers(ctx, nodeset, finalizers)
+		}
+		return nil
+	}
+
+	safe, requeueAfter, err := r.slurmControl.IsNodeSetSafeToDelete(ctx, nodeset)
+	if err != nil {
+		return err
+	}
+
+	if !safe {
+		durationStore.Push(objectutils.KeyFunc(nodeset), requeueAfter)
+		return nil
+	}
+
+	current := set.New(nodeset.Finalizers...)
+	remove := set.New(slinkyv1beta1.FinalizerNodeSetJobStateProtection)
+	keep := current.Difference(remove).SortedList()
+	return r.updateNodeSetFinalizers(ctx, nodeset, keep)
+}
+
 // syncFinalizers implements control logic for synchronizing a NodeSet's finalizers
 func (r *NodeSetReconciler) syncFinalizers(ctx context.Context, nodeset *slinkyv1beta1.NodeSet) error {
 	syncSteps := []SyncFinalizer{
+		{
+			Name: "JobStateProtection",
+			Sync: func(ctx context.Context, nodeset *slinkyv1beta1.NodeSet) error {
+				return r.syncJobStateProtectionFinalizer(ctx, nodeset)
+			},
+		},
 		{
 			Name: "Reservation",
 			Sync: func(ctx context.Context, nodeset *slinkyv1beta1.NodeSet) error {

--- a/internal/controller/nodeset/nodeset_sync_test.go
+++ b/internal/controller/nodeset/nodeset_sync_test.go
@@ -382,6 +382,35 @@ func TestNodeSetReconciler_syncReservationFinalizer(t *testing.T) {
 	}
 }
 
+func TestNodeSetReconciler_syncJobStateProtectionFinalizer(t *testing.T) {
+	controller := &slinkyv1beta1.Controller{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: corev1.NamespaceDefault,
+			Name:      "slurm",
+		},
+	}
+
+	ctx := context.Background()
+
+	nodeset := newNodeSet("foo", controller.Name, 2)
+
+	client := fake.NewFakeClient(controller.DeepCopy(), nodeset.DeepCopy())
+	r := newNodeSetController(client, nil)
+
+	err := r.syncJobStateProtectionFinalizer(ctx, nodeset)
+	if err != nil {
+		t.Errorf("syncJobStateProtectionFinalizer() error = %v", err)
+		return
+	}
+
+	if !slices.Contains(nodeset.Finalizers, slinkyv1beta1.FinalizerNodeSetJobStateProtection) {
+		t.Errorf("expected %q finalizer to be added, got %v",
+			slinkyv1beta1.FinalizerNodeSetJobStateProtection,
+			nodeset.Finalizers,
+		)
+	}
+}
+
 func TestNodeSetReconciler_adoptOrphanRevisions(t *testing.T) {
 	controller := &slinkyv1beta1.Controller{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/controller/nodeset/slurmcontrol/slurmcontrol.go
+++ b/internal/controller/nodeset/slurmcontrol/slurmcontrol.go
@@ -77,11 +77,60 @@ type SlurmControlInterface interface {
 	GetDefunctNodesForNodeSet(ctx context.Context, nodeset *slinkyv1beta1.NodeSet) ([]DefunctNode, bool, error)
 	// DeleteNode deletes a Slurm node by name.
 	DeleteNode(ctx context.Context, nodeset *slinkyv1beta1.NodeSet, nodeName string) error
+	// IsNodeSetSafeToDelete reports whether a NodeSet can be safely deleted without leaving Slurm job state references.
+	IsNodeSetSafeToDelete(ctx context.Context, nodeset *slinkyv1beta1.NodeSet) (bool, time.Duration, error)
 }
 
 // realSlurmControl is the default implementation of SlurmControlInterface.
 type realSlurmControl struct {
 	clientMap *clientmap.ClientMap
+}
+
+const (
+	// defaultMinJobAge is the default wait time before a deleting NodeSet is considered safe to remove.
+	defaultMinJobAge = 5 * time.Minute
+
+	// nodeSetDeleteRetryAfter is the retry interval when NodeSet deletion is not yet safe.
+	nodeSetDeleteRetryAfter = 30 * time.Second
+)
+
+// IsNodeSetSafeToDelete reports whether a NodeSet can be safely removed from the Slurm configuration.
+func (r *realSlurmControl) IsNodeSetSafeToDelete(
+	ctx context.Context,
+	nodeset *slinkyv1beta1.NodeSet,
+) (bool, time.Duration, error) {
+	logger := log.FromContext(ctx)
+
+	slurmClient := r.lookupClient(nodeset)
+	if slurmClient == nil {
+		logger.V(2).Info("no client for nodeset, cannot do IsNodeSetSafeToDelete()")
+		return false, nodeSetDeleteRetryAfter, nil
+	}
+
+	partitionName := common.GetSlurmNodeSetName(nodeset)
+
+	jobList := &slurmtypes.V0044JobInfoList{}
+	if err := slurmClient.List(ctx, jobList); err != nil {
+		return false, nodeSetDeleteRetryAfter, err
+	}
+
+	for _, job := range jobList.Items {
+		if ptr.Deref(job.Partition, "") == partitionName {
+			return false, nodeSetDeleteRetryAfter, nil
+		}
+	}
+
+	if nodeset.DeletionTimestamp == nil {
+		return false, nodeSetDeleteRetryAfter, nil
+	}
+
+	now := time.Now()
+	waitUntil := nodeset.DeletionTimestamp.Time.Add(defaultMinJobAge)
+	if now.Before(waitUntil) {
+		return false, waitUntil.Sub(now), nil
+	}
+
+	return true, 0, nil
 }
 
 // RefreshNodeCache implements SlurmControlInterface.


### PR DESCRIPTION
## Summary

This PR introduces an initial implementation of NodeSet deletion protection for #138.

When a NodeSet is deleted, the operator now adds a job-state protection finalizer and delays removal until the NodeSet is considered safe to delete. While the protection finalizer is present, the terminating NodeSet remains in the generated `slurm.conf` to avoid removing partition definitions prematurely.

### Changes

* Add `FinalizerNodeSetJobStateProtection`
* Add `IsNodeSetSafeToDelete()` to the `SlurmControlInterface`
* Add job-state protection finalizer synchronization during NodeSet reconciliation
* Keep terminating NodeSets in the generated `slurm.conf` while the protection finalizer is present

Related to #138.

## Current behavior

```mermaid
flowchart TD
    A["kubectl delete NodeSet"] --> B["Operator removes NodeSet<br/>from generated slurm.conf"]
    B --> C["scontrol reconfigure"]
    C --> D["slurmctld restores job_state"]
    D --> E["Job still references deleted partition"]
    E --> F["SIGSEGV / CrashLoopBackOff"]
```

## Proposed behavior

```mermaid
flowchart TD
    A["kubectl delete NodeSet"] --> B["NodeSet enters Terminating"]
    B --> C["Job-state protection finalizer"]
    C --> D["IsNodeSetSafeToDelete()"]

    D -->|No| E["Keep NodeSet in generated slurm.conf"]
    E --> C

    D -->|Yes| F["Remove finalizer"]
    F --> G["Remove NodeSet from slurm.conf"]
    G --> H["scontrol reconfigure"]
```

## Checklist

* [x] I have read
  [[CONTRIBUTING.md](https://github.com/SlinkyProject/slurm-operator/blob/main/CONTRIBUTING.md)](https://github.com/SlinkyProject/slurm-operator/blob/main/CONTRIBUTING.md)
  and the
  [[Code of Conduct](https://github.com/SlinkyProject/slurm-operator/blob/main/CODE_OF_CONDUCT.md)](https://github.com/SlinkyProject/slurm-operator/blob/main/CODE_OF_CONDUCT.md).
* [x] New or existing tests cover these changes (where applicable).
* [ ] Documentation is updated if user-visible behavior changes.

## Breaking Changes

None.

## Testing Notes

```bash
make test
```

## Additional Context

This is an initial implementation intended to protect the NodeSet deletion path. Feedback on the deletion safety criteria and follow-up test coverage is welcome.