### PR TITLE
test: use testify/require in the controller package (p2)

### DIFF
--- a/internal/builder/common/common_test.go
+++ b/internal/builder/common/common_test.go
@@ -152,14 +152,10 @@ func TestCommonBuilder_GetContainerResourceLimits(t *testing.T) {
 	client := fake.NewFakeClient()
 
 	cpu1, err := resource.ParseQuantity("1")
-	if err != nil {
-		t.Fatalf("Failed to call resource.ParseQuantity")
-	}
+	require.NoError(t, err)
 
 	mem1g, err := resource.ParseQuantity("1Gi")
-	if err != nil {
-		t.Fatalf("Failed to call resource.ParseQuantity")
-	}
+	require.NoError(t, err)
 
 	tests := []struct {
 		name string // description of this test case
@@ -203,14 +199,10 @@ func TestCommonBuilder_GetPodResourceLimits(t *testing.T) {
 	client := fake.NewFakeClient()
 
 	cpu1, err := resource.ParseQuantity("1")
-	if err != nil {
-		t.Fatalf("Failed to call resource.ParseQuantity")
-	}
+	require.NoError(t, err)
 
 	mem1g, err := resource.ParseQuantity("1Gi")
-	if err != nil {
-		t.Fatalf("Failed to call resource.ParseQuantity")
-	}
+	require.NoError(t, err)
 
 	tests := []struct {
 		name  string // description of this test case

--- a/internal/builder/workerbuilder/worker_app_test.go
+++ b/internal/builder/workerbuilder/worker_app_test.go
@@ -5,7 +5,6 @@ package workerbuilder
 
 import (
 	_ "embed"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -363,15 +362,12 @@ func TestParseExtraConf(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got, err := ParseExtraConf(tc.input)
-			if (err != nil) != tc.wantErr {
-				t.Fatalf("ParseExtraConf() err = %v, wantErr = %v", err, tc.wantErr)
-			}
 			if tc.wantErr {
+				require.Error(t, err)
 				return
 			}
-			if !reflect.DeepEqual(got, tc.want) {
-				t.Errorf("ParseExtraConf() = %v, want %v", got, tc.want)
-			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
 		})
 	}
 }
@@ -449,9 +445,7 @@ func TestBaselineFeatures(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got := baselineFeatures(tc.nodesetFn())
-			if !reflect.DeepEqual(got, tc.want) {
-				t.Errorf("baselineFeatures() = %v, want %v", got, tc.want)
-			}
+			require.Equal(t, tc.want, got)
 		})
 	}
 }
@@ -517,9 +511,7 @@ func TestSlurmdConfArgs(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got := slurmdConfArgs(tc.nodeset)
-			if !reflect.DeepEqual(got, tc.want) {
-				t.Errorf("slurmdConfArgs() = %v, want %v", got, tc.want)
-			}
+			require.Equal(t, tc.want, got)
 		})
 	}
 }

--- a/internal/builder/workerbuilder/worker_app_test.go
+++ b/internal/builder/workerbuilder/worker_app_test.go
@@ -158,24 +158,16 @@ func TestWorkerBuilder_getResourceLimits(t *testing.T) {
 
 	// Create values to test resource requirements with
 	cpu1, err := resource.ParseQuantity("1")
-	if err != nil {
-		t.Fatalf("Failed to call resource.ParseQuantity")
-	}
+	require.NoError(t, err)
 
 	mem1g, err := resource.ParseQuantity("1Gi")
-	if err != nil {
-		t.Fatalf("Failed to call resource.ParseQuantity")
-	}
+	require.NoError(t, err)
 
 	cpu4, err := resource.ParseQuantity("4")
-	if err != nil {
-		t.Fatalf("Failed to call resource.ParseQuantity")
-	}
+	require.NoError(t, err)
 
 	mem2g, err := resource.ParseQuantity("2Gi")
-	if err != nil {
-		t.Fatalf("Failed to call resource.ParseQuantity")
-	}
+	require.NoError(t, err)
 
 	type limits struct {
 		cpu    int64

--- a/internal/controller/accounting/accounting_sync_test.go
+++ b/internal/controller/accounting/accounting_sync_test.go
@@ -16,6 +16,7 @@ import (
 	builder "github.com/SlinkyProject/slurm-operator/internal/builder/accountingbuilder"
 	"github.com/SlinkyProject/slurm-operator/internal/utils/refresolver"
 	"github.com/SlinkyProject/slurm-operator/internal/utils/testutils"
+	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -71,8 +72,12 @@ func TestAccountingReconciler_sync(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := newAccountingController(tt.fields.Client)
-			if err := r.Sync(tt.args.ctx, tt.args.request); (err != nil) != tt.wantErr {
-				t.Errorf("AccountingReconciler.sync() error = %v, wantErr %v", err, tt.wantErr)
+			err := r.Sync(tt.args.ctx, tt.args.request)
+
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 		})
 	}

--- a/internal/controller/accounting/eventhandler/eventhandler_accounting_test.go
+++ b/internal/controller/accounting/eventhandler/eventhandler_accounting_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/workqueue"
@@ -78,9 +79,7 @@ func Test_AccountingEventHandler_Create(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			e := NewAccountingEventHandler(tt.fields.client)
 			e.Create(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got > tt.want {
-				t.Errorf("Create() = %v, want %v", got, tt.want)
-			}
+			require.LessOrEqual(t, tt.args.q.Len(), tt.want)
 		})
 	}
 }
@@ -151,9 +150,7 @@ func Test_AccountingEventHandler_Update(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			e := NewAccountingEventHandler(tt.fields.client)
 			e.Update(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got > tt.want {
-				t.Errorf("Create() = %v, want %v", got, tt.want)
-			}
+			require.LessOrEqual(t, tt.args.q.Len(), tt.want)
 		})
 	}
 }
@@ -219,9 +216,7 @@ func Test_AccountingEventHandler_Delete(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			e := NewAccountingEventHandler(tt.fields.client)
 			e.Delete(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got > tt.want {
-				t.Errorf("Create() = %v, want %v", got, tt.want)
-			}
+			require.LessOrEqual(t, tt.args.q.Len(), tt.want)
 		})
 	}
 }
@@ -258,9 +253,7 @@ func Test_AccountingEventHandler_Generic(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			e := NewAccountingEventHandler(tt.fields.client)
 			e.Generic(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got > tt.want {
-				t.Errorf("Create() = %v, want %v", got, tt.want)
-			}
+			require.LessOrEqual(t, tt.args.q.Len(), tt.want)
 		})
 	}
 }

--- a/internal/controller/accounting/eventhandler/eventhandler_secret_test.go
+++ b/internal/controller/accounting/eventhandler/eventhandler_secret_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -85,9 +86,7 @@ func Test_SecretEventHandler_Create(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := NewSecretEventHandler(tt.fields.Reader)
 			h.Create(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got != tt.want {
-				t.Errorf("SecretEventHandler.Create() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, tt.args.q.Len())
 		})
 	}
 }
@@ -160,9 +159,7 @@ func Test_SecretEventHandler_Delete(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := NewSecretEventHandler(tt.fields.Reader)
 			h.Delete(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got != tt.want {
-				t.Errorf("SecretEventHandler.Delete() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, tt.args.q.Len())
 		})
 	}
 }
@@ -199,9 +196,7 @@ func Test_SecretEventHandler_Generic(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := NewSecretEventHandler(tt.fields.Reader)
 			h.Generic(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got != tt.want {
-				t.Errorf("SecretEventHandler.Generic() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, tt.args.q.Len())
 		})
 	}
 }
@@ -276,9 +271,7 @@ func Test_SecretEventHandler_Update(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := NewSecretEventHandler(tt.fields.Reader)
 			h.Update(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got != tt.want {
-				t.Errorf("SecretEventHandler.Update() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, tt.args.q.Len())
 		})
 	}
 }

--- a/internal/controller/controller/controller_sync_test.go
+++ b/internal/controller/controller/controller_sync_test.go
@@ -16,13 +16,13 @@ import (
 
 	clientfake "github.com/SlinkyProject/slurm-client/pkg/client/fake"
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-
 	builder "github.com/SlinkyProject/slurm-operator/internal/builder/controllerbuilder"
 	"github.com/SlinkyProject/slurm-operator/internal/clientmap"
 	"github.com/SlinkyProject/slurm-operator/internal/utils/refresolver"
+	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -93,8 +93,12 @@ func TestControllerReconciler_sync(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := newControllerController(tt.fields.Client, tt.fields.ClientMap)
-			if err := r.Sync(tt.args.ctx, tt.args.request); (err != nil) != tt.wantErr {
-				t.Errorf("ControllerReconciler.sync() error = %v, wantErr %v", err, tt.wantErr)
+			err := r.Sync(tt.args.ctx, tt.args.request)
+
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 		})
 	}

--- a/internal/controller/controller/eventhandler/eventhandler_accounting_test.go
+++ b/internal/controller/controller/eventhandler/eventhandler_accounting_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/workqueue"
@@ -78,9 +79,7 @@ func Test_AccountingEventHandler_Create(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			e := NewAccountingEventHandler(tt.fields.client)
 			e.Create(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got > tt.want {
-				t.Errorf("Create() = %v, want %v", got, tt.want)
-			}
+			require.LessOrEqual(t, tt.args.q.Len(), tt.want)
 		})
 	}
 }
@@ -151,9 +150,7 @@ func Test_AccountingEventHandler_Update(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			e := NewAccountingEventHandler(tt.fields.client)
 			e.Update(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got > tt.want {
-				t.Errorf("Create() = %v, want %v", got, tt.want)
-			}
+			require.LessOrEqual(t, tt.args.q.Len(), tt.want)
 		})
 	}
 }
@@ -219,9 +216,7 @@ func Test_AccountingEventHandler_Delete(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			e := NewAccountingEventHandler(tt.fields.client)
 			e.Delete(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got > tt.want {
-				t.Errorf("Create() = %v, want %v", got, tt.want)
-			}
+			require.LessOrEqual(t, tt.args.q.Len(), tt.want)
 		})
 	}
 }
@@ -258,9 +253,7 @@ func Test_AccountingEventHandler_Generic(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			e := NewAccountingEventHandler(tt.fields.client)
 			e.Generic(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got > tt.want {
-				t.Errorf("Create() = %v, want %v", got, tt.want)
-			}
+			require.LessOrEqual(t, tt.args.q.Len(), tt.want)
 		})
 	}
 }

--- a/internal/controller/controller/eventhandler/eventhandler_nodeset_test.go
+++ b/internal/controller/controller/eventhandler/eventhandler_nodeset_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/util/workqueue"
@@ -61,9 +62,7 @@ func Test_NodeSetEventHandler_Create(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := NewNodeSetEventHandler(tt.fields.Reader)
 			h.Create(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got != tt.want {
-				t.Errorf("NodeSetEventHandler.Create() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, tt.args.q.Len())
 		})
 	}
 }
@@ -110,9 +109,7 @@ func Test_NodeSetEventHandler_Delete(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := NewNodeSetEventHandler(tt.fields.Reader)
 			h.Delete(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got != tt.want {
-				t.Errorf("NodeSetEventHandler.Delete() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, tt.args.q.Len())
 		})
 	}
 }
@@ -150,9 +147,7 @@ func Test_NodeSetEventHandler_Generic(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := NewNodeSetEventHandler(tt.fields.Reader)
 			h.Generic(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got != tt.want {
-				t.Errorf("NodeSetEventHandler.Generic() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, tt.args.q.Len())
 		})
 	}
 }
@@ -200,9 +195,7 @@ func Test_NodeSetEventHandler_Update(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := NewNodeSetEventHandler(tt.fields.Reader)
 			h.Update(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got != tt.want {
-				t.Errorf("NodeSetEventHandler.Update() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, tt.args.q.Len())
 		})
 	}
 }

--- a/internal/controller/controller/eventhandler/eventhandler_secret_test.go
+++ b/internal/controller/controller/eventhandler/eventhandler_secret_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -80,9 +81,7 @@ func Test_SecretEventHandler_Create(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := NewSecretEventHandler(tt.fields.Reader)
 			h.Create(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got != tt.want {
-				t.Errorf("SecretEventHandler.Create() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, tt.args.q.Len())
 		})
 	}
 }
@@ -150,9 +149,7 @@ func Test_SecretEventHandler_Delete(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := NewSecretEventHandler(tt.fields.Reader)
 			h.Delete(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got != tt.want {
-				t.Errorf("SecretEventHandler.Delete() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, tt.args.q.Len())
 		})
 	}
 }
@@ -189,9 +186,7 @@ func Test_SecretEventHandler_Generic(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := NewSecretEventHandler(tt.fields.Reader)
 			h.Generic(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got != tt.want {
-				t.Errorf("SecretEventHandler.Generic() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, tt.args.q.Len())
 		})
 	}
 }
@@ -261,9 +256,7 @@ func Test_SecretEventHandler_Update(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := NewSecretEventHandler(tt.fields.Reader)
 			h.Update(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got != tt.want {
-				t.Errorf("SecretEventHandler.Update() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, tt.args.q.Len())
 		})
 	}
 }

--- a/internal/controller/loginset/eventhandler/eventhandler_loginset_test.go
+++ b/internal/controller/loginset/eventhandler/eventhandler_loginset_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/workqueue"
@@ -78,9 +79,7 @@ func Test_ControllerEventHandler_Create(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			e := NewControllerEventHandler(tt.fields.client)
 			e.Create(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got > tt.want {
-				t.Errorf("Create() = %v, want %v", got, tt.want)
-			}
+			require.LessOrEqual(t, tt.args.q.Len(), tt.want)
 		})
 	}
 }
@@ -151,9 +150,7 @@ func Test_ControllerEventHandler_Update(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			e := NewControllerEventHandler(tt.fields.client)
 			e.Update(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got > tt.want {
-				t.Errorf("Create() = %v, want %v", got, tt.want)
-			}
+			require.LessOrEqual(t, tt.args.q.Len(), tt.want)
 		})
 	}
 }
@@ -219,9 +216,7 @@ func Test_ControllerEventHandler_Delete(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			e := NewControllerEventHandler(tt.fields.client)
 			e.Delete(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got > tt.want {
-				t.Errorf("Create() = %v, want %v", got, tt.want)
-			}
+			require.LessOrEqual(t, tt.args.q.Len(), tt.want)
 		})
 	}
 }
@@ -258,9 +253,7 @@ func Test_ControllerEventHandler_Generic(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			e := NewControllerEventHandler(tt.fields.client)
 			e.Generic(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got > tt.want {
-				t.Errorf("Create() = %v, want %v", got, tt.want)
-			}
+			require.LessOrEqual(t, tt.args.q.Len(), tt.want)
 		})
 	}
 }

--- a/internal/controller/loginset/eventhandler/eventhandler_secret_test.go
+++ b/internal/controller/loginset/eventhandler/eventhandler_secret_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -105,9 +106,7 @@ func Test_SecretEventHandler_Create(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := NewSecretEventHandler(tt.fields.Reader)
 			h.Create(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got != tt.want {
-				t.Errorf("SecretEventHandler.Create() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, tt.args.q.Len())
 		})
 	}
 }
@@ -200,9 +199,7 @@ func Test_SecretEventHandler_Delete(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := NewSecretEventHandler(tt.fields.Reader)
 			h.Delete(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got != tt.want {
-				t.Errorf("SecretEventHandler.Delete() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, tt.args.q.Len())
 		})
 	}
 }
@@ -239,9 +236,7 @@ func Test_SecretEventHandler_Generic(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := NewSecretEventHandler(tt.fields.Reader)
 			h.Generic(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got != tt.want {
-				t.Errorf("SecretEventHandler.Generic() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, tt.args.q.Len())
 		})
 	}
 }
@@ -337,9 +332,7 @@ func Test_SecretEventHandler_Update(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := NewSecretEventHandler(tt.fields.Reader)
 			h.Update(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got != tt.want {
-				t.Errorf("SecretEventHandler.Update() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, tt.args.q.Len())
 		})
 	}
 }

--- a/internal/controller/loginset/loginset_sync_test.go
+++ b/internal/controller/loginset/loginset_sync_test.go
@@ -16,6 +16,7 @@ import (
 	builder "github.com/SlinkyProject/slurm-operator/internal/builder/loginbuilder"
 	"github.com/SlinkyProject/slurm-operator/internal/utils/refresolver"
 	"github.com/SlinkyProject/slurm-operator/internal/utils/testutils"
+	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -72,9 +73,14 @@ func TestLoginsetReconciler_sync(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := newLoginsetController(tt.fields.Client)
-			if err := r.Sync(tt.args.ctx, tt.args.request); (err != nil) != tt.wantErr {
-				t.Errorf("LoginReconciler.sync() error = %v, wantErr %v", err, tt.wantErr)
+			err := r.Sync(tt.args.ctx, tt.args.request)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
 			}
+
+			require.NoError(t, err)
 		})
 	}
 }

--- a/internal/controller/nodeset/eventhandler/eventhandler_controller_test.go
+++ b/internal/controller/nodeset/eventhandler/eventhandler_controller_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -117,9 +118,7 @@ func Test_ControllerEventHandler_Create(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := NewControllerEventHandler(tt.fields.Reader)
 			h.Create(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got != tt.want {
-				t.Errorf("ControllerEventHandler.Create() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, tt.args.q.Len())
 		})
 	}
 }
@@ -225,9 +224,7 @@ func Test_ControllerEventHandler_Delete(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := NewControllerEventHandler(tt.fields.Reader)
 			h.Delete(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got != tt.want {
-				t.Errorf("ControllerEventHandler.Delete() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, tt.args.q.Len())
 		})
 	}
 }
@@ -264,9 +261,7 @@ func Test_ControllerEventHandler_Generic(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := NewControllerEventHandler(tt.fields.Reader)
 			h.Generic(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got != tt.want {
-				t.Errorf("ControllerEventHandler.Generic() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, tt.args.q.Len())
 		})
 	}
 }
@@ -376,9 +371,7 @@ func Test_ControllerEventHandler_Update(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := NewControllerEventHandler(tt.fields.Reader)
 			h.Update(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got != tt.want {
-				t.Errorf("ControllerEventHandler.Update() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, tt.args.q.Len())
 		})
 	}
 }

--- a/internal/controller/nodeset/eventhandler/eventhandler_node_test.go
+++ b/internal/controller/nodeset/eventhandler/eventhandler_node_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/workqueue"
@@ -52,9 +53,7 @@ func Test_NodeEventHandler_Create(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := NewNodeEventHandler(tt.fields.Reader)
 			h.Create(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got != tt.want {
-				t.Errorf("NodeEventHandler.Create() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, tt.args.q.Len())
 		})
 	}
 }
@@ -91,9 +90,7 @@ func Test_NodeEventHandler_Delete(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := NewNodeEventHandler(tt.fields.Reader)
 			h.Delete(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got != tt.want {
-				t.Errorf("NodeEventHandler.Delete() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, tt.args.q.Len())
 		})
 	}
 }
@@ -130,9 +127,7 @@ func Test_NodeEventHandler_Generic(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := NewNodeEventHandler(tt.fields.Reader)
 			h.Generic(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got != tt.want {
-				t.Errorf("NodeEventHandler.Generic() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, tt.args.q.Len())
 		})
 	}
 }
@@ -226,9 +221,7 @@ func Test_NodeEventHandler_Update(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := NewNodeEventHandler(tt.fields.Reader)
 			h.Update(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got != tt.want {
-				t.Errorf("NodeEventHandler.Update() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, tt.args.q.Len())
 		})
 	}
 }

--- a/internal/controller/nodeset/eventhandler/eventhandler_pod_test.go
+++ b/internal/controller/nodeset/eventhandler/eventhandler_pod_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/workqueue"
@@ -69,9 +70,7 @@ func Test_PodEventHandler_Create(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := NewPodEventHandler(tt.fields.Reader, tt.fields.expectations)
 			h.Create(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got > tt.want {
-				t.Errorf("Create() = %v, want %v", got, tt.want)
-			}
+			require.LessOrEqual(t, tt.args.q.Len(), tt.want)
 		})
 	}
 }
@@ -128,9 +127,7 @@ func Test_PodEventHandler_Delete(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := NewPodEventHandler(tt.fields.Reader, tt.fields.expectations)
 			h.Delete(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got > tt.want {
-				t.Errorf("Delete() = %v, want %v", got, tt.want)
-			}
+			require.LessOrEqual(t, tt.args.q.Len(), tt.want)
 		})
 	}
 }
@@ -187,9 +184,7 @@ func Test_PodEventHandler_Generic(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := NewPodEventHandler(tt.fields.Reader, tt.fields.expectations)
 			h.Generic(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got > tt.want {
-				t.Errorf("Generic() = %v, want %v", got, tt.want)
-			}
+			require.LessOrEqual(t, tt.args.q.Len(), tt.want)
 		})
 	}
 }
@@ -252,9 +247,7 @@ func Test_PodEventHandler_Update(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := NewPodEventHandler(tt.fields.Reader, tt.fields.expectations)
 			h.Update(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got > tt.want {
-				t.Errorf("Update() = %v, want %v", got, tt.want)
-			}
+			require.LessOrEqual(t, tt.args.q.Len(), tt.want)
 		})
 	}
 }

--- a/internal/controller/nodeset/eventhandler/eventhandler_secret_test.go
+++ b/internal/controller/nodeset/eventhandler/eventhandler_secret_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -81,9 +82,7 @@ func Test_SecretEventHandler_Create(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := NewSecretEventHandler(tt.fields.Reader)
 			h.Create(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got != tt.want {
-				t.Errorf("SecretEventHandler.Create() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, tt.args.q.Len())
 		})
 	}
 }
@@ -152,9 +151,7 @@ func Test_SecretEventHandler_Delete(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := NewSecretEventHandler(tt.fields.Reader)
 			h.Delete(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got != tt.want {
-				t.Errorf("SecretEventHandler.Delete() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, tt.args.q.Len())
 		})
 	}
 }
@@ -191,9 +188,7 @@ func Test_SecretEventHandler_Generic(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := NewSecretEventHandler(tt.fields.Reader)
 			h.Generic(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got != tt.want {
-				t.Errorf("SecretEventHandler.Generic() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, tt.args.q.Len())
 		})
 	}
 }
@@ -264,9 +259,7 @@ func Test_SecretEventHandler_Update(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := NewSecretEventHandler(tt.fields.Reader)
 			h.Update(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got != tt.want {
-				t.Errorf("SecretEventHandler.Update() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, tt.args.q.Len())
 		})
 	}
 }

--- a/internal/controller/nodeset/indexes/indexes_test.go
+++ b/internal/controller/nodeset/indexes/indexes_test.go
@@ -42,9 +42,7 @@ func Test_getPodNodeName(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := getPodNodeName(tt.o)
-			if !apiequality.Semantic.DeepEqual(got, tt.want) {
-				t.Errorf("getPodNodeName() = %v, want %v", got, tt.want)
-			}
+			require.True(t, apiequality.Semantic.DeepEqual(got, tt.want), "getPodNodeName() = %v, want %v", got, tt.want)
 		})
 	}
 }

--- a/internal/controller/nodeset/indexes/indexes_test.go
+++ b/internal/controller/nodeset/indexes/indexes_test.go
@@ -9,6 +9,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/stretchr/testify/require"
 )
 
 func Test_getPodNodeName(t *testing.T) {
@@ -58,9 +60,7 @@ func TestNewFakeClientBuilderWithIndexes(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := NewFakeClientBuilderWithIndexes()
-			if got == nil {
-				t.Errorf("NewFakeClientBuilderWithIndexes() = %v", got)
-			}
+			require.NotNil(t, got)
 		})
 	}
 }

--- a/internal/controller/nodeset/nodeset_history_test.go
+++ b/internal/controller/nodeset/nodeset_history_test.go
@@ -18,6 +18,7 @@ import (
 
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
 	"github.com/SlinkyProject/slurm-operator/internal/utils/structutils"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNodeSetReconciler_truncateHistory(t *testing.T) {
@@ -134,9 +135,14 @@ func TestNodeSetReconciler_truncateHistory(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := newNodeSetController(tt.fields.Client, nil)
-			if err := r.truncateHistory(tt.args.ctx, tt.args.nodeset, tt.args.revisions, tt.args.current, tt.args.update); (err != nil) != tt.wantErr {
-				t.Errorf("NodeSetReconciler.truncateHistory() error = %v, wantErr %v", err, tt.wantErr)
+			err := r.truncateHistory(tt.args.ctx, tt.args.nodeset, tt.args.revisions, tt.args.current, tt.args.update)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
 			}
+
+			require.NoError(t, err)
 		})
 	}
 }
@@ -251,9 +257,10 @@ func TestNodeSetReconciler_getNodeSetRevisions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := newNodeSetController(tt.fields.Client, nil)
 			got, got1, got2, err := r.getNodeSetRevisions(tt.args.nodeset, tt.args.revisions)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("NodeSetReconciler.getNodeSetRevisions() error = %v, wantErr %v", err, tt.wantErr)
-				return
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 			if !apiequality.Semantic.DeepEqual(got, tt.want) {
 				t.Errorf("NodeSetReconciler.getNodeSetRevisions() got = %v, want %v", got, tt.want)
@@ -261,9 +268,7 @@ func TestNodeSetReconciler_getNodeSetRevisions(t *testing.T) {
 			if !apiequality.Semantic.DeepEqual(got1, tt.want1) {
 				t.Errorf("NodeSetReconciler.getNodeSetRevisions() got1 = %v, want %v", got1, tt.want1)
 			}
-			if got2 != tt.want2 {
-				t.Errorf("NodeSetReconciler.getNodeSetRevisions() got2 = %v, want %v", got2, tt.want2)
-			}
+			require.Equal(t, tt.want2, got2)
 		})
 	}
 }

--- a/internal/controller/nodeset/nodeset_history_test.go
+++ b/internal/controller/nodeset/nodeset_history_test.go
@@ -262,12 +262,8 @@ func TestNodeSetReconciler_getNodeSetRevisions(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
-			if !apiequality.Semantic.DeepEqual(got, tt.want) {
-				t.Errorf("NodeSetReconciler.getNodeSetRevisions() got = %v, want %v", got, tt.want)
-			}
-			if !apiequality.Semantic.DeepEqual(got1, tt.want1) {
-				t.Errorf("NodeSetReconciler.getNodeSetRevisions() got1 = %v, want %v", got1, tt.want1)
-			}
+			require.True(t, apiequality.Semantic.DeepEqual(got, tt.want), "NodeSetReconciler.getNodeSetRevisions() got = %v, want %v", got, tt.want)
+			require.True(t, apiequality.Semantic.DeepEqual(got1, tt.want1), "NodeSetReconciler.getNodeSetRevisions() got1 = %v, want %v", got1, tt.want1)
 			require.Equal(t, tt.want2, got2)
 		})
 	}

--- a/internal/controller/nodeset/nodeset_sync_status_test.go
+++ b/internal/controller/nodeset/nodeset_sync_status_test.go
@@ -33,6 +33,7 @@ import (
 	nodesetutils "github.com/SlinkyProject/slurm-operator/internal/controller/nodeset/utils"
 	"github.com/SlinkyProject/slurm-operator/internal/utils/structutils"
 	slurmconditions "github.com/SlinkyProject/slurm-operator/pkg/conditions"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNodeSetReconciler_syncStatus(t *testing.T) {
@@ -167,9 +168,13 @@ func TestNodeSetReconciler_syncStatus(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := newNodeSetController(tt.fields.Client, tt.fields.ClientMap)
-			if err := r.syncStatus(tt.args.ctx, tt.args.nodeset, tt.args.pods, tt.args.currentRevision, tt.args.updateRevision, tt.args.collisionCount, tt.args.hash, tt.args.errors...); (err != nil) != tt.wantErr {
-				t.Errorf("NodeSetReconciler.syncStatus() error = %v, wantErr %v", err, tt.wantErr)
+			err := r.syncStatus(tt.args.ctx, tt.args.nodeset, tt.args.pods, tt.args.currentRevision, tt.args.updateRevision, tt.args.collisionCount, tt.args.hash, tt.args.errors...)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
 			}
+
+			require.NoError(t, err)
 		})
 	}
 }
@@ -239,9 +244,13 @@ func TestNodeSetReconciler_syncSlurmStatus(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := newNodeSetController(tt.fields.Client, tt.fields.ClientMap)
-			if err := r.syncSlurmStatus(tt.args.ctx, tt.args.nodeset, tt.args.pods); (err != nil) != tt.wantErr {
-				t.Errorf("NodeSetReconciler.syncSlurmStatus() error = %v, wantErr %v", err, tt.wantErr)
+			err := r.syncSlurmStatus(tt.args.ctx, tt.args.nodeset, tt.args.pods)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
 			}
+
+			require.NoError(t, err)
 		})
 	}
 }
@@ -397,15 +406,16 @@ func TestNodeSetReconciler_syncNodeSetStatus(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := newNodeSetController(tt.fields.Client, tt.fields.ClientMap)
-			if err := r.syncNodeSetStatus(tt.args.ctx, tt.args.nodeset, tt.args.pods, tt.args.currentRevision, tt.args.updateRevision, tt.args.collisionCount, tt.args.hash); (err != nil) != tt.wantErr {
-				t.Errorf("NodeSetReconciler.syncNodeSetStatus() error = %v, wantErr %v", err, tt.wantErr)
+			err := r.syncNodeSetStatus(tt.args.ctx, tt.args.nodeset, tt.args.pods, tt.args.currentRevision, tt.args.updateRevision, tt.args.collisionCount, tt.args.hash)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 			got := &slinkyv1beta1.NodeSet{}
 			key := client.ObjectKeyFromObject(tt.args.nodeset)
 			if err := r.Get(tt.args.ctx, key, got); err == nil {
-				if diff := cmp.Diff(tt.wantStatus, &got.Status); diff != "" {
-					t.Errorf("unexpected status (-want,+got):\n%s", diff)
-				}
+				require.Equal(t, tt.wantStatus, &got.Status)
 			}
 		})
 	}
@@ -537,16 +547,14 @@ func TestNodeSetReconciler_calculateReplicaStatus(t *testing.T) {
 			}
 			r := newNodeSetController(c, nil)
 			got, err := r.calculateReplicaStatus(context.TODO(), tt.args.nodeset, tt.args.pods, tt.args.currentRevision, tt.args.updateRevision)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("NodeSetReconciler.calculateReplicaStatus() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
+
 			if tt.wantErr {
+				require.Error(t, err)
 				return
 			}
-			if diff := cmp.Diff(tt.want, got); diff != "" {
-				t.Errorf("unexpected status (-want,+got):\n%s", diff)
-			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -658,15 +666,13 @@ func Test_applySlurmPodConditions(t *testing.T) {
 			applySlurmPodConditions(status, tt.desired)
 
 			gotSlurm := slurmPodConditions(status)
-			if diff := cmp.Diff(tt.wantSlurm, gotSlurm, cmpOpts); diff != "" {
-				t.Errorf("unexpected slurm conditions (-want,+got):\n%s", diff)
-			}
+			diff := cmp.Diff(tt.wantSlurm, gotSlurm, cmpOpts)
+			require.Empty(t, diff)
 
 			if tt.wantNonSlurmOnly {
 				gotNonSlurm := nonSlurmPodConditions(status)
-				if diff := cmp.Diff(tt.wantNonSlurm, gotNonSlurm, cmpOpts); diff != "" {
-					t.Errorf("unexpected non-slurm conditions (-want,+got):\n%s", diff)
-				}
+				diff := cmp.Diff(tt.wantNonSlurm, gotNonSlurm, cmpOpts)
+				require.Empty(t, diff)
 			}
 		})
 	}
@@ -796,16 +802,12 @@ func TestNodeSetReconciler_calculateReservationCondition(t *testing.T) {
 			r.slurmControl = slurmcontrol.NewSlurmControl(newSlurmClientMap(tt.nodeset.Spec.ControllerRef.Name, tt.slurmclient))
 
 			got, err := r.calculateReservationCondition(context.TODO(), tt.nodeset, tt.nodeset.Status.Conditions)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("NodeSetReconciler.calculateReservationCondition() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
 			if tt.wantErr {
+				require.Error(t, err)
 				return
 			}
-			if diff := cmp.Diff(tt.want, got); diff != "" {
-				t.Errorf("unexpected status (-want,+got):\n%s", diff)
-			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -1125,15 +1127,16 @@ func TestNodeSetReconciler_updateNodeSetStatus(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := newNodeSetController(tt.fields.Client, nil)
-			if err := r.updateNodeSetStatus(tt.args.ctx, tt.args.nodeset, tt.args.newStatus); (err != nil) != tt.wantErr {
-				t.Errorf("NodeSetReconciler.updateNodeSetStatus() error = %v, wantErr %v", err, tt.wantErr)
+			err := r.updateNodeSetStatus(tt.args.ctx, tt.args.nodeset, tt.args.newStatus)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 			got := &slinkyv1beta1.NodeSet{}
 			key := client.ObjectKeyFromObject(tt.args.nodeset)
 			if err := r.Get(tt.args.ctx, key, got); err == nil {
-				if diff := cmp.Diff(tt.args.newStatus, &got.Status); diff != "" {
-					t.Errorf("unexpected status (-want,+got):\n%s", diff)
-				}
+				require.Equal(t, tt.args.newStatus, &got.Status)
 			}
 		})
 	}
@@ -1349,8 +1352,10 @@ func Test_calculateOrdinalToNode(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := newNodeSetController(tt.client, nil)
 			got, err := r.calculateOrdinalToNode(context.TODO(), tt.args.nodeset, tt.args.pods)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("NodeSetReconciler.calculateNodeToOrdinal() error = %v, wantErr %v", err, tt.wantErr)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 			if diff := cmp.Diff(tt.want, got); !apiequality.Semantic.DeepEqual(got, tt.want) && diff != "" {
 				t.Errorf("NodeSetReconciler.calculateNodeToOrdinal() mismatch (-want +got):\n%s", diff)

--- a/internal/controller/nodeset/nodeset_sync_status_test.go
+++ b/internal/controller/nodeset/nodeset_sync_status_test.go
@@ -1018,17 +1018,12 @@ func TestNodeSetReconciler_updateNodeSetPodConditions(t *testing.T) {
 				Client: tt.fields.Client,
 			}
 			err := r.updateNodeSetPodConditions(tt.args.ctx, tt.args.pods, tt.args.nodeStatus)
-			if !errors.Is(err, tt.wantErr) {
-				t.Errorf("NodeSetReconciler.updateNodeSetPodConditions() error = %v, wantErr %v", err, tt.wantErr)
-			}
+			require.ErrorIs(t, err, tt.wantErr)
 			for key, ns := range tt.args.nodeStatus.NodeStates {
 				// Verify the correct conditions are present in the correct pod
 				pod := &corev1.Pod{}
 				err = r.Get(tt.args.ctx, client.ObjectKey{Name: key, Namespace: "default"}, pod)
-				if err != nil {
-					t.Errorf("NodeSetReconciler.updateNodeSetPodConditions() error = %v", err)
-					return
-				}
+				require.NoError(t, err)
 				var slurmCondCount int
 				for _, condition := range pod.Status.Conditions {
 					if strings.HasPrefix(string(condition.Type), slurmconditions.PodStatePrefix) {
@@ -1040,16 +1035,10 @@ func TestNodeSetReconciler_updateNodeSetPodConditions(t *testing.T) {
 								found = true
 							}
 						}
-						if !found {
-							t.Errorf(`NodeSetReconciler.updateNodeSetPodConditions() could not find a pod (%v) condition
-							as a Slurm node state (%v)`, condition, ns)
-						}
+						require.True(t, found, "NodeSetReconciler.updateNodeSetPodConditions() could not find a pod (%v) condition as a Slurm node state (%v)", condition, ns)
 					}
 				}
-				if slurmCondCount != len(ns) {
-					t.Errorf("NodeSetReconciler.updateNodeSetPodConditions() SlurmNodeState condition count = %d, want %d",
-						slurmCondCount, len(ns))
-				}
+				require.Equal(t, len(ns), slurmCondCount, "NodeSetReconciler.updateNodeSetPodConditions() SlurmNodeState condition count = %d, want %d", slurmCondCount, len(ns))
 			}
 		})
 	}
@@ -1357,9 +1346,7 @@ func Test_calculateOrdinalToNode(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
-			if diff := cmp.Diff(tt.want, got); !apiequality.Semantic.DeepEqual(got, tt.want) && diff != "" {
-				t.Errorf("NodeSetReconciler.calculateNodeToOrdinal() mismatch (-want +got):\n%s", diff)
-			}
+			require.True(t, apiequality.Semantic.DeepEqual(got, tt.want), "NodeSetReconciler.calculateNodeToOrdinal() mismatch (-want +got):\n%s", cmp.Diff(tt.want, got))
 		})
 	}
 }

--- a/internal/controller/nodeset/nodeset_sync_test.go
+++ b/internal/controller/nodeset/nodeset_sync_test.go
@@ -1157,8 +1157,8 @@ func TestNodeSetReconciler_processCondemned(t *testing.T) {
 				Items: []slurmtypes.V0044Node{
 					{
 						V0044Node: slurmapi.V0044Node{
-							Name:  new(nodesetutils.GetSlurmNodeName(pods[0])),
-							State: new([]slurmapi.V0044NodeState{slurmapi.V0044NodeStateIDLE}),
+							Name:  ptr.To(nodesetutils.GetSlurmNodeName(pods[0])),
+							State: ptr.To([]slurmapi.V0044NodeState{slurmapi.V0044NodeStateIDLE}),
 						},
 					},
 				},
@@ -1211,8 +1211,8 @@ func TestNodeSetReconciler_processCondemned(t *testing.T) {
 				Items: []slurmtypes.V0044Node{
 					{
 						V0044Node: slurmapi.V0044Node{
-							Name:  new(nodesetutils.GetSlurmNodeName(pods[0])),
-							State: new([]slurmapi.V0044NodeState{slurmapi.V0044NodeStateALLOCATED}),
+							Name:  ptr.To(nodesetutils.GetSlurmNodeName(pods[0])),
+							State: ptr.To([]slurmapi.V0044NodeState{slurmapi.V0044NodeStateALLOCATED}),
 						},
 					},
 				},
@@ -1438,8 +1438,8 @@ func TestNodeSetReconciler_syncCordon(t *testing.T) {
 				Items: []slurmtypes.V0044Node{
 					{
 						V0044Node: slurmapi.V0044Node{
-							Name:  new(slurmNodeName),
-							State: new([]slurmapi.V0044NodeState{slurmapi.V0044NodeStateIDLE}),
+							Name:  ptr.To(slurmNodeName),
+							State: ptr.To([]slurmapi.V0044NodeState{slurmapi.V0044NodeStateIDLE}),
 						},
 					},
 				},
@@ -1464,8 +1464,8 @@ func TestNodeSetReconciler_syncCordon(t *testing.T) {
 				Items: []slurmtypes.V0044Node{
 					{
 						V0044Node: slurmapi.V0044Node{
-							Name:  new(slurmNodeName),
-							State: new([]slurmapi.V0044NodeState{slurmapi.V0044NodeStateIDLE}),
+							Name:  ptr.To(slurmNodeName),
+							State: ptr.To([]slurmapi.V0044NodeState{slurmapi.V0044NodeStateIDLE}),
 						},
 					},
 				},
@@ -1485,8 +1485,8 @@ func TestNodeSetReconciler_syncCordon(t *testing.T) {
 				Items: []slurmtypes.V0044Node{
 					{
 						V0044Node: slurmapi.V0044Node{
-							Name:  new(slurmNodeName),
-							State: new([]slurmapi.V0044NodeState{slurmapi.V0044NodeStateIDLE}),
+							Name:  ptr.To(slurmNodeName),
+							State: ptr.To([]slurmapi.V0044NodeState{slurmapi.V0044NodeStateIDLE}),
 						},
 					},
 				},
@@ -1505,8 +1505,8 @@ func TestNodeSetReconciler_syncCordon(t *testing.T) {
 				Items: []slurmtypes.V0044Node{
 					{
 						V0044Node: slurmapi.V0044Node{
-							Name: new(slurmNodeName),
-							State: new([]slurmapi.V0044NodeState{
+							Name: ptr.To(slurmNodeName),
+							State: ptr.To([]slurmapi.V0044NodeState{
 								slurmapi.V0044NodeStateIDLE,
 								slurmapi.V0044NodeStateDRAIN,
 							}),
@@ -1528,9 +1528,9 @@ func TestNodeSetReconciler_syncCordon(t *testing.T) {
 				Items: []slurmtypes.V0044Node{
 					{
 						V0044Node: slurmapi.V0044Node{
-							Name:   new(slurmNodeName),
-							State:  new([]slurmapi.V0044NodeState{slurmapi.V0044NodeStateIDLE}),
-							Reason: new("manual operator drain outside slurm-operator"),
+							Name:   ptr.To(slurmNodeName),
+							State:  ptr.To([]slurmapi.V0044NodeState{slurmapi.V0044NodeStateIDLE}),
+							Reason: ptr.To("manual operator drain outside slurm-operator"),
 						},
 					},
 				},
@@ -1549,9 +1549,9 @@ func TestNodeSetReconciler_syncCordon(t *testing.T) {
 				Items: []slurmtypes.V0044Node{
 					{
 						V0044Node: slurmapi.V0044Node{
-							Name:   new(slurmNodeName),
-							State:  new([]slurmapi.V0044NodeState{slurmapi.V0044NodeStateDOWN}),
-							Reason: new("Not responding to ping"),
+							Name:   ptr.To(slurmNodeName),
+							State:  ptr.To([]slurmapi.V0044NodeState{slurmapi.V0044NodeStateDOWN}),
+							Reason: ptr.To("Not responding to ping"),
 						},
 					},
 				},
@@ -1580,8 +1580,8 @@ func TestNodeSetReconciler_syncCordon(t *testing.T) {
 				Items: []slurmtypes.V0044Node{
 					{
 						V0044Node: slurmapi.V0044Node{
-							Name:  new(slurmNodeName),
-							State: new([]slurmapi.V0044NodeState{slurmapi.V0044NodeStateIDLE}),
+							Name:  ptr.To(slurmNodeName),
+							State: ptr.To([]slurmapi.V0044NodeState{slurmapi.V0044NodeStateIDLE}),
 						},
 					},
 				},
@@ -1618,8 +1618,8 @@ func TestNodeSetReconciler_syncCordon(t *testing.T) {
 				Items: []slurmtypes.V0044Node{
 					{
 						V0044Node: slurmapi.V0044Node{
-							Name:  new(slurmNodeName),
-							State: new([]slurmapi.V0044NodeState{slurmapi.V0044NodeStateIDLE}),
+							Name:  ptr.To(slurmNodeName),
+							State: ptr.To([]slurmapi.V0044NodeState{slurmapi.V0044NodeStateIDLE}),
 						},
 					},
 				},
@@ -1653,8 +1653,8 @@ func TestNodeSetReconciler_syncCordon(t *testing.T) {
 				Items: []slurmtypes.V0044Node{
 					{
 						V0044Node: slurmapi.V0044Node{
-							Name:  new(slurmNodeName),
-							State: new([]slurmapi.V0044NodeState{slurmapi.V0044NodeStateIDLE}),
+							Name:  ptr.To(slurmNodeName),
+							State: ptr.To([]slurmapi.V0044NodeState{slurmapi.V0044NodeStateIDLE}),
 						},
 					},
 				},
@@ -1685,8 +1685,8 @@ func TestNodeSetReconciler_syncCordon(t *testing.T) {
 				Items: []slurmtypes.V0044Node{
 					{
 						V0044Node: slurmapi.V0044Node{
-							Name:  new(slurmNodeName),
-							State: new([]slurmapi.V0044NodeState{slurmapi.V0044NodeStateIDLE}),
+							Name:  ptr.To(slurmNodeName),
+							State: ptr.To([]slurmapi.V0044NodeState{slurmapi.V0044NodeStateIDLE}),
 						},
 					},
 				},
@@ -1722,8 +1722,8 @@ func TestNodeSetReconciler_syncCordon(t *testing.T) {
 				Items: []slurmtypes.V0044Node{
 					{
 						V0044Node: slurmapi.V0044Node{
-							Name:  new(slurmNodeName),
-							State: new([]slurmapi.V0044NodeState{slurmapi.V0044NodeStateIDLE}),
+							Name:  ptr.To(slurmNodeName),
+							State: ptr.To([]slurmapi.V0044NodeState{slurmapi.V0044NodeStateIDLE}),
 						},
 					},
 				},
@@ -2120,12 +2120,12 @@ func TestNodeSetReconciler_makePodCordonAndDrain(t *testing.T) {
 						Items: []slurmtypes.V0044Node{
 							{
 								V0044Node: slurmapi.V0044Node{
-									Name: new(nodesetutils.GetSlurmNodeName(pod)),
-									State: new([]slurmapi.V0044NodeState{
+									Name: ptr.To(nodesetutils.GetSlurmNodeName(pod)),
+									State: ptr.To([]slurmapi.V0044NodeState{
 										slurmapi.V0044NodeStateIDLE,
 										slurmapi.V0044NodeStateDRAIN,
 									}),
-									Reason: new("preserve me"),
+									Reason: ptr.To("preserve me"),
 								},
 							},
 						},
@@ -2153,12 +2153,12 @@ func TestNodeSetReconciler_makePodCordonAndDrain(t *testing.T) {
 						Items: []slurmtypes.V0044Node{
 							{
 								V0044Node: slurmapi.V0044Node{
-									Name: new(nodesetutils.GetSlurmNodeName(pod)),
-									State: new([]slurmapi.V0044NodeState{
+									Name: ptr.To(nodesetutils.GetSlurmNodeName(pod)),
+									State: ptr.To([]slurmapi.V0044NodeState{
 										slurmapi.V0044NodeStateIDLE,
 										slurmapi.V0044NodeStateDRAIN,
 									}),
-									Reason: new("override me"),
+									Reason: ptr.To("override me"),
 								},
 							},
 						},
@@ -4922,12 +4922,12 @@ func TestNodeSetReconciler_syncSlurmNodeRecords(t *testing.T) {
 		},
 	}
 
-	defunctNodeState := new([]slurmapi.V0044NodeState{
+	defunctNodeState := ptr.To([]slurmapi.V0044NodeState{
 		slurmapi.V0044NodeStateDOWN,
 		slurmapi.V0044NodeStateNOTRESPONDING,
 	})
 	podInfo := func(ns *slinkyv1beta1.NodeSet, podName, node string) *string {
-		return new((&podinfo.PodInfo{
+		return ptr.To((&podinfo.PodInfo{
 			Namespace:   corev1.NamespaceDefault,
 			PodName:     podName,
 			Node:        node,
@@ -5193,13 +5193,9 @@ func Test_sanitizeSlurmReason(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := sanitizeSlurmReason(tt.input)
-			if got != tt.want {
-				t.Errorf("sanitizeSlurmReason() = %q, want %q", got, tt.want)
-			}
-			if utf8.RuneCountInString(got) > maxSlurmReasonLength {
-				t.Errorf("sanitizeSlurmReason() returned %d runes, exceeds max %d",
-					utf8.RuneCountInString(got), maxSlurmReasonLength)
-			}
+
+			require.Equal(t, tt.want, got)
+			require.LessOrEqual(t, utf8.RuneCountInString(got), maxSlurmReasonLength)
 		})
 	}
 }

--- a/internal/controller/nodeset/nodeset_sync_test.go
+++ b/internal/controller/nodeset/nodeset_sync_test.go
@@ -13,7 +13,6 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"github.com/google/go-cmp/cmp"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -25,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/events"
-	"k8s.io/klog/v2"
 	kubecontroller "k8s.io/kubernetes/pkg/controller"
 	"k8s.io/kubernetes/pkg/controller/history"
 	"k8s.io/utils/ptr"
@@ -52,6 +50,7 @@ import (
 	"github.com/SlinkyProject/slurm-operator/internal/utils/podutils"
 	"github.com/SlinkyProject/slurm-operator/internal/utils/structutils"
 	"github.com/SlinkyProject/slurm-operator/internal/utils/testutils"
+	"github.com/stretchr/testify/require"
 )
 
 func newNodeSetController(client client.Client, clientMap *clientmap.ClientMap) *NodeSetReconciler {
@@ -238,9 +237,7 @@ func TestNodeSetReconciler_syncReservationFinalizer(t *testing.T) {
 
 	// Configure times for testing
 	now, err := time.Parse(time.RFC3339, "2026-03-04T00:00:00Z")
-	if err != nil {
-		t.Errorf("Failed to initialize test. Failed to parse time: %v", err)
-	}
+	require.NoError(t, err)
 	startTime := now.Unix()
 	endTime := now.Add(time.Hour).Unix()
 
@@ -363,21 +360,17 @@ func TestNodeSetReconciler_syncReservationFinalizer(t *testing.T) {
 			r := newNodeSetController(client, nil)
 			r.slurmControl = tt.fields.slurmControl
 			err := r.syncReservationFinalizer(ctx, tt.args.nodeset)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("TestNodeSetReconciler_syncReservationFinalizer() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
 			if tt.wantErr {
+				require.Error(t, err)
 				return
 			}
+			require.NoError(t, err)
 
 			gotFinalizers := slices.Clone(tt.args.nodeset.Finalizers)
 			slices.Sort(gotFinalizers)
 			want := slices.Clone(tt.wantFinalizers)
 			slices.Sort(want)
-			if diff := cmp.Diff(want, gotFinalizers); diff != "" {
-				t.Errorf("finalizers mismatch (-want +got):\n%s", diff)
-			}
+			require.Equal(t, want, gotFinalizers)
 		})
 	}
 }
@@ -435,8 +428,11 @@ func TestNodeSetReconciler_adoptOrphanRevisions(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := newNodeSetController(tt.fields.Client, nil)
-			if err := r.adoptOrphanRevisions(tt.args.ctx, tt.args.nodeset); (err != nil) != tt.wantErr {
-				t.Errorf("NodeSetReconciler.adoptOrphanRevisions() error = %v, wantErr %v", err, tt.wantErr)
+			err := r.adoptOrphanRevisions(tt.args.ctx, tt.args.nodeset)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 		})
 	}
@@ -505,8 +501,11 @@ func TestNodeSetReconciler_doAdoptOrphanRevisions(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := newNodeSetController(tt.fields.Client, nil)
-			if err := r.doAdoptOrphanRevisions(tt.args.nodeset, tt.args.revisions); (err != nil) != tt.wantErr {
-				t.Errorf("NodeSetReconciler.doAdoptOrphanRevisions() error = %v, wantErr %v", err, tt.wantErr)
+			err := r.doAdoptOrphanRevisions(tt.args.nodeset, tt.args.revisions)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 		})
 	}
@@ -590,10 +589,11 @@ func TestNodeSetReconciler_listRevisions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := newNodeSetController(tt.fields.Client, nil)
 			got, err := r.listRevisions(tt.args.nodeset)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("NodeSetReconciler.listRevisions() error = %v, wantErr %v", err, tt.wantErr)
+			if tt.wantErr {
+				require.Error(t, err)
 				return
 			}
+			require.NoError(t, err)
 			if !apiequality.Semantic.DeepEqual(got, tt.want) {
 				t.Errorf("NodeSetReconciler.listRevisions() = %v, want %v", got, tt.want)
 			}
@@ -646,17 +646,16 @@ func TestNodeSetReconciler_getNodeSetPods(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := newNodeSetController(tt.fields.Client, nil)
 			got, err := r.getNodeSetPods(tt.args.ctx, tt.args.nodeset)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("NodeSetReconciler.getNodeSetPods() error = %v, wantErr %v", err, tt.wantErr)
+			if tt.wantErr {
+				require.Error(t, err)
 				return
 			}
+			require.NoError(t, err)
 			gotPodNames := make([]string, len(got))
 			for i, pod := range got {
 				gotPodNames[i] = klog.KObj(pod).String()
 			}
-			if diff := cmp.Diff(tt.want, gotPodNames); diff != "" {
-				t.Errorf("NodeSetReconciler.getNodeSetPods() (-want,+got):\n%s", diff)
-			}
+			require.Equal(t, tt.want, gotPodNames)
 		})
 	}
 }
@@ -742,9 +741,13 @@ func TestNodeSetReconciler_sync(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := newNodeSetController(tt.fields.Client, tt.fields.ClientMap)
-			if err := r.sync(tt.args.ctx, tt.args.nodeset, tt.args.pods, tt.args.hash); (err != nil) != tt.wantErr {
-				t.Errorf("NodeSetReconciler.sync() error = %v, wantErr %v", err, tt.wantErr)
+			err := r.sync(tt.args.ctx, tt.args.nodeset, tt.args.pods, tt.args.hash)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
 			}
+
+			require.NoError(t, err)
 		})
 	}
 }
@@ -911,34 +914,34 @@ func TestNodeSetReconciler_syncNodeSetPods(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := newNodeSetController(tt.fields.Client, tt.fields.ClientMap)
-			if err := r.syncNodeSetPods(tt.args.ctx, tt.args.nodeset, tt.args.pods, tt.args.hash); (err != nil) != tt.wantErr {
-				t.Errorf("NodeSetReconciler.syncNodeSetPods() error = %v, wantErr %v", err, tt.wantErr)
+			err := r.syncNodeSetPods(tt.args.ctx, tt.args.nodeset, tt.args.pods, tt.args.hash)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 			podList := &corev1.PodList{}
 			optsList := &client.ListOptions{
 				Namespace: tt.args.nodeset.Namespace,
 			}
-			err := tt.fields.Client.List(ctx, podList, optsList)
-			if err != nil {
-				t.Errorf("Failed to list pods for NodeSet error = %v", err)
-			}
+			err = tt.fields.Client.List(ctx, podList, optsList)
+			require.NoError(t, err)
 
 			// If we are not scaling down, podList.Items should reflect current state
 			if len(tt.args.pods) <= tt.wantPods {
-				if len(podList.Items) != tt.wantPods {
-					t.Errorf("syncNodeSetPods() failed: expected pod count = %v, got pod count = %v", tt.wantPods, len(podList.Items))
-				}
+				require.Equal(t, tt.wantPods, len(podList.Items))
 			}
 
 			// If we are scaling down, we need to sync again
 			if len(tt.args.pods) > tt.wantPods {
-				if err := r.syncNodeSetPods(tt.args.ctx, tt.args.nodeset, tt.args.pods, tt.args.hash); (err != nil) != tt.wantErr {
-					t.Errorf("NodeSetReconciler.syncNodeSetPods() error = %v, wantErr %v", err, tt.wantErr)
+				err = r.syncNodeSetPods(tt.args.ctx, tt.args.nodeset, tt.args.pods, tt.args.hash)
+				if tt.wantErr {
+					require.Error(t, err)
+				} else {
+					require.NoError(t, err)
 				}
-				err := tt.fields.Client.List(ctx, podList, optsList)
-				if err != nil {
-					t.Errorf("Failed to list pods for NodeSet error = %v", err)
-				}
+				err = tt.fields.Client.List(ctx, podList, optsList)
+				require.NoError(t, err)
 			}
 		})
 	}
@@ -1362,8 +1365,11 @@ func TestNodeSetReconciler_processCondemned(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := newNodeSetController(tt.fields.Client, tt.fields.ClientMap)
-			if err := r.processCondemned(tt.args.ctx, tt.args.nodeset, tt.args.condemned, tt.args.i); (err != nil) != tt.wantErr {
-				t.Errorf("NodeSetReconciler.processCondemned() error = %v, wantErr %v", err, tt.wantErr)
+			err := r.processCondemned(tt.args.ctx, tt.args.nodeset, tt.args.condemned, tt.args.i)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 			pod := tt.args.condemned[tt.args.i]
 			if isDrain, err := r.slurmControl.IsNodeDrain(tt.args.ctx, tt.args.nodeset, pod); err != nil {
@@ -1372,11 +1378,11 @@ func TestNodeSetReconciler_processCondemned(t *testing.T) {
 				t.Errorf("slurmControl.IsNodeDrain() = %v, wantDrain %v", isDrain, tt.wantDrain)
 			}
 			key := client.ObjectKeyFromObject(pod)
-			err := r.Get(tt.args.ctx, key, pod)
-			podStillExists := err == nil
-			podGone := apierrors.IsNotFound(err)
-			if err != nil && !podGone {
-				t.Errorf("Client.Get() error = %v", err)
+			getErr := r.Get(tt.args.ctx, key, pod)
+			podStillExists := getErr == nil
+			podGone := apierrors.IsNotFound(getErr)
+			if getErr != nil && !podGone {
+				t.Errorf("Client.Get() error = %v", getErr)
 			}
 			if tt.wantPodDeleted && !podGone {
 				t.Errorf("expected pod to be deleted from the API server")
@@ -1737,14 +1743,15 @@ func TestNodeSetReconciler_syncCordon(t *testing.T) {
 			k8sClient := fake.NewFakeClient(nodeset.DeepCopy(), pod.DeepCopy(), tt.kubeNode.DeepCopy())
 			r := newNodeSetControllerWithPropagatedNodeConditions(k8sClient, clientMap, tt.propagatedNodeConditions)
 
-			if err := r.syncCordon(context.Background(), nodeset.DeepCopy(), []*corev1.Pod{pod}); (err != nil) != tt.wantErr {
-				t.Fatalf("syncCordon() error = %v, wantErr %v", err, tt.wantErr)
+			err := r.syncCordon(context.Background(), nodeset.DeepCopy(), []*corev1.Pod{pod})
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 
 			gotPod := &corev1.Pod{}
-			if err := r.Get(context.Background(), client.ObjectKeyFromObject(pod), gotPod); err != nil {
-				t.Fatalf("Get pod: %v", err)
-			}
+			require.NoError(t, r.Get(context.Background(), client.ObjectKeyFromObject(pod), gotPod))
 			if got, want := podutils.IsPodCordon(gotPod), tt.wantPodCordoned; got != want {
 				t.Errorf("IsPodCordon() = %v, want %v", got, want)
 			}
@@ -1755,12 +1762,8 @@ func TestNodeSetReconciler_syncCordon(t *testing.T) {
 				Name:      nodeset.Spec.ControllerRef.Name,
 			}
 			sc := r.ClientMap.Get(mapKey)
-			if sc == nil {
-				t.Fatal("ClientMap.Get() returned nil")
-			}
-			if err := sc.Get(context.Background(), slurmclient.ObjectKey(slurmNodeName), gotNode); err != nil {
-				t.Fatalf("slurm Get node: %v", err)
-			}
+			require.NotNil(t, sc)
+			require.NoError(t, sc.Get(context.Background(), slurmclient.ObjectKey(slurmNodeName), gotNode))
 			if got, want := gotNode.GetStateAsSet().Has(slurmapi.V0044NodeStateDRAIN), tt.wantSlurmDrain; got != want {
 				t.Errorf("Slurm node DRAIN = %v, want %v", got, want)
 			}
@@ -1902,8 +1905,11 @@ func TestNodeSetReconciler_doPodProcessing(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := newNodeSetController(tt.fields.Client, tt.fields.ClientMap)
-			if err := r.doPodProcessing(tt.args.ctx, tt.args.nodeset, tt.args.pods, tt.args.podsToDelete, tt.args.hash); (err != nil) != tt.wantErr {
-				t.Errorf("NodeSetReconciler.doPodProcessing() error = %v, wantErr %v", err, tt.wantErr)
+			err := r.doPodProcessing(tt.args.ctx, tt.args.nodeset, tt.args.pods, tt.args.podsToDelete, tt.args.hash)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 		})
 	}
@@ -2040,19 +2046,22 @@ func TestNodeSetReconciler_processNodeSetPod(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := newNodeSetController(tt.fields.Client, tt.fields.ClientMap)
-			if err := r.processNodeSetPod(tt.args.ctx, tt.args.nodeset, tt.args.pod); (err != nil) != tt.wantErr {
-				t.Errorf("NodeSetReconciler.processNodeSetPod() error = %v, wantErr %v", err, tt.wantErr)
+			err := r.processNodeSetPod(tt.args.ctx, tt.args.nodeset, tt.args.pod)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 			gotPod := &corev1.Pod{}
-			err := tt.fields.Client.Get(tt.args.ctx, client.ObjectKeyFromObject(tt.args.pod), gotPod)
+			getErr := tt.fields.Client.Get(tt.args.ctx, client.ObjectKeyFromObject(tt.args.pod), gotPod)
 			if tt.wantDelete {
-				if err == nil {
+				if getErr == nil {
 					t.Errorf("expected pod to be deleted, but it still exists")
-				} else if !apierrors.IsNotFound(err) {
-					t.Errorf("Client.Get() unexpected error = %v", err)
+				} else if !apierrors.IsNotFound(getErr) {
+					t.Errorf("Client.Get() unexpected error = %v", getErr)
 				}
-			} else if err != nil && !apierrors.IsNotFound(err) {
-				t.Errorf("Client.Get() unexpected error = %v", err)
+			} else if getErr != nil && !apierrors.IsNotFound(getErr) {
+				t.Errorf("Client.Get() unexpected error = %v", getErr)
 			}
 		})
 	}
@@ -2283,40 +2292,36 @@ func TestNodeSetReconciler_makePodCordonAndDrain(t *testing.T) {
 				Namespace: nodeset.Namespace,
 				Name:      nodeset.Spec.ControllerRef.Name,
 			}
-			if err := r.makePodCordonAndDrain(tt.args.ctx, tt.args.nodeset, tt.args.pod, tt.args.reason, tt.args.overrideReason); (err != nil) != tt.wantErr {
-				t.Errorf("NodeSetReconciler.makePodCordonAndDrain() error = %v, wantErr %v", err, tt.wantErr)
+			err := r.makePodCordonAndDrain(tt.args.ctx, tt.args.nodeset, tt.args.pod, tt.args.reason, tt.args.overrideReason)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
 			}
+			require.NoError(t, err)
 			// Check Pod Annotations
 			gotPod := &corev1.Pod{}
-			if err := r.Get(tt.args.ctx, client.ObjectKeyFromObject(tt.args.pod), gotPod); err != nil {
-				if !apierrors.IsNotFound(err) {
-					t.Errorf("client.Get() error = %v", err)
+			if getErr := r.Get(tt.args.ctx, client.ObjectKeyFromObject(tt.args.pod), gotPod); getErr != nil {
+				if !apierrors.IsNotFound(getErr) {
+					t.Errorf("client.Get() error = %v", getErr)
 				}
-			} else if !tt.wantErr {
+			} else {
 				if ok := podutils.IsPodCordon(gotPod); !ok {
 					t.Errorf("IsPodCordon() = %v", ok)
 				}
 			}
-			if tt.wantErr {
-				return
-			}
 			sc := r.ClientMap.Get(mapKey)
-			if sc == nil {
-				t.Error("ClientMap.Get() is nil")
-			}
+			require.NotNil(t, sc)
 			gotSlurmNode := &slurmtypes.V0044Node{}
-			if err := sc.Get(tt.args.ctx, slurmclient.ObjectKey(nodesetutils.GetSlurmNodeName(tt.args.pod)), gotSlurmNode); err != nil {
-				if err.Error() != http.StatusText(http.StatusNotFound) {
-					t.Errorf("slurmclient.Get() error = %v", err)
+			if getErr := sc.Get(tt.args.ctx, slurmclient.ObjectKey(nodesetutils.GetSlurmNodeName(tt.args.pod)), gotSlurmNode); getErr != nil {
+				if getErr.Error() != http.StatusText(http.StatusNotFound) {
+					t.Errorf("slurmclient.Get() error = %v", getErr)
 				}
 			}
 			if ok := gotSlurmNode.GetStateAsSet().Has(slurmapi.V0044NodeStateDRAIN); !ok {
 				t.Errorf("SlurmNode Has DRAIN = %v", ok)
 			}
 			gotNodeReason := ptr.Deref(gotSlurmNode.Reason, "")
-			if gotNodeReason != tt.wantNodeReason {
-				t.Fatalf("MakeNodeDrain() reason = '%s', want = '%s'", gotNodeReason, tt.wantNodeReason)
-			}
+			require.Equal(t, tt.wantNodeReason, gotNodeReason)
 		})
 	}
 }
@@ -2387,14 +2392,17 @@ func TestNodeSetReconciler_makePodCordon(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := newNodeSetController(tt.fields.Client, tt.fields.ClientMap)
-			if err := r.makePodCordon(tt.args.ctx, tt.args.pod); (err != nil) != tt.wantErr {
-				t.Errorf("NodeSetReconciler.makePodCordon() error = %v, wantErr %v", err, tt.wantErr)
+			err := r.makePodCordon(tt.args.ctx, tt.args.pod)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 			// Check Pod Annotations
 			gotPod := &corev1.Pod{}
-			if err := r.Get(tt.args.ctx, client.ObjectKeyFromObject(tt.args.pod), gotPod); err != nil {
-				if !apierrors.IsNotFound(err) {
-					t.Errorf("client.Get() error = %v", err)
+			if getErr := r.Get(tt.args.ctx, client.ObjectKeyFromObject(tt.args.pod), gotPod); getErr != nil {
+				if !apierrors.IsNotFound(getErr) {
+					t.Errorf("client.Get() error = %v", getErr)
 				}
 			} else if !tt.wantErr {
 				if ok := podutils.IsPodCordon(gotPod); !ok {
@@ -2535,14 +2543,17 @@ func TestNodeSetReconciler_makePodUncordonAndUndrain(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := newNodeSetController(tt.fields.Client, tt.fields.ClientMap)
-			if err := r.makePodUncordonAndUndrain(tt.args.ctx, tt.args.nodeset, tt.args.pod, tt.args.reason); (err != nil) != tt.wantErr {
-				t.Errorf("NodeSetReconciler.makePodUncordonAndUndrain() error = %v, wantErr %v", err, tt.wantErr)
+			err := r.makePodUncordonAndUndrain(tt.args.ctx, tt.args.nodeset, tt.args.pod, tt.args.reason)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 			// Check Pod Annotations
 			gotPod := &corev1.Pod{}
-			if err := r.Get(tt.args.ctx, client.ObjectKeyFromObject(tt.args.pod), gotPod); err != nil {
-				if !apierrors.IsNotFound(err) {
-					t.Errorf("client.Get() error = %v", err)
+			if getErr := r.Get(tt.args.ctx, client.ObjectKeyFromObject(tt.args.pod), gotPod); getErr != nil {
+				if !apierrors.IsNotFound(getErr) {
+					t.Errorf("client.Get() error = %v", getErr)
 				}
 			} else if !tt.wantErr {
 				if ok := podutils.IsPodCordon(gotPod); ok {
@@ -2556,12 +2567,10 @@ func TestNodeSetReconciler_makePodUncordonAndUndrain(t *testing.T) {
 				Name:      nodeset.Spec.ControllerRef.Name,
 			}
 			sc := r.ClientMap.Get(mapKey)
-			if sc == nil {
-				t.Error("ClientMap.Get() is nil")
-			}
-			if err := sc.Get(tt.args.ctx, slurmclient.ObjectKey(nodesetutils.GetSlurmNodeName(tt.args.pod)), gotSlurmNode); err != nil {
-				if err.Error() != http.StatusText(http.StatusNotFound) {
-					t.Errorf("slurmclient.Get() error = %v", err)
+			require.NotNil(t, sc)
+			if getErr := sc.Get(tt.args.ctx, slurmclient.ObjectKey(nodesetutils.GetSlurmNodeName(tt.args.pod)), gotSlurmNode); getErr != nil {
+				if getErr.Error() != http.StatusText(http.StatusNotFound) {
+					t.Errorf("slurmclient.Get() error = %v", getErr)
 				}
 			} else if !tt.wantErr {
 				if ok := gotSlurmNode.GetStateAsSet().Has(slurmapi.V0044NodeStateDRAIN); ok {
@@ -2636,14 +2645,17 @@ func TestNodeSetReconciler_makePodUncordon(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := newNodeSetController(tt.fields.Client, nil)
-			if err := r.makePodUncordon(tt.args.ctx, tt.args.pod); (err != nil) != tt.wantErr {
-				t.Errorf("NodeSetReconciler.makePodUncordon() error = %v, wantErr %v", err, tt.wantErr)
+			err := r.makePodUncordon(tt.args.ctx, tt.args.pod)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 			// Check Pod Annotations
 			gotPod := &corev1.Pod{}
-			if err := r.Get(tt.args.ctx, client.ObjectKeyFromObject(tt.args.pod), gotPod); err != nil {
-				if !apierrors.IsNotFound(err) {
-					t.Errorf("client.Get() error = %v", err)
+			if getErr := r.Get(tt.args.ctx, client.ObjectKeyFromObject(tt.args.pod), gotPod); getErr != nil {
+				if !apierrors.IsNotFound(getErr) {
+					t.Errorf("client.Get() error = %v", getErr)
 				}
 			} else if !tt.wantErr {
 				if ok := podutils.IsPodCordon(gotPod); ok {
@@ -2815,8 +2827,11 @@ func TestNodeSetReconciler_syncUpdate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := newNodeSetController(tt.fields.Client, tt.fields.ClientMap)
-			if err := r.syncUpdate(tt.args.ctx, tt.args.nodeset, tt.args.pods, tt.args.hash); (err != nil) != tt.wantErr {
-				t.Errorf("NodeSetReconciler.syncUpdate() error = %v, wantErr %v", err, tt.wantErr)
+			err := r.syncUpdate(tt.args.ctx, tt.args.nodeset, tt.args.pods, tt.args.hash)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 		})
 	}
@@ -3088,9 +3103,13 @@ func TestNodeSetReconciler_syncRollingUpdate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := newNodeSetController(tt.fields.Client, tt.fields.ClientMap)
-			if err := r.syncRollingUpdate(tt.args.ctx, tt.args.nodeset, tt.args.pods, tt.args.hash); (err != nil) != tt.wantErr {
-				t.Errorf("NodeSetReconciler.syncRollingUpdate() error = %v, wantErr %v", err, tt.wantErr)
+			err := r.syncRollingUpdate(tt.args.ctx, tt.args.nodeset, tt.args.pods, tt.args.hash)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
+
 			for _, pod := range tt.wantCordoned {
 				gotPod := &corev1.Pod{}
 				if err := r.Get(tt.args.ctx, client.ObjectKeyFromObject(pod), gotPod); err != nil {
@@ -3312,9 +3331,13 @@ func TestNodeSetReconciler_syncScheduledUpdate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := newNodeSetController(tt.fields.Client, tt.fields.ClientMap)
-			if err := r.syncScheduledUpdate(tt.args.ctx, tt.args.nodeset, tt.args.pods, tt.args.hash); (err != nil) != tt.wantErr {
-				t.Errorf("NodeSetReconciler.syncScheduledUpdate() error = %v, wantErr %v", err, tt.wantErr)
+			err := r.syncScheduledUpdate(tt.args.ctx, tt.args.nodeset, tt.args.pods, tt.args.hash)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
 			}
+
+			require.NoError(t, err)
 		})
 	}
 }
@@ -3650,12 +3673,8 @@ func TestNodeSetReconciler_splitUpdatePods(t *testing.T) {
 
 			slices.Sort(gotPodsToDeleteOrdered)
 			slices.Sort(gotPodsToKeepOrdered)
-			if diff := cmp.Diff(tt.wantPodsToDelete, gotPodsToDeleteOrdered); diff != "" {
-				t.Errorf("gotPodsToDelete (-want,+got):\n%s", diff)
-			}
-			if diff := cmp.Diff(tt.wantPodsToKeep, gotPodsToKeepOrdered); diff != "" {
-				t.Errorf("gotPodsToKeep (-want,+got):\n%s", diff)
-			}
+			require.Equal(t, tt.wantPodsToDelete, gotPodsToDeleteOrdered)
+			require.Equal(t, tt.wantPodsToKeep, gotPodsToKeepOrdered)
 		})
 	}
 }
@@ -3717,12 +3736,8 @@ func Test_findUpdatedPods(t *testing.T) {
 
 			slices.Sort(gotNewPodsOrdered)
 			slices.Sort(gotOldPodsOrdered)
-			if diff := cmp.Diff(tt.wantNewPods, gotNewPodsOrdered); diff != "" {
-				t.Errorf("gotNewPods (-want,+got):\n%s", diff)
-			}
-			if diff := cmp.Diff(tt.wantOldPods, gotOldPodsOrdered); diff != "" {
-				t.Errorf("gotOldPods (-want,+got):\n%s", diff)
-			}
+			require.Equal(t, tt.wantNewPods, gotNewPodsOrdered)
+			require.Equal(t, tt.wantOldPods, gotOldPodsOrdered)
 		})
 	}
 }
@@ -3761,9 +3776,13 @@ func TestNodeSetReconciler_syncClusterWorkerService(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := newNodeSetController(tt.fields.Client, nil)
-			if err := r.syncClusterWorkerService(tt.args.ctx, tt.args.nodeset); (err != nil) != tt.wantErr {
-				t.Errorf("NodeSetReconciler.syncClusterWorkerService() error = %v, wantErr %v", err, tt.wantErr)
+			err := r.syncClusterWorkerService(tt.args.ctx, tt.args.nodeset)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
 			}
+
+			require.NoError(t, err)
 		})
 	}
 }
@@ -3907,9 +3926,8 @@ func Test_isNodeCordoned(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := newNodeSetController(tt.fields.Client, nil)
-			if got := r.isNodeCordoned(tt.args.ctx, tt.args.pod); got != tt.want {
-				t.Errorf("isNodeCordoned() = %v, want %v", got, tt.want)
-			}
+			got := r.isNodeCordoned(tt.args.ctx, tt.args.pod)
+			require.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -4104,22 +4122,21 @@ func Test_syncPodUncordon(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := newNodeSetController(tt.fields.Client, tt.fields.ClientMap)
-			if err := r.syncPodUncordon(tt.args.ctx, tt.args.nodeset, tt.args.pod); (err != nil) != tt.wantErr {
-				t.Errorf("syncPodUncordon() error = %v, wantErr %v", err, tt.wantErr)
+			err := r.syncPodUncordon(tt.args.ctx, tt.args.nodeset, tt.args.pod)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 
 			gotPod := &corev1.Pod{}
-			if err := tt.fields.Client.Get(tt.args.ctx, client.ObjectKeyFromObject(tt.args.pod), gotPod); err != nil {
-				t.Fatalf("Get() pod failed: %v", err)
-			}
+			require.NoError(t, tt.fields.Client.Get(tt.args.ctx, client.ObjectKeyFromObject(tt.args.pod), gotPod))
 			if got := podutils.IsPodCordon(gotPod); got != tt.wantPodCordoned {
 				t.Errorf("pod cordon state after syncPodUncordon() = %v, want %v", got, tt.wantPodCordoned)
 			}
 
-			gotDrain, err := r.slurmControl.IsNodeDrain(tt.args.ctx, tt.args.nodeset, tt.args.pod)
-			if err != nil {
-				t.Fatalf("IsNodeDrain() failed: %v", err)
-			}
+			gotDrain, drainErr := r.slurmControl.IsNodeDrain(tt.args.ctx, tt.args.nodeset, tt.args.pod)
+			require.NoError(t, drainErr)
 			if gotDrain != tt.wantSlurmNodeDrained {
 				t.Errorf("slurm node DRAIN state after syncPodUncordon() = %v, want %v", gotDrain, tt.wantSlurmNodeDrained)
 			}
@@ -4194,15 +4211,11 @@ func TestNodeSetReconciler_syncSlurmTopology(t *testing.T) {
 			ctx := context.Background()
 			r := newNodeSetController(tt.client, tt.clientMap)
 			gotErr := r.syncSlurmTopology(context.Background(), tt.nodeset, tt.pods)
-			if gotErr != nil {
-				if !tt.wantErr {
-					t.Errorf("syncSlurmTopology() failed: %v", gotErr)
-				}
+			if tt.wantErr {
+				require.Error(t, gotErr)
 				return
 			}
-			if tt.wantErr {
-				t.Fatal("syncSlurmTopology() succeeded unexpectedly")
-			}
+			require.NoError(t, gotErr)
 			for _, pod := range tt.pods {
 				checkPod := &corev1.Pod{}
 				if err := tt.client.Get(ctx, client.ObjectKeyFromObject(pod), checkPod); err != nil {
@@ -4938,20 +4951,14 @@ func TestNodeSetReconciler_syncSlurmNodes(t *testing.T) {
 			ctx := context.Background()
 			r := NewReconciler(tt.kclient, tt.clientMap, nil)
 			gotErr := r.syncSlurmNodes(context.Background(), tt.nodeset, tt.pods)
-			if gotErr != nil {
-				if !tt.wantErr {
-					t.Errorf("syncSlurmNodes() failed: %v", gotErr)
-				}
+			if tt.wantErr {
+				require.Error(t, gotErr)
 				return
 			}
-			if tt.wantErr {
-				t.Fatal("syncSlurmNodes() succeeded unexpectedly")
-			}
+			require.NoError(t, gotErr)
 			scontrol := slurmcontrol.NewSlurmControl(tt.clientMap)
 			slurmNodeNames, ok, err := scontrol.GetNodesForPods(ctx, tt.nodeset, tt.pods)
-			if err != nil {
-				t.Fatalf("slurmControl failed to get Slurm node names: %v", err)
-			}
+			require.NoError(t, err)
 			if !ok {
 				if ok != tt.wantOk {
 					t.Fatal("slurmControl used a client unexpectedly")
@@ -4959,9 +4966,7 @@ func TestNodeSetReconciler_syncSlurmNodes(t *testing.T) {
 				return
 			}
 			podList := &corev1.PodList{}
-			if err := tt.kclient.List(ctx, podList); err != nil {
-				t.Fatalf("kclient failed to list pods: %v", err)
-			}
+			require.NoError(t, tt.kclient.List(ctx, podList))
 			if len(podList.Items) != len(slurmNodeNames) {
 				t.Errorf("syncSlurmNodes() unregistered Slurm node but healthy pod was not deleted")
 			}
@@ -5172,19 +5177,18 @@ func TestNodeSetReconciler_syncSlurmNodeRecords(t *testing.T) {
 			clientMap := newClientMap(controller.Name, sclient)
 			r := NewReconciler(kclient, clientMap, nil)
 
-			if err := r.syncSlurmNodeRecords(context.Background(), nodeset); (err != nil) != tt.wantErr {
-				t.Fatalf("syncSlurmNodeRecords() error = %v", err)
+			err := r.syncSlurmNodeRecords(context.Background(), nodeset)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 
 			for _, name := range stillExist {
-				if err := sclient.Get(context.Background(), slurmclient.ObjectKey(name), &slurmtypes.V0044Node{}); err != nil {
-					t.Fatalf("expected Slurm node %q to remain, got: %v", name, err)
-				}
+				require.NoError(t, sclient.Get(context.Background(), slurmclient.ObjectKey(name), &slurmtypes.V0044Node{}), "expected Slurm node %q to remain", name)
 			}
 			for _, name := range pruned {
-				if err := sclient.Get(context.Background(), slurmclient.ObjectKey(name), &slurmtypes.V0044Node{}); err == nil {
-					t.Fatalf("expected Slurm node %q to be pruned, it still exists", name)
-				}
+				require.Error(t, sclient.Get(context.Background(), slurmclient.ObjectKey(name), &slurmtypes.V0044Node{}), "expected Slurm node %q to be pruned", name)
 			}
 		})
 	}

--- a/internal/controller/nodeset/nodeset_sync_test.go
+++ b/internal/controller/nodeset/nodeset_sync_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/events"
+	"k8s.io/klog/v2"
 	kubecontroller "k8s.io/kubernetes/pkg/controller"
 	"k8s.io/kubernetes/pkg/controller/history"
 	"k8s.io/utils/ptr"
@@ -594,9 +595,7 @@ func TestNodeSetReconciler_listRevisions(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			if !apiequality.Semantic.DeepEqual(got, tt.want) {
-				t.Errorf("NodeSetReconciler.listRevisions() = %v, want %v", got, tt.want)
-			}
+			require.True(t, apiequality.Semantic.DeepEqual(got, tt.want), "NodeSetReconciler.listRevisions() = %v, want %v", got, tt.want)
 		})
 	}
 }
@@ -1372,23 +1371,23 @@ func TestNodeSetReconciler_processCondemned(t *testing.T) {
 				require.NoError(t, err)
 			}
 			pod := tt.args.condemned[tt.args.i]
-			if isDrain, err := r.slurmControl.IsNodeDrain(tt.args.ctx, tt.args.nodeset, pod); err != nil {
-				t.Errorf("slurmControl.IsNodeDrain() error = %v", err)
-			} else if isDrain != tt.wantDrain && !tt.wantDelete {
-				t.Errorf("slurmControl.IsNodeDrain() = %v, wantDrain %v", isDrain, tt.wantDrain)
+			isDrain, err := r.slurmControl.IsNodeDrain(tt.args.ctx, tt.args.nodeset, pod)
+			require.NoError(t, err)
+			if isDrain != tt.wantDrain && !tt.wantDelete {
+				require.True(t, isDrain == tt.wantDrain, "slurmControl.IsNodeDrain() = %v, wantDrain %v", isDrain, tt.wantDrain)
 			}
 			key := client.ObjectKeyFromObject(pod)
 			getErr := r.Get(tt.args.ctx, key, pod)
 			podStillExists := getErr == nil
 			podGone := apierrors.IsNotFound(getErr)
 			if getErr != nil && !podGone {
-				t.Errorf("Client.Get() error = %v", getErr)
+				require.NoError(t, getErr)
 			}
-			if tt.wantPodDeleted && !podGone {
-				t.Errorf("expected pod to be deleted from the API server")
+			if tt.wantPodDeleted {
+				require.True(t, podGone, "expected pod to be deleted from the API server")
 			}
-			if !tt.wantPodDeleted && !podStillExists && !tt.wantErr {
-				t.Errorf("expected pod to still exist")
+			if !tt.wantPodDeleted && !tt.wantErr {
+				require.True(t, podStillExists, "expected pod to still exist")
 			}
 		})
 	}
@@ -1752,9 +1751,7 @@ func TestNodeSetReconciler_syncCordon(t *testing.T) {
 
 			gotPod := &corev1.Pod{}
 			require.NoError(t, r.Get(context.Background(), client.ObjectKeyFromObject(pod), gotPod))
-			if got, want := podutils.IsPodCordon(gotPod), tt.wantPodCordoned; got != want {
-				t.Errorf("IsPodCordon() = %v, want %v", got, want)
-			}
+			require.Equal(t, tt.wantPodCordoned, podutils.IsPodCordon(gotPod), "IsPodCordon() result")
 
 			gotNode := &slurmtypes.V0044Node{}
 			mapKey := types.NamespacedName{
@@ -1764,13 +1761,10 @@ func TestNodeSetReconciler_syncCordon(t *testing.T) {
 			sc := r.ClientMap.Get(mapKey)
 			require.NotNil(t, sc)
 			require.NoError(t, sc.Get(context.Background(), slurmclient.ObjectKey(slurmNodeName), gotNode))
-			if got, want := gotNode.GetStateAsSet().Has(slurmapi.V0044NodeStateDRAIN), tt.wantSlurmDrain; got != want {
-				t.Errorf("Slurm node DRAIN = %v, want %v", got, want)
-			}
+			require.Equal(t, tt.wantSlurmDrain, gotNode.GetStateAsSet().Has(slurmapi.V0044NodeStateDRAIN), "Slurm node DRAIN")
 			if tt.wantReasonSub != "" {
-				if reason := ptr.Deref(gotNode.Reason, ""); !strings.Contains(reason, tt.wantReasonSub) {
-					t.Errorf("Slurm node Reason = %q, want substring %q", reason, tt.wantReasonSub)
-				}
+				reason := ptr.Deref(gotNode.Reason, "")
+				require.True(t, strings.Contains(reason, tt.wantReasonSub), "Slurm node Reason = %q, want substring %q", reason, tt.wantReasonSub)
 			}
 		})
 	}
@@ -2055,13 +2049,9 @@ func TestNodeSetReconciler_processNodeSetPod(t *testing.T) {
 			gotPod := &corev1.Pod{}
 			getErr := tt.fields.Client.Get(tt.args.ctx, client.ObjectKeyFromObject(tt.args.pod), gotPod)
 			if tt.wantDelete {
-				if getErr == nil {
-					t.Errorf("expected pod to be deleted, but it still exists")
-				} else if !apierrors.IsNotFound(getErr) {
-					t.Errorf("Client.Get() unexpected error = %v", getErr)
-				}
-			} else if getErr != nil && !apierrors.IsNotFound(getErr) {
-				t.Errorf("Client.Get() unexpected error = %v", getErr)
+				require.True(t, apierrors.IsNotFound(getErr), "expected pod to be deleted, but it still exists")
+			} else if getErr != nil {
+				require.True(t, apierrors.IsNotFound(getErr), "Client.Get() unexpected error = %v", getErr)
 			}
 		})
 	}
@@ -2301,25 +2291,17 @@ func TestNodeSetReconciler_makePodCordonAndDrain(t *testing.T) {
 			// Check Pod Annotations
 			gotPod := &corev1.Pod{}
 			if getErr := r.Get(tt.args.ctx, client.ObjectKeyFromObject(tt.args.pod), gotPod); getErr != nil {
-				if !apierrors.IsNotFound(getErr) {
-					t.Errorf("client.Get() error = %v", getErr)
-				}
+				require.True(t, apierrors.IsNotFound(getErr), "client.Get() error = %v", getErr)
 			} else {
-				if ok := podutils.IsPodCordon(gotPod); !ok {
-					t.Errorf("IsPodCordon() = %v", ok)
-				}
+				require.True(t, podutils.IsPodCordon(gotPod), "IsPodCordon() = false")
 			}
 			sc := r.ClientMap.Get(mapKey)
 			require.NotNil(t, sc)
 			gotSlurmNode := &slurmtypes.V0044Node{}
 			if getErr := sc.Get(tt.args.ctx, slurmclient.ObjectKey(nodesetutils.GetSlurmNodeName(tt.args.pod)), gotSlurmNode); getErr != nil {
-				if getErr.Error() != http.StatusText(http.StatusNotFound) {
-					t.Errorf("slurmclient.Get() error = %v", getErr)
-				}
+				require.True(t, getErr.Error() == http.StatusText(http.StatusNotFound), "slurmclient.Get() error = %v", getErr)
 			}
-			if ok := gotSlurmNode.GetStateAsSet().Has(slurmapi.V0044NodeStateDRAIN); !ok {
-				t.Errorf("SlurmNode Has DRAIN = %v", ok)
-			}
+			require.True(t, gotSlurmNode.GetStateAsSet().Has(slurmapi.V0044NodeStateDRAIN), "SlurmNode Has DRAIN = false")
 			gotNodeReason := ptr.Deref(gotSlurmNode.Reason, "")
 			require.Equal(t, tt.wantNodeReason, gotNodeReason)
 		})
@@ -2401,13 +2383,9 @@ func TestNodeSetReconciler_makePodCordon(t *testing.T) {
 			// Check Pod Annotations
 			gotPod := &corev1.Pod{}
 			if getErr := r.Get(tt.args.ctx, client.ObjectKeyFromObject(tt.args.pod), gotPod); getErr != nil {
-				if !apierrors.IsNotFound(getErr) {
-					t.Errorf("client.Get() error = %v", getErr)
-				}
+				require.True(t, apierrors.IsNotFound(getErr), "client.Get() error = %v", getErr)
 			} else if !tt.wantErr {
-				if ok := podutils.IsPodCordon(gotPod); !ok {
-					t.Errorf("IsPodCordon() = %v", ok)
-				}
+				require.True(t, podutils.IsPodCordon(gotPod), "IsPodCordon() = false")
 			}
 		})
 	}
@@ -2552,13 +2530,9 @@ func TestNodeSetReconciler_makePodUncordonAndUndrain(t *testing.T) {
 			// Check Pod Annotations
 			gotPod := &corev1.Pod{}
 			if getErr := r.Get(tt.args.ctx, client.ObjectKeyFromObject(tt.args.pod), gotPod); getErr != nil {
-				if !apierrors.IsNotFound(getErr) {
-					t.Errorf("client.Get() error = %v", getErr)
-				}
+				require.True(t, apierrors.IsNotFound(getErr), "client.Get() error = %v", getErr)
 			} else if !tt.wantErr {
-				if ok := podutils.IsPodCordon(gotPod); ok {
-					t.Errorf("IsPodCordon() = %v", ok)
-				}
+				require.False(t, podutils.IsPodCordon(gotPod), "IsPodCordon() = true, want false")
 			}
 			// Check Slurm Node State
 			gotSlurmNode := &slurmtypes.V0044Node{}
@@ -2569,13 +2543,9 @@ func TestNodeSetReconciler_makePodUncordonAndUndrain(t *testing.T) {
 			sc := r.ClientMap.Get(mapKey)
 			require.NotNil(t, sc)
 			if getErr := sc.Get(tt.args.ctx, slurmclient.ObjectKey(nodesetutils.GetSlurmNodeName(tt.args.pod)), gotSlurmNode); getErr != nil {
-				if getErr.Error() != http.StatusText(http.StatusNotFound) {
-					t.Errorf("slurmclient.Get() error = %v", getErr)
-				}
+				require.True(t, getErr.Error() == http.StatusText(http.StatusNotFound), "slurmclient.Get() error = %v", getErr)
 			} else if !tt.wantErr {
-				if ok := gotSlurmNode.GetStateAsSet().Has(slurmapi.V0044NodeStateDRAIN); ok {
-					t.Errorf("SlurmNode Has DRAIN = %v", ok)
-				}
+				require.False(t, gotSlurmNode.GetStateAsSet().Has(slurmapi.V0044NodeStateDRAIN), "SlurmNode Has DRAIN = true, want false")
 			}
 		})
 	}
@@ -2654,13 +2624,9 @@ func TestNodeSetReconciler_makePodUncordon(t *testing.T) {
 			// Check Pod Annotations
 			gotPod := &corev1.Pod{}
 			if getErr := r.Get(tt.args.ctx, client.ObjectKeyFromObject(tt.args.pod), gotPod); getErr != nil {
-				if !apierrors.IsNotFound(getErr) {
-					t.Errorf("client.Get() error = %v", getErr)
-				}
+				require.True(t, apierrors.IsNotFound(getErr), "client.Get() error = %v", getErr)
 			} else if !tt.wantErr {
-				if ok := podutils.IsPodCordon(gotPod); ok {
-					t.Errorf("IsPodCordon() = %v", ok)
-				}
+				require.False(t, podutils.IsPodCordon(gotPod), "IsPodCordon() = true, want false")
 			}
 		})
 	}
@@ -4131,15 +4097,11 @@ func Test_syncPodUncordon(t *testing.T) {
 
 			gotPod := &corev1.Pod{}
 			require.NoError(t, tt.fields.Client.Get(tt.args.ctx, client.ObjectKeyFromObject(tt.args.pod), gotPod))
-			if got := podutils.IsPodCordon(gotPod); got != tt.wantPodCordoned {
-				t.Errorf("pod cordon state after syncPodUncordon() = %v, want %v", got, tt.wantPodCordoned)
-			}
+			require.Equal(t, tt.wantPodCordoned, podutils.IsPodCordon(gotPod), "pod cordon state after syncPodUncordon()")
 
 			gotDrain, drainErr := r.slurmControl.IsNodeDrain(tt.args.ctx, tt.args.nodeset, tt.args.pod)
 			require.NoError(t, drainErr)
-			if gotDrain != tt.wantSlurmNodeDrained {
-				t.Errorf("slurm node DRAIN state after syncPodUncordon() = %v, want %v", gotDrain, tt.wantSlurmNodeDrained)
-			}
+			require.Equal(t, tt.wantSlurmNodeDrained, gotDrain, "slurm node DRAIN state after syncPodUncordon()")
 		})
 	}
 }
@@ -4218,21 +4180,15 @@ func TestNodeSetReconciler_syncSlurmTopology(t *testing.T) {
 			require.NoError(t, gotErr)
 			for _, pod := range tt.pods {
 				checkPod := &corev1.Pod{}
-				if err := tt.client.Get(ctx, client.ObjectKeyFromObject(pod), checkPod); err != nil {
-					t.Errorf("Get() failed: %v", err)
-				}
+				require.NoError(t, tt.client.Get(ctx, client.ObjectKeyFromObject(pod), checkPod), "Get() failed")
 				if pod.Spec.NodeName == "" {
 					continue
 				}
 				checkNode := &corev1.Node{}
 				checkNodeKey := types.NamespacedName{Name: pod.Spec.NodeName}
-				if err := tt.client.Get(ctx, checkNodeKey, checkNode); err != nil {
-					t.Errorf("Get() failed: %v", err)
-				}
+				require.NoError(t, tt.client.Get(ctx, checkNodeKey, checkNode), "Get() failed")
 				topologySpec := checkNode.Annotations[slinkyv1beta1.AnnotationNodeTopologySpec]
-				if !apiequality.Semantic.DeepEqual(checkPod.Annotations[slinkyv1beta1.AnnotationNodeTopologySpec], topologySpec) {
-					t.Errorf("pod and node topology are incongruent: node = '%v' ; pod = '%v'", topologySpec, checkPod.Annotations[slinkyv1beta1.AnnotationNodeTopologySpec])
-				}
+				require.True(t, apiequality.Semantic.DeepEqual(checkPod.Annotations[slinkyv1beta1.AnnotationNodeTopologySpec], topologySpec), "pod and node topology are incongruent: node = '%v' ; pod = '%v'", topologySpec, checkPod.Annotations[slinkyv1beta1.AnnotationNodeTopologySpec])
 
 				mapKey := types.NamespacedName{
 					Namespace: nodeset.Namespace,
@@ -4244,12 +4200,8 @@ func TestNodeSetReconciler_syncSlurmTopology(t *testing.T) {
 				}
 				slurmNode := &slurmtypes.V0044Node{}
 				slurmNodeKey := slurmclient.ObjectKey(nodesetutils.GetSlurmNodeName(pod))
-				if err := sclient.Get(ctx, slurmNodeKey, slurmNode); err != nil {
-					t.Errorf("Get() failed: %v", err)
-				}
-				if !apiequality.Semantic.DeepEqual(topologySpec, ptr.Deref(slurmNode.Topology, "")) {
-					t.Errorf("Kube node and Slurm node topology are incongruent: Kube node = '%v' ; slurm node = '%v'", topologySpec, ptr.Deref(slurmNode.Topology, ""))
-				}
+				require.NoError(t, sclient.Get(ctx, slurmNodeKey, slurmNode), "Get() failed")
+				require.True(t, apiequality.Semantic.DeepEqual(topologySpec, ptr.Deref(slurmNode.Topology, "")), "Kube node and Slurm node topology are incongruent: Kube node = '%v' ; slurm node = '%v'", topologySpec, ptr.Deref(slurmNode.Topology, ""))
 			}
 		})
 	}
@@ -4543,20 +4495,16 @@ func TestGetNodesToDaemonPods(t *testing.T) {
 			gotPods := map[string]bool{}
 			for node, pods := range nodesToDaemonPods {
 				for _, pod := range pods {
-					if pod.Spec.NodeName != node {
-						t.Errorf("pod %v grouped into %v but belongs in %v", pod.Name, node, pod.Spec.NodeName)
-					}
+					require.Equal(t, node, pod.Spec.NodeName, "pod %v grouped into %v but belongs in %v", pod.Name, node, pod.Spec.NodeName)
 					gotPods[pod.Name] = true
 				}
 			}
 			for _, wantName := range tc.expectedPodNames {
-				if !gotPods[wantName] {
-					t.Errorf("expected pod %v but didn't get it", wantName)
-				}
+				require.True(t, gotPods[wantName], "expected pod %v but didn't get it", wantName)
 				delete(gotPods, wantName)
 			}
 			for podName := range gotPods {
-				t.Errorf("unexpected pod %v was returned", podName)
+				require.Fail(t, "unexpected pod was returned", "unexpected pod %v was returned", podName)
 			}
 		})
 	}
@@ -4701,12 +4649,8 @@ func TestNodeShouldRunDaemonPod(t *testing.T) {
 			r := newNodeSetController(client, nil)
 
 			shouldRun, shouldContinueRunning := r.NodeShouldRunDaemonPod(ctx, c.node, c.nodeset)
-			if shouldRun != c.shouldRun {
-				t.Errorf("NodeShouldRunDaemonPod(): predicateName: %v expected shouldRun: %v, got: %v", c.predicateName, c.shouldRun, shouldRun)
-			}
-			if shouldContinueRunning != c.shouldContinueRunning {
-				t.Errorf("NodeShouldRunDaemonPod(): predicateName: %v expected shouldContinueRunning: %v, got: %v", c.predicateName, c.shouldContinueRunning, shouldContinueRunning)
-			}
+			require.Equal(t, c.shouldRun, shouldRun, "NodeShouldRunDaemonPod(): predicateName: %v expected shouldRun: %v, got: %v", c.predicateName, c.shouldRun, shouldRun)
+			require.Equal(t, c.shouldContinueRunning, shouldContinueRunning, "NodeShouldRunDaemonPod(): predicateName: %v expected shouldContinueRunning: %v, got: %v", c.predicateName, c.shouldContinueRunning, shouldContinueRunning)
 		})
 	}
 }
@@ -4845,16 +4789,12 @@ func TestNodeSetReconciler_podsShouldBeOnNode(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			needing, toDelete := r.podsShouldBeOnNode(ctx, tt.node, tt.nodeToDaemonPods, tt.nodeset)
-			if !slices.Equal(needing, tt.expectedNeedingDaemonPods) {
-				t.Errorf("nodesNeedingDaemonPods = %v, want %v", needing, tt.expectedNeedingDaemonPods)
-			}
+			require.True(t, slices.Equal(needing, tt.expectedNeedingDaemonPods), "nodesNeedingDaemonPods = %v, want %v", needing, tt.expectedNeedingDaemonPods)
 			gotNames := make([]string, 0, len(toDelete))
 			for _, p := range toDelete {
 				gotNames = append(gotNames, p.Name)
 			}
-			if !slices.Equal(gotNames, tt.expectedPodNamesToDelete) {
-				t.Errorf("podsToDelete names = %v, want %v", gotNames, tt.expectedPodNamesToDelete)
-			}
+			require.True(t, slices.Equal(gotNames, tt.expectedPodNamesToDelete), "podsToDelete names = %v, want %v", gotNames, tt.expectedPodNamesToDelete)
 		})
 	}
 }
@@ -4960,22 +4900,16 @@ func TestNodeSetReconciler_syncSlurmNodes(t *testing.T) {
 			slurmNodeNames, ok, err := scontrol.GetNodesForPods(ctx, tt.nodeset, tt.pods)
 			require.NoError(t, err)
 			if !ok {
-				if ok != tt.wantOk {
-					t.Fatal("slurmControl used a client unexpectedly")
-				}
+				require.Equal(t, tt.wantOk, ok, "slurmControl used a client unexpectedly")
 				return
 			}
 			podList := &corev1.PodList{}
 			require.NoError(t, tt.kclient.List(ctx, podList))
-			if len(podList.Items) != len(slurmNodeNames) {
-				t.Errorf("syncSlurmNodes() unregistered Slurm node but healthy pod was not deleted")
-			}
+			require.Equal(t, len(slurmNodeNames), len(podList.Items), "syncSlurmNodes() unregistered Slurm node but healthy pod was not deleted")
 			slurmNodeNameSet := set.New(slurmNodeNames...)
 			for _, pod := range podList.Items {
 				slurmNodeName := nodesetutils.GetSlurmNodeName(&pod)
-				if !slurmNodeNameSet.Has(slurmNodeName) {
-					t.Errorf("syncSlurmNodes() unexpected pod exists: %v", slurmNodeName)
-				}
+				require.True(t, slurmNodeNameSet.Has(slurmNodeName), "syncSlurmNodes() unexpected pod exists: %v", slurmNodeName)
 			}
 		})
 	}

--- a/internal/controller/nodeset/podcontrol/podcontrol_test.go
+++ b/internal/controller/nodeset/podcontrol/podcontrol_test.go
@@ -8,8 +8,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"reflect"
-	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -775,9 +773,7 @@ func Test_realPodControl_createPersistentVolumeClaims(t *testing.T) {
 			}
 			if tt.wantEvent != "" {
 				event := testutils.ReadOneEvent(t, tt.fields.recorder)
-				if !strings.Contains(event, tt.wantEvent) {
-					t.Errorf("realPodControl.createPersistentVolumeClaims() event = %v, want substring %q", event, tt.wantEvent)
-				}
+				require.Contains(t, event, tt.wantEvent)
 			}
 			testutils.AssertNoEvents(t, tt.fields.recorder)
 		})

--- a/internal/controller/nodeset/podcontrol/podcontrol_test.go
+++ b/internal/controller/nodeset/podcontrol/podcontrol_test.go
@@ -32,6 +32,7 @@ import (
 	nodesetutils "github.com/SlinkyProject/slurm-operator/internal/controller/nodeset/utils"
 	"github.com/SlinkyProject/slurm-operator/internal/utils/podcontrol"
 	"github.com/SlinkyProject/slurm-operator/internal/utils/testutils"
+	"github.com/stretchr/testify/require"
 )
 
 func init() {
@@ -203,8 +204,11 @@ func Test_realPodControl_CreateNodeSetPod(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := NewPodControl(tt.fields.Client, tt.fields.recorder)
-			if err := r.CreateNodeSetPod(tt.args.ctx, tt.args.nodeset, tt.args.pod); (err != nil) != tt.wantErr {
-				t.Errorf("realPodControl.CreateNodeSetPod() error = %v, wantErr %v", err, tt.wantErr)
+			err := r.CreateNodeSetPod(tt.args.ctx, tt.args.nodeset, tt.args.pod)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 		})
 	}
@@ -263,8 +267,11 @@ func Test_realPodControl_DeleteNodeSetPod(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := NewPodControl(tt.fields.Client, tt.fields.recorder)
-			if err := r.DeleteNodeSetPod(tt.args.ctx, tt.args.nodeset, tt.args.pod); (err != nil) != tt.wantErr {
-				t.Errorf("realPodControl.DeleteNodeSetPod() error = %v, wantErr %v", err, tt.wantErr)
+			err := r.DeleteNodeSetPod(tt.args.ctx, tt.args.nodeset, tt.args.pod)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 		})
 	}
@@ -345,8 +352,11 @@ func Test_realPodControl_UpdateNodeSetPod(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := NewPodControl(tt.fields.Client, tt.fields.recorder)
-			if err := r.UpdateNodeSetPod(tt.args.ctx, tt.args.nodeset, tt.args.pod); (err != nil) != tt.wantErr {
-				t.Errorf("realPodControl.UpdateNodeSetPod() error = %v, wantErr %v", err, tt.wantErr)
+			err := r.UpdateNodeSetPod(tt.args.ctx, tt.args.nodeset, tt.args.pod)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 		})
 	}
@@ -431,13 +441,12 @@ func Test_realPodControl_PodPVCsMatchRetentionPolicy(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := NewPodControl(tt.fields.Client, tt.fields.recorder)
 			got, err := r.PodPVCsMatchRetentionPolicy(tt.args.ctx, tt.args.nodeset, tt.args.pod)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("realPodControl.PodPVCsMatchRetentionPolicy() error = %v, wantErr %v", err, tt.wantErr)
-				return
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
-			if got != tt.want {
-				t.Errorf("realPodControl.PodPVCsMatchRetentionPolicy() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -502,8 +511,11 @@ func Test_realPodControl_UpdatePodPVCsForRetentionPolicy(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := NewPodControl(tt.fields.Client, tt.fields.recorder)
-			if err := r.UpdatePodPVCsForRetentionPolicy(tt.args.ctx, tt.args.nodeset, tt.args.pod); (err != nil) != tt.wantErr {
-				t.Errorf("realPodControl.UpdatePodPVCsForRetentionPolicy() error = %v, wantErr %v", err, tt.wantErr)
+			err := r.UpdatePodPVCsForRetentionPolicy(tt.args.ctx, tt.args.nodeset, tt.args.pod)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 		})
 	}
@@ -614,9 +626,8 @@ func Test_realPodControl_IsPodPVCsStale(t *testing.T) {
 		r := NewPodControl(c, events.NewFakeRecorder(10))
 		expected := tc.expected
 		// Note that the error isn't / can't be tested.
-		if stale, _ := r.IsPodPVCsStale(context.TODO(), &nodeset, &pod); stale != expected {
-			t.Errorf("unexpected stale for %s", tc.name)
-		}
+		stale, _ := r.IsPodPVCsStale(context.TODO(), &nodeset, &pod)
+		require.Equal(t, expected, stale, "unexpected stale for %s", tc.name)
 	}
 }
 
@@ -756,8 +767,11 @@ func Test_realPodControl_createPersistentVolumeClaims(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := newPodControl(tt.fields.Client, tt.fields.recorder)
-			if err := r.createPersistentVolumeClaims(tt.args.ctx, tt.args.nodeset, tt.args.pod); (err != nil) != tt.wantErr {
-				t.Errorf("realPodControl.createPersistentVolumeClaims() error = %v, wantErr %v", err, tt.wantErr)
+			err := r.createPersistentVolumeClaims(tt.args.ctx, tt.args.nodeset, tt.args.pod)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 			if tt.wantEvent != "" {
 				event := testutils.ReadOneEvent(t, tt.fields.recorder)
@@ -874,9 +888,7 @@ func Test_isClaimOwnerUpToDate(t *testing.T) {
 					}
 					claim.SetOwnerReferences(claimRefs)
 					shouldMatch := setPodRef == tc.needsPodRef && setSetRef == tc.needsSetRef
-					if isClaimOwnerUpToDate(logger, &claim, &nodeset, &pod) != shouldMatch {
-						t.Errorf("Bad match for %s with pod=%v,nodeset=%v,others=%v", tc.name, setPodRef, setSetRef, useOtherRefs)
-					}
+					require.Equal(t, shouldMatch, isClaimOwnerUpToDate(logger, &claim, &nodeset, &pod), "Bad match for %s with pod=%v,nodeset=%v,others=%v", tc.name, setPodRef, setSetRef, useOtherRefs)
 				}
 			}
 		}
@@ -1059,9 +1071,7 @@ func TestEdgeCases_isClaimOwnerUpToDate(t *testing.T) {
 		nodeset.Spec.PersistentVolumeClaimRetentionPolicy = tc.policy
 		claim.SetOwnerReferences(tc.ownerRefs)
 		got := isClaimOwnerUpToDate(logger, &claim, &nodeset, &pod)
-		if got != tc.shouldMatch {
-			t.Errorf("Unexpected match for %s, got %t expected %t", tc.name, got, tc.shouldMatch)
-		}
+		require.Equal(t, tc.shouldMatch, got, "Unexpected match for %s", tc.name)
 	}
 }
 
@@ -1241,9 +1251,7 @@ func Test_hasUnexpectedController(t *testing.T) {
 		pod := &corev1.Pod{}
 		pod.SetName("pod")
 		pod.SetUID("pod-uid")
-		if hasUnexpectedController(target, nodeset, pod) {
-			t.Errorf("Any controller should be allowed when no retention policy (retain behavior) is specified. Incorrectly identified unexpected controller at %s", tc.name)
-		}
+		require.False(t, hasUnexpectedController(target, nodeset, pod), "Any controller should be allowed when no retention policy (retain behavior) is specified. Incorrectly identified unexpected controller at %s", tc.name)
 		const retainPolicy = slinkyv1beta1.RetainPersistentVolumeClaimRetentionPolicyType
 		const deletePolicy = slinkyv1beta1.DeletePersistentVolumeClaimRetentionPolicyType
 		for _, policy := range []slinkyv1beta1.NodeSetPersistentVolumeClaimRetentionPolicy{
@@ -1254,9 +1262,7 @@ func Test_hasUnexpectedController(t *testing.T) {
 		} {
 			nodeset.Spec.PersistentVolumeClaimRetentionPolicy = policy
 			got := hasUnexpectedController(target, nodeset, pod)
-			if got != tc.shouldReportUnexpectedController {
-				t.Errorf("Unexpected controller mismatch at %s (policy %v)", tc.name, policy)
-			}
+			require.Equal(t, tc.shouldReportUnexpectedController, got, "Unexpected controller mismatch at %s (policy %v)", tc.name, policy)
 		}
 	}
 }
@@ -1443,9 +1449,7 @@ func Test_hasNonControllerOwner(t *testing.T) {
 		nodeset.SetName("set")
 		nodeset.Spec.ScalingMode = slinkyv1beta1.ScalingModeStatefulset
 		got := hasNonControllerOwner(&claim, &nodeset, &pod)
-		if got != tc.nonController {
-			t.Errorf("Failed %s: got %t, expected %t", tc.name, got, tc.nonController)
-		}
+		require.Equal(t, tc.nonController, got, "Failed %s", tc.name)
 	}
 }
 
@@ -1582,12 +1586,8 @@ func Test_updateClaimOwnerRefForSetAndPod(t *testing.T) {
 				}
 				return false
 			}
-			if check(&claim, &pod) != tc.needsPodRef {
-				t.Errorf("Bad pod ref for %s hasPodRef=%v hasSetRef=%v", tc.name, hasPodRef, hasSetRef)
-			}
-			if check(&claim, &nodeset) != tc.needsSetRef {
-				t.Errorf("Bad nodeset ref for %s hasPodRef=%v hasSetRef=%v", tc.name, hasPodRef, hasSetRef)
-			}
+			require.Equal(t, tc.needsPodRef, check(&claim, &pod), "Bad pod ref for %s hasPodRef=%v hasSetRef=%v", tc.name, hasPodRef, hasSetRef)
+			require.Equal(t, tc.needsSetRef, check(&claim, &nodeset), "Bad nodeset ref for %s hasPodRef=%v hasSetRef=%v", tc.name, hasPodRef, hasSetRef)
 		}
 	}
 }
@@ -1624,9 +1624,7 @@ func Test_hasOwnerRef(t *testing.T) {
 		owner := corev1.Pod{}
 		owner.GetObjectMeta().SetUID(tc.uid)
 		got := hasOwnerRef(&target, &owner)
-		if got != tc.hasRef {
-			t.Errorf("Expected %t for %s, got %t", tc.hasRef, tc.uid, got)
-		}
+		require.Equal(t, tc.hasRef, got, "Expected %t for %s", tc.hasRef, tc.uid)
 	}
 }
 
@@ -1644,14 +1642,12 @@ func Test_getPersistentVolumeClaimRetentionPolicy(t *testing.T) {
 	nodeset.Spec.ScalingMode = slinkyv1beta1.ScalingModeStatefulset
 	nodeset.Spec.PersistentVolumeClaimRetentionPolicy = retainPolicy
 	got := getPersistentVolumeClaimRetentionPolicy(&nodeset)
-	if got.WhenScaled != slinkyv1beta1.RetainPersistentVolumeClaimRetentionPolicyType || got.WhenDeleted != slinkyv1beta1.RetainPersistentVolumeClaimRetentionPolicyType {
-		t.Errorf("Expected retain policy")
-	}
+	require.Equal(t, slinkyv1beta1.RetainPersistentVolumeClaimRetentionPolicyType, got.WhenScaled)
+	require.Equal(t, slinkyv1beta1.RetainPersistentVolumeClaimRetentionPolicyType, got.WhenDeleted)
 	nodeset.Spec.PersistentVolumeClaimRetentionPolicy = scaledownPolicy
 	got = getPersistentVolumeClaimRetentionPolicy(&nodeset)
-	if got.WhenScaled != slinkyv1beta1.DeletePersistentVolumeClaimRetentionPolicyType || got.WhenDeleted != slinkyv1beta1.RetainPersistentVolumeClaimRetentionPolicyType {
-		t.Errorf("Expected scaledown policy")
-	}
+	require.Equal(t, slinkyv1beta1.DeletePersistentVolumeClaimRetentionPolicyType, got.WhenScaled)
+	require.Equal(t, slinkyv1beta1.RetainPersistentVolumeClaimRetentionPolicyType, got.WhenDeleted)
 }
 
 func Test_hasStaleOwnerRef(t *testing.T) {
@@ -1669,15 +1665,9 @@ func Test_hasStaleOwnerRef(t *testing.T) {
 	ownerC := corev1.Pod{}
 	ownerC.Name = "yvonne"
 	ownerC.SetUID("345")
-	if hasStaleOwnerRef(&target, &ownerA, podGVK) {
-		t.Error("ownerA should not be stale")
-	}
-	if !hasStaleOwnerRef(&target, &ownerB, podGVK) {
-		t.Error("ownerB should be stale")
-	}
-	if hasStaleOwnerRef(&target, &ownerC, podGVK) {
-		t.Error("ownerC should not be stale")
-	}
+	require.False(t, hasStaleOwnerRef(&target, &ownerA, podGVK), "ownerA should not be stale")
+	require.True(t, hasStaleOwnerRef(&target, &ownerB, podGVK), "ownerB should be stale")
+	require.False(t, hasStaleOwnerRef(&target, &ownerC, podGVK), "ownerC should not be stale")
 }
 
 func Test_matchesRef(t *testing.T) {
@@ -1751,9 +1741,7 @@ func Test_matchesRef(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		got := matchesRef(&tc.ref, &tc.obj, tc.schema)
-		if got != tc.shouldMatch {
-			t.Errorf("Failed %s: got %t, expected %t", tc.name, got, tc.shouldMatch)
-		}
+		require.Equal(t, tc.shouldMatch, got, "Failed %s", tc.name)
 	}
 }
 
@@ -1796,9 +1784,8 @@ func Test_addControllerRef(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := addControllerRef(tt.args.refs, tt.args.owner, tt.args.gvk); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("addControllerRef() = %v, want %v", got, tt.want)
-			}
+			got := addControllerRef(tt.args.refs, tt.args.owner, tt.args.gvk)
+			require.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/internal/controller/nodeset/slurmcontrol/slurmcontrol_test.go
+++ b/internal/controller/nodeset/slurmcontrol/slurmcontrol_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"net/http"
-	"reflect"
 	"slices"
 	"testing"
 	"time"
@@ -24,6 +23,7 @@ import (
 	"github.com/SlinkyProject/slurm-operator/internal/utils/podinfo"
 	slurmconditions "github.com/SlinkyProject/slurm-operator/pkg/conditions"
 	"github.com/puttsk/hostlist"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -151,13 +151,16 @@ func Test_realSlurmControl_UpdateNodeWithPodInfo(t *testing.T) {
 			sclient := fake.NewClientBuilder().WithUpdateFn(slurmUpdateFn).WithObjects(tt.fields.node).Build()
 			controllerName := tt.args.nodeset.Spec.ControllerRef.Name
 			r := NewSlurmControl(newSlurmClientMap(controllerName, sclient))
-			if err := r.UpdateNodeWithPodInfo(tt.args.ctx, tt.args.nodeset, tt.args.pod); (err != nil) != tt.wantErr {
-				t.Errorf("UpdateNodeWithPodInfo() error = %v, wantErr %v", err, tt.wantErr)
+			err := r.UpdateNodeWithPodInfo(tt.args.ctx, tt.args.nodeset, tt.args.pod)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 			checkNode := &types.V0044Node{}
-			if err := sclient.Get(ctx, tt.fields.node.GetKey(), checkNode); err != nil {
-				if !tolerateError(err) {
-					t.Fatalf("client.Get() err = %v", err)
+			if getErr := sclient.Get(ctx, tt.fields.node.GetKey(), checkNode); getErr != nil {
+				if !tolerateError(getErr) {
+					require.NoError(t, getErr)
 				}
 			}
 			checkPodInfo := podinfo.PodInfo{}
@@ -267,23 +270,22 @@ func Test_realSlurmControl_MakeNodeDrain(t *testing.T) {
 			sclient := fake.NewClientBuilder().WithUpdateFn(slurmUpdateFn).WithObjects(tt.fields.node).Build()
 			controllerName := tt.args.nodeset.Spec.ControllerRef.Name
 			r := NewSlurmControl(newSlurmClientMap(controllerName, sclient))
-			if err := r.MakeNodeDrain(tt.args.ctx, tt.args.nodeset, tt.args.pod, tt.args.reason, tt.args.overrideReason); (err != nil) != tt.wantErr {
-				t.Errorf("MakeNodeDrain() error = %v, wantErr %v", err, tt.wantErr)
+			err := r.MakeNodeDrain(tt.args.ctx, tt.args.nodeset, tt.args.pod, tt.args.reason, tt.args.overrideReason)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 			checkNode := &types.V0044Node{}
-			if err := sclient.Get(ctx, tt.fields.node.GetKey(), checkNode); err != nil {
-				if !tolerateError(err) {
-					t.Fatalf("client.Get() err = %v", err)
+			if getErr := sclient.Get(ctx, tt.fields.node.GetKey(), checkNode); getErr != nil {
+				if !tolerateError(getErr) {
+					require.NoError(t, getErr)
 				}
 			}
 			isDrain := checkNode.GetStateAsSet().Has(api.V0044NodeStateDRAIN)
-			if !isDrain {
-				t.Fatalf("MakeNodeDrain() failed to DRAIN the node")
-			}
+			require.True(t, isDrain, "MakeNodeDrain() failed to DRAIN the node")
 			nodeReason := ptr.Deref(checkNode.Reason, "")
-			if nodeReason != tt.wantReason {
-				t.Fatalf("MakeNodeDrain() reason = '%s', want = '%s'", nodeReason, tt.wantReason)
-			}
+			require.Equal(t, tt.wantReason, nodeReason)
 		})
 	}
 }
@@ -360,19 +362,20 @@ func Test_realSlurmControl_MakeNodeUndrain(t *testing.T) {
 			sclient := fake.NewClientBuilder().WithUpdateFn(slurmUpdateFn).WithObjects(tt.fields.node).Build()
 			controllerName := tt.args.nodeset.Spec.ControllerRef.Name
 			r := NewSlurmControl(newSlurmClientMap(controllerName, sclient))
-			if err := r.MakeNodeUndrain(tt.args.ctx, tt.args.nodeset, tt.args.pod, tt.args.reason); (err != nil) != tt.wantErr {
-				t.Errorf("MakeNodeUndrain() error = %v, wantErr %v", err, tt.wantErr)
+			err := r.MakeNodeUndrain(tt.args.ctx, tt.args.nodeset, tt.args.pod, tt.args.reason)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 			checkNode := &types.V0044Node{}
-			if err := sclient.Get(ctx, tt.fields.node.GetKey(), checkNode); err != nil {
-				if !tolerateError(err) {
-					t.Fatalf("client.Get() = %v", err)
+			if getErr := sclient.Get(ctx, tt.fields.node.GetKey(), checkNode); getErr != nil {
+				if !tolerateError(getErr) {
+					require.NoError(t, getErr)
 				}
 			}
 			isUndrain := !checkNode.GetStateAsSet().Has(api.V0044NodeStateDRAIN)
-			if isUndrain != tt.wantUndrain {
-				t.Fatalf("MakeNodeUndrain() = %v", isUndrain)
-			}
+			require.Equal(t, tt.wantUndrain, isUndrain)
 		})
 	}
 }
@@ -445,18 +448,21 @@ func Test_realSlurmControl_UpdateNodeTopology(t *testing.T) {
 			sclient := fake.NewClientBuilder().WithUpdateFn(slurmUpdateFn).WithObjects(tt.fields.node).Build()
 			controllerName := tt.args.nodeset.Spec.ControllerRef.Name
 			r := NewSlurmControl(newSlurmClientMap(controllerName, sclient))
-			if err := r.UpdateNodeTopology(tt.args.ctx, tt.args.nodeset, tt.args.pod, tt.args.topologySpec); (err != nil) != tt.wantErr {
-				t.Errorf("UpdateNodeTopology() error = %v, wantErr %v", err, tt.wantErr)
+			err := r.UpdateNodeTopology(tt.args.ctx, tt.args.nodeset, tt.args.pod, tt.args.topologySpec)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 			checkNode := &types.V0044Node{}
-			if err := sclient.Get(ctx, tt.fields.node.GetKey(), checkNode); err != nil {
-				if !tolerateError(err) {
-					t.Fatalf("client.Get() = %v", err)
+			if getErr := sclient.Get(ctx, tt.fields.node.GetKey(), checkNode); getErr != nil {
+				if !tolerateError(getErr) {
+					require.NoError(t, getErr)
 				}
 			}
 			got := ptr.Deref(checkNode.Topology, "")
 			if !apiequality.Semantic.DeepEqual(got, tt.args.topologySpec) {
-				t.Fatalf("UpdateNodeTopology() topologySpec = %v", got)
+				t.Errorf("UpdateNodeTopology() topologySpec = %v", got)
 			}
 		})
 	}
@@ -701,13 +707,12 @@ func Test_realSlurmControl_IsNodeDrain(t *testing.T) {
 				clientMap: tt.fields.clientMap,
 			}
 			got, err := r.IsNodeDrain(tt.args.ctx, tt.args.nodeset, tt.args.pod)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("realSlurmControl.IsNodeDrain() error = %v, wantErr %v", err, tt.wantErr)
-				return
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
-			if got != tt.want {
-				t.Errorf("realSlurmControl.IsNodeDrain() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -986,12 +991,12 @@ func Test_realSlurmControl_IsNodeDrained(t *testing.T) {
 				clientMap: tt.fields.clientMap,
 			}
 			got, err := r.IsNodeDrained(tt.args.ctx, tt.args.nodeset, tt.args.pod)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("realSlurmControl.IsNodeDrained() error = %v, wantErr %v", err, tt.wantErr)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
-			if got != tt.want {
-				t.Errorf("realSlurmControl.IsNodeDrained() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -1342,12 +1347,12 @@ func Test_realSlurmControl_IsNodeDownForUnresponsive(t *testing.T) {
 				clientMap: tt.fields.clientMap,
 			}
 			got, err := r.IsNodeDownForUnresponsive(tt.args.ctx, tt.args.nodeset, tt.args.pod)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("realSlurmControl.IsNodeDownForUnresponsive() error = %v, wantErr %v", err, tt.wantErr)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
-			if got != tt.want {
-				t.Errorf("realSlurmControl.IsNodeDownForUnresponsive() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -1454,12 +1459,12 @@ func Test_realSlurmControl_IsNodeReasonOurs(t *testing.T) {
 				clientMap: tt.fields.clientMap,
 			}
 			got, err := r.IsNodeReasonOurs(tt.args.ctx, tt.args.nodeset, tt.args.pod)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("realSlurmControl.IsNodeReasonOurs() error = %v, wantErr %v", err, tt.wantErr)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
-			if got != tt.want {
-				t.Errorf("realSlurmControl.IsNodeReasonOurs() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -2207,8 +2212,10 @@ func Test_realSlurmControl_CalculateNodeStatus(t *testing.T) {
 				clientMap: tt.fields.clientMap,
 			}
 			got, err := r.CalculateNodeStatus(tt.args.ctx, tt.args.nodeset, tt.args.pods)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("realSlurmControl.CalculateNodeStatus() error = %v, wantErr %v", err, tt.wantErr)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 			if !apiequality.Semantic.DeepEqual(got, tt.want) {
 				t.Errorf("realSlurmControl.CalculateNodeStatus() = %v, want %v", got, tt.want)
@@ -2362,15 +2369,14 @@ func Test_realSlurmControl_GetNodeDeadlines(t *testing.T) {
 			controllerName := tt.args.nodeset.Spec.ControllerRef.Name
 			r := NewSlurmControl(newSlurmClientMap(controllerName, sclient))
 			got, err := r.GetNodeDeadlines(tt.args.ctx, tt.args.nodeset, tt.args.pods)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("GetNodeDeadlines() error = %v, wantErr %v", err, tt.wantErr)
-				return
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 			for _, node := range tt.fields.nodeList.Items {
-				if ts := got.Peek(ptr.Deref(node.Name, "")); !ts.After(now) {
-					t.Errorf("timestamp = %v, after = %v", ts, ts.After(now))
-				}
-
+				ts := got.Peek(ptr.Deref(node.Name, ""))
+				require.True(t, ts.After(now), "timestamp = %v, after = %v", ts, ts.After(now))
 			}
 		})
 	}
@@ -2454,19 +2460,19 @@ func Test_realSlurmControl_GetNodesForPods(t *testing.T) {
 			r := NewSlurmControl(newSlurmClientMap(controllerName, sclient))
 			got, ok, gotErr := r.GetNodesForPods(context.Background(), tt.nodeset, tt.pods)
 			if gotErr != nil {
-				if !tt.wantErr {
-					t.Errorf("GetNodesForPods() failed: %v", gotErr)
+				if tt.wantErr {
+					require.Error(t, gotErr)
+				} else {
+					require.NoError(t, gotErr)
 				}
 				return
 			}
 			if !ok {
-				if ok != tt.wantOk {
-					t.Fatalf("GetNodesForPods() ok %v, want %v", ok, tt.wantOk)
-				}
+				require.Equal(t, tt.wantOk, ok)
 				return
 			}
 			if tt.wantErr {
-				t.Fatal("GetNodesForPods() succeeded unexpectedly")
+				require.NoError(t, gotErr, "GetNodesForPods() succeeded unexpectedly")
 			}
 			slices.Sort(got)
 			slices.Sort(tt.want)
@@ -2480,9 +2486,7 @@ func Test_realSlurmControl_GetNodesForPods(t *testing.T) {
 func Test_realSlurmControl_CheckReservationForNodeSet(t *testing.T) {
 	// Configure times for testing
 	now, err := time.Parse(time.RFC3339, "2026-03-04T00:00:00Z")
-	if err != nil {
-		t.Errorf("Failed to initialize test. Failed to parse time: %v", err)
-	}
+	require.NoError(t, err)
 	startTime := now.Unix()
 	endTime := now.Add(time.Hour).Unix()
 
@@ -2558,18 +2562,12 @@ func Test_realSlurmControl_CheckReservationForNodeSet(t *testing.T) {
 			r := NewSlurmControl(newSlurmClientMap(controllerName, tt.client))
 
 			got, gotErr := r.CheckReservationForNodeSet(context.Background(), tt.nodeset)
-			if gotErr != nil {
-				if !tt.wantErr {
-					t.Errorf("CheckReservationForNodeSet() error = %v, wantErr %v", gotErr, tt.wantErr)
-				}
-				return
-			}
 			if tt.wantErr {
-				t.Fatalf("CheckReservationForNodeSet() error = %v, wantErr %v", gotErr, tt.wantErr)
+				require.Error(t, gotErr)
+			} else {
+				require.NoError(t, gotErr)
 			}
-			if got != tt.want {
-				t.Fatalf("CheckReservationForNodeSet() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -2584,9 +2582,7 @@ func Test_realSlurmControl_GetPodsUnderReservation(t *testing.T) {
 
 	// Configure times for testing
 	future, err := time.Parse(time.RFC3339, "2099-03-04T00:00:00Z")
-	if err != nil {
-		t.Errorf("Failed to initialize test. Failed to parse time: %v", err)
-	}
+	require.NoError(t, err)
 	startTimeFuture := future.Unix()
 	endTimeFuture := future.Add(time.Hour).Unix()
 
@@ -2755,15 +2751,11 @@ func Test_realSlurmControl_GetPodsUnderReservation(t *testing.T) {
 			r := NewSlurmControl(newSlurmClientMap(controllerName, tt.client))
 
 			got, gotErr := r.GetPodsUnderReservation(context.Background(), tt.nodeset, tt.pods)
-			if gotErr != nil {
-				if !tt.wantErr {
-					t.Errorf("GetReservation() failed: %v", gotErr)
-				}
+			if tt.wantErr {
+				require.Error(t, gotErr)
 				return
 			}
-			if tt.wantErr {
-				t.Fatal("GetReservation() succeeded unexpectedly")
-			}
+			require.NoError(t, gotErr)
 			if !apiequality.Semantic.DeepEqual(got, tt.want) {
 				t.Errorf("UpdateNodeWithPodInfo() got = %v, want %v", got, tt.want)
 			}
@@ -2774,9 +2766,7 @@ func Test_realSlurmControl_GetPodsUnderReservation(t *testing.T) {
 func Test_realSlurmControl_DeleteReservationForNodeSet(t *testing.T) {
 	// Configure times for testing
 	now, err := time.Parse(time.RFC3339, "2026-03-04T00:00:00Z")
-	if err != nil {
-		t.Errorf("Failed to initialize test. Failed to parse time: %v", err)
-	}
+	require.NoError(t, err)
 	startTime := now.Unix()
 	endTime := now.Add(time.Hour).Unix()
 
@@ -2864,14 +2854,10 @@ func Test_realSlurmControl_DeleteReservationForNodeSet(t *testing.T) {
 			r := NewSlurmControl(newSlurmClientMap(controllerName, tt.client))
 
 			gotErr := r.DeleteReservationForNodeSet(context.Background(), tt.nodeset)
-			if gotErr != nil {
-				if !tt.wantErr {
-					t.Errorf("GetReservation() failed: %v", gotErr)
-				}
-				return
-			}
 			if tt.wantErr {
-				t.Fatal("GetReservation() succeeded unexpectedly")
+				require.Error(t, gotErr)
+			} else {
+				require.NoError(t, gotErr)
 			}
 		})
 	}
@@ -3406,14 +3392,10 @@ func Test_realSlurmControl_SyncReservationForNodeSet(t *testing.T) {
 			r := NewSlurmControl(newSlurmClientMap(controllerName, tt.client))
 
 			gotErr := r.SyncReservationForNodeSet(context.Background(), tt.nodeset, tt.pods)
-			if gotErr != nil {
-				if !tt.wantErr {
-					t.Errorf("SyncReservationForNodeSet() failed: %v", gotErr)
-				}
-				return
-			}
 			if tt.wantErr {
-				t.Fatal("SyncReservationForNodeSet() succeeded unexpectedly")
+				require.Error(t, gotErr)
+			} else {
+				require.NoError(t, gotErr)
 			}
 		})
 	}
@@ -3466,9 +3448,8 @@ func Test_tolerateError(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tolerateError(tt.args.err); got != tt.want {
-				t.Errorf("tolerateError() = %v, want %v", got, tt.want)
-			}
+			got := tolerateError(tt.args.err)
+			require.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -3550,9 +3531,8 @@ func Test_nodeState(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := nodeState(tt.args.node, tt.args.state); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("nodeState() = %v, want %v", got, tt.want)
-			}
+			got := nodeState(tt.args.node, tt.args.state)
+			require.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -3670,15 +3650,13 @@ func Test_realSlurmControl_GetDefunctNodesForNodeSet(t *testing.T) {
 
 			r := &realSlurmControl{clientMap: clientMap}
 			got, ok, err := r.GetDefunctNodesForNodeSet(ctx, nodeset)
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("GetDefunctNodesForNodeSet() error = %v, wantErr %v", err, tt.wantErr)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
-			if ok != tt.wantOk {
-				t.Fatalf("GetDefunctNodesForNodeSet() ok = %v, want %v", ok, tt.wantOk)
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Fatalf("GetDefunctNodesForNodeSet() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.wantOk, ok)
+			require.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -3703,13 +3681,10 @@ func Test_realSlurmControl_DeleteNode(t *testing.T) {
 	sclient := fake.NewClientBuilder().WithObjects(node).Build()
 	r := &realSlurmControl{clientMap: newSlurmClientMap(controller.Name, sclient)}
 
-	if err := r.DeleteNode(ctx, nodeset, "foo-0"); err != nil {
-		t.Fatalf("DeleteNode() error = %v", err)
-	}
+	err := r.DeleteNode(ctx, nodeset, "foo-0")
+	require.NoError(t, err)
 
 	checkNode := &types.V0044Node{}
-	err := sclient.Get(ctx, node.GetKey(), checkNode)
-	if !tolerateError(err) {
-		t.Fatalf("DeleteNode() node still exists: %v", err)
-	}
+	getErr := sclient.Get(ctx, node.GetKey(), checkNode)
+	require.True(t, tolerateError(getErr), "DeleteNode() node still exists: %v", getErr)
 }

--- a/internal/controller/nodeset/slurmcontrol/slurmcontrol_test.go
+++ b/internal/controller/nodeset/slurmcontrol/slurmcontrol_test.go
@@ -222,12 +222,12 @@ func Test_realSlurmControl_MakeNodeDrain(t *testing.T) {
 			fields: fields{
 				node: &types.V0044Node{
 					V0044Node: api.V0044Node{
-						Name: new(nodesetutils.GetSlurmNodeName(pod)),
-						State: new([]api.V0044NodeState{
+						Name: ptr.To(nodesetutils.GetSlurmNodeName(pod)),
+						State: ptr.To([]api.V0044NodeState{
 							api.V0044NodeStateIDLE,
 							api.V0044NodeStateDRAIN,
 						}),
-						Reason: new("already drained"),
+						Reason: ptr.To("already drained"),
 					},
 				},
 			},
@@ -244,12 +244,12 @@ func Test_realSlurmControl_MakeNodeDrain(t *testing.T) {
 			fields: fields{
 				node: &types.V0044Node{
 					V0044Node: api.V0044Node{
-						Name: new(nodesetutils.GetSlurmNodeName(pod)),
-						State: new([]api.V0044NodeState{
+						Name: ptr.To(nodesetutils.GetSlurmNodeName(pod)),
+						State: ptr.To([]api.V0044NodeState{
 							api.V0044NodeStateIDLE,
 							api.V0044NodeStateDRAIN,
 						}),
-						Reason: new("already drained"),
+						Reason: ptr.To("already drained"),
 					},
 				},
 			},
@@ -589,21 +589,24 @@ func Test_realSlurmControl_UpdateNodeFeatures(t *testing.T) {
 			sclient := builder.Build()
 			controllerName := tt.args.nodeset.Spec.ControllerRef.Name
 			r := NewSlurmControl(newSlurmClientMap(controllerName, sclient))
-			if err := r.UpdateNodeFeatures(tt.args.ctx, tt.args.nodeset, tt.args.pod, prefix, tt.args.features); (err != nil) != tt.wantErr {
-				t.Errorf("UpdateNodeFeatures() error = %v, wantErr %v", err, tt.wantErr)
+			err := r.UpdateNodeFeatures(tt.args.ctx, tt.args.nodeset, tt.args.pod, prefix, tt.args.features)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
 			}
-			if tt.wantSkip && updates != 0 {
-				t.Errorf("UpdateNodeFeatures() issued %d update(s), want 0 (already in sync)", updates)
+			require.NoError(t, err)
+			if tt.wantSkip {
+				require.Zero(t, updates, "UpdateNodeFeatures() issued %d update(s), want 0 (already in sync)", updates)
 			}
 			// The Slurm node feature set is only well-defined on the success path; for
 			// the tolerated-404 and error cases there is nothing to assert.
-			if tt.notRegistered || tt.wantErr {
+			if tt.notRegistered {
 				return
 			}
 			checkNode := &types.V0044Node{}
-			if err := sclient.Get(ctx, tt.node.GetKey(), checkNode); err != nil {
-				if !tolerateError(err) {
-					t.Fatalf("client.Get() = %v", err)
+			if getErr := sclient.Get(ctx, tt.node.GetKey(), checkNode); getErr != nil {
+				if !tolerateError(getErr) {
+					require.NoError(t, getErr)
 				}
 			}
 			gotAvail := ptr.Deref(checkNode.Features, api.V0044CsvString{})
@@ -614,12 +617,8 @@ func Test_realSlurmControl_UpdateNodeFeatures(t *testing.T) {
 			wantActive := slices.Clone(tt.wantActive)
 			slices.Sort(wantAvail)
 			slices.Sort(wantActive)
-			if !slices.Equal(gotAvail, wantAvail) {
-				t.Errorf("UpdateNodeFeatures() available = %v, want %v", gotAvail, wantAvail)
-			}
-			if !slices.Equal(gotActive, wantActive) {
-				t.Errorf("UpdateNodeFeatures() active = %v, want %v", gotActive, wantActive)
-			}
+			require.Equal(t, wantAvail, gotAvail, "UpdateNodeFeatures() available features mismatch")
+			require.Equal(t, wantActive, gotActive, "UpdateNodeFeatures() active features mismatch")
 		})
 	}
 }
@@ -1409,7 +1408,7 @@ func Test_realSlurmControl_IsNodeReasonOurs(t *testing.T) {
 						State: ptr.To([]api.V0044NodeState{
 							api.V0044NodeStateDOWN,
 						}),
-						Reason: new(FormatNodeReason("foo")),
+						Reason: ptr.To(FormatNodeReason("foo")),
 					},
 				}
 				sclient := fake.NewClientBuilder().WithObjects(node).Build()

--- a/internal/controller/nodeset/slurmcontrol/slurmcontrol_test.go
+++ b/internal/controller/nodeset/slurmcontrol/slurmcontrol_test.go
@@ -165,9 +165,7 @@ func Test_realSlurmControl_UpdateNodeWithPodInfo(t *testing.T) {
 			}
 			checkPodInfo := podinfo.PodInfo{}
 			_ = podinfo.ParseIntoPodInfo(checkNode.Comment, &checkPodInfo)
-			if !apiequality.Semantic.DeepEqual(checkPodInfo, tt.wantPodInfo) {
-				t.Errorf("UpdateNodeWithPodInfo() podInfo = %v, want %v", checkPodInfo, tt.wantPodInfo)
-			}
+			require.True(t, apiequality.Semantic.DeepEqual(checkPodInfo, tt.wantPodInfo), "UpdateNodeWithPodInfo() podInfo = %v, want %v", checkPodInfo, tt.wantPodInfo)
 		})
 	}
 }
@@ -461,9 +459,7 @@ func Test_realSlurmControl_UpdateNodeTopology(t *testing.T) {
 				}
 			}
 			got := ptr.Deref(checkNode.Topology, "")
-			if !apiequality.Semantic.DeepEqual(got, tt.args.topologySpec) {
-				t.Errorf("UpdateNodeTopology() topologySpec = %v", got)
-			}
+			require.True(t, apiequality.Semantic.DeepEqual(got, tt.args.topologySpec), "UpdateNodeTopology() topologySpec = %v", got)
 		})
 	}
 }
@@ -2217,9 +2213,7 @@ func Test_realSlurmControl_CalculateNodeStatus(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
-			if !apiequality.Semantic.DeepEqual(got, tt.want) {
-				t.Errorf("realSlurmControl.CalculateNodeStatus() = %v, want %v", got, tt.want)
-			}
+			require.True(t, apiequality.Semantic.DeepEqual(got, tt.want), "realSlurmControl.CalculateNodeStatus() = %v, want %v", got, tt.want)
 		})
 	}
 }
@@ -2476,9 +2470,7 @@ func Test_realSlurmControl_GetNodesForPods(t *testing.T) {
 			}
 			slices.Sort(got)
 			slices.Sort(tt.want)
-			if !apiequality.Semantic.DeepEqual(got, tt.want) {
-				t.Errorf("GetNodesForPods() = %v, want %v", got, tt.want)
-			}
+			require.True(t, apiequality.Semantic.DeepEqual(got, tt.want), "GetNodesForPods() = %v, want %v", got, tt.want)
 		})
 	}
 }
@@ -2756,9 +2748,7 @@ func Test_realSlurmControl_GetPodsUnderReservation(t *testing.T) {
 				return
 			}
 			require.NoError(t, gotErr)
-			if !apiequality.Semantic.DeepEqual(got, tt.want) {
-				t.Errorf("UpdateNodeWithPodInfo() got = %v, want %v", got, tt.want)
-			}
+			require.True(t, apiequality.Semantic.DeepEqual(got, tt.want), "UpdateNodeWithPodInfo() got = %v, want %v", got, tt.want)
 		})
 	}
 }

--- a/internal/controller/nodeset/utils/sort_test.go
+++ b/internal/controller/nodeset/utils/sort_test.go
@@ -627,12 +627,8 @@ func TestSplitUnhealthyPods(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gotUnhealthyPods, gotHealthyPods := SplitUnhealthyPods(tt.args.pods)
-			if !apiequality.Semantic.DeepEqual(gotUnhealthyPods, tt.wantUnhealthyPods) {
-				t.Errorf("SplitUnhealthyPods() gotUnhealthyPods = %v, want %v", gotUnhealthyPods, tt.wantUnhealthyPods)
-			}
-			if !apiequality.Semantic.DeepEqual(gotHealthyPods, tt.wantHealthyPods) {
-				t.Errorf("SplitUnhealthyPods() gotHealthyPods = %v, want %v", gotHealthyPods, tt.wantHealthyPods)
-			}
+			require.True(t, apiequality.Semantic.DeepEqual(gotUnhealthyPods, tt.wantUnhealthyPods), "SplitUnhealthyPods() gotUnhealthyPods = %v, want %v", gotUnhealthyPods, tt.wantUnhealthyPods)
+			require.True(t, apiequality.Semantic.DeepEqual(gotHealthyPods, tt.wantHealthyPods), "SplitUnhealthyPods() gotHealthyPods = %v, want %v", gotHealthyPods, tt.wantHealthyPods)
 		})
 	}
 }

--- a/internal/controller/nodeset/utils/sort_test.go
+++ b/internal/controller/nodeset/utils/sort_test.go
@@ -10,13 +10,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSortingActivePods(t *testing.T) {
@@ -301,9 +301,7 @@ func TestSortingActivePods(t *testing.T) {
 					gotOrder[i] = randomizedPods[i].Name
 				}
 
-				if diff := cmp.Diff(test.wantOrder, gotOrder); diff != "" {
-					t.Errorf("Sorted active pod names (-want,+got):\n%s", diff)
-				}
+				require.Equal(t, test.wantOrder, gotOrder)
 			}
 		})
 	}
@@ -370,9 +368,8 @@ func Test_afterOrZero(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := afterOrZero(tt.args.t1, tt.args.t2); got != tt.want {
-				t.Errorf("afterOrZero() = %v, want %v", got, tt.want)
-			}
+			got := afterOrZero(tt.args.t1, tt.args.t2)
+			require.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -447,12 +444,8 @@ func TestSplitActivePods(t *testing.T) {
 				gotPods2Names[i] = gotPods2[i].Name
 			}
 
-			if diff := cmp.Diff(tt.wantPods1Names, gotPods1Names); diff != "" {
-				t.Errorf("Sorted active pod names (-want,+got):\n%s", diff)
-			}
-			if diff := cmp.Diff(tt.wantPods2Names, gotPods2Names); diff != "" {
-				t.Errorf("Sorted active pod names (-want,+got):\n%s", diff)
-			}
+			require.Equal(t, tt.wantPods1Names, gotPods1Names)
+			require.Equal(t, tt.wantPods2Names, gotPods2Names)
 		})
 	}
 }
@@ -517,9 +510,7 @@ func TestExcludePods(t *testing.T) {
 			for i := range got {
 				gotNames[i] = got[i].Name
 			}
-			if diff := cmp.Diff(tt.wantNames, gotNames); diff != "" {
-				t.Errorf("ExcludePods() names (-want,+got):\n%s", diff)
-			}
+			require.Equal(t, tt.wantNames, gotNames)
 		})
 	}
 }

--- a/internal/controller/nodeset/utils/utils_test.go
+++ b/internal/controller/nodeset/utils/utils_test.go
@@ -890,9 +890,8 @@ func TestGetPersistentVolumeClaims(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := GetPersistentVolumeClaims(tt.args.nodeset, tt.args.pod); !apiequality.Semantic.DeepEqual(got, tt.want) {
-				t.Errorf("GetPersistentVolumeClaims() = %v, want %v", got, tt.want)
-			}
+			got := GetPersistentVolumeClaims(tt.args.nodeset, tt.args.pod)
+			require.True(t, apiequality.Semantic.DeepEqual(got, tt.want), "GetPersistentVolumeClaims() = %v, want %v", got, tt.want)
 		})
 	}
 }

--- a/internal/controller/nodeset/utils/utils_test.go
+++ b/internal/controller/nodeset/utils/utils_test.go
@@ -25,6 +25,7 @@ import (
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
 	"github.com/SlinkyProject/slurm-operator/internal/builder/labels"
 	"github.com/SlinkyProject/slurm-operator/internal/utils/historycontrol"
+	"github.com/stretchr/testify/require"
 )
 
 func newNodeSet(name string) *slinkyv1beta1.NodeSet {
@@ -270,9 +271,8 @@ func TestIsPodFromNodeSet(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := IsPodFromNodeSet(tt.args.nodeset, tt.args.pod); got != tt.want {
-				t.Errorf("IsPodFromNodeSet() = %v, want %v", got, tt.want)
-			}
+			got := IsPodFromNodeSet(tt.args.nodeset, tt.args.pod)
+			require.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -308,9 +308,8 @@ func TestGetOrdinal(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := GetOrdinal(tt.args.pod); got != tt.want {
-				t.Errorf("GetOrdinal() = %v, want %v", got, tt.want)
-			}
+			got := GetOrdinal(tt.args.pod)
+			require.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -350,12 +349,8 @@ func TestGetParentNameAndOrdinal(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, got1 := GetParentNameAndOrdinal(tt.args.pod)
-			if got != tt.want {
-				t.Errorf("GetParentNameAndOrdinal() got = %v, want %v", got, tt.want)
-			}
-			if got1 != tt.want1 {
-				t.Errorf("GetParentNameAndOrdinal() got1 = %v, want %v", got1, tt.want1)
-			}
+			require.Equal(t, tt.want, got)
+			require.Equal(t, tt.want1, got1)
 		})
 	}
 }
@@ -389,9 +384,8 @@ func TestOrdinalGetPodName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := GetOrdinalPodName(tt.args.nodeset, tt.args.ordinal); got != tt.want {
-				t.Errorf("GetOrdinalPodName() = %v, want %v", got, tt.want)
-			}
+			got := GetOrdinalPodName(tt.args.nodeset, tt.args.ordinal)
+			require.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -427,9 +421,8 @@ func TestGetSlurmNodeName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := GetSlurmNodeName(tt.args.pod); got != tt.want {
-				t.Errorf("GetSlurmNodeName() = %v, want %v", got, tt.want)
-			}
+			got := GetSlurmNodeName(tt.args.pod)
+			require.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -523,9 +516,8 @@ func TestIsIdentityMatch(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := IsIdentityMatch(tt.args.nodeset, tt.args.pod); got != tt.want {
-				t.Errorf("IsIdentityMatch() = %v, want %v", got, tt.want)
-			}
+			got := IsIdentityMatch(tt.args.nodeset, tt.args.pod)
+			require.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -596,40 +588,22 @@ func TestNewNodeSetDaemonSetPod(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			pod := NewNodeSetDaemonSetPod(client, nodeset, controller, tt.args.nodeName, tt.args.hostnameOverride, tt.args.revisionHash)
-			if pod == nil {
-				t.Fatal("NewNodeSetDaemonSetPod() returned nil")
-			}
+			require.NotNil(t, pod)
 			if tt.checkIdentity {
 				wantHostname := GetDaemonSetPodHostname(tt.args.nodeName, tt.args.hostnameOverride)
-				if pod.GenerateName != nodeset.Name+"-" {
-					t.Errorf("GenerateName = %q, want %q", pod.GenerateName, nodeset.Name+"-")
-				}
-				if pod.Name != "" {
-					t.Errorf("Name = %q, want %q", pod.Name, "")
-				}
-				if pod.Namespace != nodeset.Namespace {
-					t.Errorf("Namespace = %q, want %q", pod.Namespace, nodeset.Namespace)
-				}
-				if pod.Spec.Hostname != wantHostname {
-					t.Errorf("Spec.Hostname = %q, want %q", pod.Spec.Hostname, wantHostname)
-				}
-				if pod.Spec.NodeName != "" {
-					t.Errorf("Spec.NodeName = %q, want empty", pod.Spec.NodeName)
-				}
-				if got := pod.Labels[slinkyv1beta1.LabelNodeSetPodHostname]; got != wantHostname {
-					t.Errorf("Labels[%s] = %q, want %q", slinkyv1beta1.LabelNodeSetPodHostname, got, wantHostname)
-				}
-				if got := pod.Labels[slinkyv1beta1.LabelNodeSetScalingMode]; got != string(slinkyv1beta1.ScalingModeDaemonset) {
-					t.Errorf("Labels[%s] = %q, want %q", slinkyv1beta1.LabelNodeSetScalingMode, got, string(slinkyv1beta1.ScalingModeDaemonset))
-				}
-				if len(pod.OwnerReferences) != 1 || pod.OwnerReferences[0].Kind != slinkyv1beta1.NodeSetKind || pod.OwnerReferences[0].Name != nodeset.Name {
-					t.Errorf("OwnerReferences = %+v, want single ref to NodeSet %q", pod.OwnerReferences, nodeset.Name)
-				}
+				require.Equal(t, nodeset.Name+"-", pod.GenerateName)
+				require.Equal(t, "", pod.Name)
+				require.Equal(t, nodeset.Namespace, pod.Namespace)
+				require.Equal(t, wantHostname, pod.Spec.Hostname)
+				require.Equal(t, "", pod.Spec.NodeName)
+				require.Equal(t, wantHostname, pod.Labels[slinkyv1beta1.LabelNodeSetPodHostname])
+				require.Equal(t, string(slinkyv1beta1.ScalingModeDaemonset), pod.Labels[slinkyv1beta1.LabelNodeSetScalingMode])
+				require.Equal(t, 1, len(pod.OwnerReferences))
+				require.Equal(t, slinkyv1beta1.NodeSetKind, pod.OwnerReferences[0].Kind)
+				require.Equal(t, nodeset.Name, pod.OwnerReferences[0].Name)
 			}
 			if tt.wantRevision != nil {
-				if got := historycontrol.GetRevision(pod.Labels); got != *tt.wantRevision {
-					t.Errorf("revision label = %q, want %q", got, *tt.wantRevision)
-				}
+				require.Equal(t, *tt.wantRevision, historycontrol.GetRevision(pod.Labels))
 			}
 			if tt.checkVolumes {
 				claimNames := make(map[string]bool)
@@ -642,9 +616,7 @@ func TestNewNodeSetDaemonSetPod(t *testing.T) {
 				for i := range nodeset.Spec.VolumeClaimTemplates {
 					claim := &nodeset.Spec.VolumeClaimTemplates[i]
 					wantName := GetPersistentVolumeClaimNameNodeName(nodeset, claim, podHostname)
-					if !claimNames[wantName] {
-						t.Errorf("missing volume with ClaimName %q", wantName)
-					}
+					require.True(t, claimNames[wantName], "missing volume with ClaimName %q", wantName)
 				}
 			}
 		})
@@ -677,33 +649,23 @@ func TestNewNodeSetSimulatedPod(t *testing.T) {
 		nodeset.Spec.Template.PodSpecWrapper.Affinity = userAffinity
 
 		pod := NewNodeSetSimulatedPod(client, nodeset, controller, "node-1")
-		switch {
-		case pod == nil:
-			t.Fatal("NewNodeSetSimulatedPod() returned nil")
-		case pod.Spec.NodeName != "node-1":
-			t.Errorf("Spec.NodeName = %q, want %q", pod.Spec.NodeName, "node-1")
-		case pod.Spec.Affinity == nil || pod.Spec.Affinity.NodeAffinity == nil ||
-			pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil:
-			t.Fatal("user node affinity was not preserved")
-		}
+		require.NotNil(t, pod)
+		require.Equal(t, "node-1", pod.Spec.NodeName)
+		require.NotNil(t, pod.Spec.Affinity)
+		require.NotNil(t, pod.Spec.Affinity.NodeAffinity)
+		require.NotNil(t, pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution)
 		terms := pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
-		if len(terms) != 1 {
-			t.Fatalf("expected 1 NodeSelectorTerm, got %d", len(terms))
-		}
-		if len(terms[0].MatchExpressions) != 1 || terms[0].MatchExpressions[0].Key != "gpu" {
-			t.Errorf("user MatchExpressions not preserved: %+v", terms[0].MatchExpressions)
-		}
+		require.Equal(t, 1, len(terms))
+		require.Equal(t, 1, len(terms[0].MatchExpressions))
+		require.Equal(t, "gpu", terms[0].MatchExpressions[0].Key)
 	})
 
 	t.Run("Works without user affinity", func(t *testing.T) {
 		nodeset := newNodeSetDaemonset("foo", "")
 
 		pod := NewNodeSetSimulatedPod(client, nodeset, controller, "node-2")
-		if pod == nil {
-			t.Fatal("NewNodeSetSimulatedPod() returned nil")
-		} else if pod.Spec.NodeName != "node-2" {
-			t.Errorf("Spec.NodeName = %q, want %q", pod.Spec.NodeName, "node-2")
-		}
+		require.NotNil(t, pod)
+		require.Equal(t, "node-2", pod.Spec.NodeName)
 	})
 
 	t.Run("Preserves nodeSelector", func(t *testing.T) {
@@ -711,11 +673,8 @@ func TestNewNodeSetSimulatedPod(t *testing.T) {
 		nodeset.Spec.Template.PodSpecWrapper.NodeSelector = map[string]string{"disk": "ssd"}
 
 		pod := NewNodeSetSimulatedPod(client, nodeset, controller, "node-3")
-		if pod == nil {
-			t.Fatal("NewNodeSetSimulatedPod() returned nil")
-		} else if pod.Spec.NodeSelector["disk"] != "ssd" {
-			t.Errorf("nodeSelector not preserved: got %v", pod.Spec.NodeSelector)
-		}
+		require.NotNil(t, pod)
+		require.Equal(t, "ssd", pod.Spec.NodeSelector["disk"])
 	})
 
 	t.Run("Preserves tolerations", func(t *testing.T) {
@@ -725,20 +684,15 @@ func TestNewNodeSetSimulatedPod(t *testing.T) {
 		}
 
 		pod := NewNodeSetSimulatedPod(client, nodeset, controller, "node-4")
-		if pod == nil {
-			t.Fatal("NewNodeSetSimulatedPod() returned nil")
-			return
-		}
+		require.NotNil(t, pod)
 		found := false
-		for _, t := range pod.Spec.Tolerations {
-			if t.Key == "gpu" {
+		for _, tol := range pod.Spec.Tolerations {
+			if tol.Key == "gpu" {
 				found = true
 				break
 			}
 		}
-		if !found {
-			t.Errorf("user toleration not preserved: got %v", pod.Spec.Tolerations)
-		}
+		require.True(t, found, "user toleration not preserved: got %v", pod.Spec.Tolerations)
 	})
 }
 
@@ -799,9 +753,8 @@ func TestGetDaemonSetPodHostname(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := GetDaemonSetPodHostname(tt.nodeName, tt.hostnameOverride); got != tt.want {
-				t.Errorf("GetDaemonSetPodHostname() = %q, want %q", got, tt.want)
-			}
+			got := GetDaemonSetPodHostname(tt.nodeName, tt.hostnameOverride)
+			require.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -868,9 +821,8 @@ func TestIsStorageMatch(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := IsStorageMatch(tt.args.nodeset, tt.args.pod); got != tt.want {
-				t.Errorf("IsStorageMatch() = %v, want %v", got, tt.want)
-			}
+			got := IsStorageMatch(tt.args.nodeset, tt.args.pod)
+			require.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -987,9 +939,8 @@ func TestGetPersistentVolumeClaimNameOrdinal(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := GetPersistentVolumeClaimNameOrdinal(tt.args.nodeset, tt.args.claim, tt.args.paddedOrdinal); got != tt.want {
-				t.Errorf("GetPersistentVolumeClaimNameOrdinal() = %v, want %v", got, tt.want)
-			}
+			got := GetPersistentVolumeClaimNameOrdinal(tt.args.nodeset, tt.args.claim, tt.args.paddedOrdinal)
+			require.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -1022,9 +973,8 @@ func TestGetPersistentVolumeClaimNameNodeName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := GetPersistentVolumeClaimNameNodeName(tt.args.nodeset, tt.args.claim, tt.args.nodeName); got != tt.want {
-				t.Errorf("GetPersistentVolumeClaimNameNodeName() = %v, want %v", got, tt.want)
-			}
+			got := GetPersistentVolumeClaimNameNodeName(tt.args.nodeset, tt.args.claim, tt.args.nodeName)
+			require.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -1123,24 +1073,16 @@ func TestSetOwnerReferences(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
 			err := SetOwnerReferences(tt.client, ctx, tt.object, tt.clusterName)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("SetOwnerReferences() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
 			if tt.wantErr {
+				require.Error(t, err)
 				return
 			}
+			require.NoError(t, err)
 			refs := tt.object.GetOwnerReferences()
-			if len(refs) != tt.wantRefs {
-				t.Errorf("SetOwnerReferences() owner refs count = %v, want %v", len(refs), tt.wantRefs)
-			}
+			require.Equal(t, tt.wantRefs, len(refs))
 			for _, ref := range refs {
-				if ref.Controller != nil && *ref.Controller {
-					t.Errorf("SetOwnerReferences() set controller=true; expected non-controller owner ref")
-				}
-				if ref.BlockOwnerDeletion == nil || !*ref.BlockOwnerDeletion {
-					t.Errorf("SetOwnerReferences() expected BlockOwnerDeletion=true")
-				}
+				require.False(t, ref.Controller != nil && *ref.Controller, "SetOwnerReferences() set controller=true; expected non-controller owner ref")
+				require.True(t, ref.BlockOwnerDeletion != nil && *ref.BlockOwnerDeletion, "SetOwnerReferences() expected BlockOwnerDeletion=true")
 			}
 		})
 	}

--- a/internal/controller/restapi/eventhandler/eventhandler_controller_test.go
+++ b/internal/controller/restapi/eventhandler/eventhandler_controller_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/workqueue"
@@ -78,9 +79,7 @@ func Test_ControllerEventHandler_Create(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			e := NewControllerEventHandler(tt.fields.client)
 			e.Create(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got > tt.want {
-				t.Errorf("Create() = %v, want %v", got, tt.want)
-			}
+			require.LessOrEqual(t, tt.args.q.Len(), tt.want)
 		})
 	}
 }
@@ -151,9 +150,7 @@ func Test_ControllerEventHandler_Update(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			e := NewControllerEventHandler(tt.fields.client)
 			e.Update(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got > tt.want {
-				t.Errorf("Create() = %v, want %v", got, tt.want)
-			}
+			require.LessOrEqual(t, tt.args.q.Len(), tt.want)
 		})
 	}
 }
@@ -219,9 +216,7 @@ func Test_ControllerEventHandler_Delete(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			e := NewControllerEventHandler(tt.fields.client)
 			e.Delete(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got > tt.want {
-				t.Errorf("Create() = %v, want %v", got, tt.want)
-			}
+			require.LessOrEqual(t, tt.args.q.Len(), tt.want)
 		})
 	}
 }
@@ -258,9 +253,7 @@ func Test_ControllerEventHandler_Generic(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			e := NewControllerEventHandler(tt.fields.client)
 			e.Generic(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got > tt.want {
-				t.Errorf("Create() = %v, want %v", got, tt.want)
-			}
+			require.LessOrEqual(t, tt.args.q.Len(), tt.want)
 		})
 	}
 }

--- a/internal/controller/restapi/eventhandler/eventhandler_secret_test.go
+++ b/internal/controller/restapi/eventhandler/eventhandler_secret_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -81,9 +82,7 @@ func Test_SecretEventHandler_Create(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := NewSecretEventHandler(tt.fields.Reader)
 			h.Create(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got != tt.want {
-				t.Errorf("SecretEventHandler.Create() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, tt.args.q.Len())
 		})
 	}
 }
@@ -152,9 +151,7 @@ func Test_SecretEventHandler_Delete(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := NewSecretEventHandler(tt.fields.Reader)
 			h.Delete(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got != tt.want {
-				t.Errorf("SecretEventHandler.Delete() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, tt.args.q.Len())
 		})
 	}
 }
@@ -191,9 +188,7 @@ func Test_SecretEventHandler_Generic(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := NewSecretEventHandler(tt.fields.Reader)
 			h.Generic(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got != tt.want {
-				t.Errorf("SecretEventHandler.Generic() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, tt.args.q.Len())
 		})
 	}
 }
@@ -264,9 +259,7 @@ func Test_SecretEventHandler_Update(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := NewSecretEventHandler(tt.fields.Reader)
 			h.Update(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got != tt.want {
-				t.Errorf("SecretEventHandler.Update() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, tt.args.q.Len())
 		})
 	}
 }

--- a/internal/controller/restapi/restapi_sync_test.go
+++ b/internal/controller/restapi/restapi_sync_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/SlinkyProject/slurm-operator/internal/clientmap"
 	"github.com/SlinkyProject/slurm-operator/internal/utils/refresolver"
 	"github.com/SlinkyProject/slurm-operator/internal/utils/testutils"
+	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -91,8 +92,11 @@ func TestRestapiReconciler_sync(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := newRestapiController(tt.fields.Client, tt.fields.ClientMap)
-			if err := r.Sync(tt.args.ctx, tt.args.request); (err != nil) != tt.wantErr {
-				t.Errorf("RestapiReconciler.sync() error = %v, wantErr %v", err, tt.wantErr)
+			err := r.Sync(tt.args.ctx, tt.args.request)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 		})
 	}

--- a/internal/controller/slurmclient/eventhandler/eventhandler_restapi_test.go
+++ b/internal/controller/slurmclient/eventhandler/eventhandler_restapi_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/workqueue"
@@ -90,9 +91,7 @@ func Test_RestApiEventHandler_Create(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			e := NewRestApiEventHandler(tt.fields.client)
 			e.Create(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got != tt.want {
-				t.Errorf("Create() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, tt.args.q.Len())
 		})
 	}
 }
@@ -226,9 +225,7 @@ func Test_RestApiEventHandler_Update(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			e := NewRestApiEventHandler(tt.fields.client)
 			e.Update(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got != tt.want {
-				t.Errorf("Update() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, tt.args.q.Len())
 		})
 	}
 }
@@ -306,9 +303,7 @@ func Test_RestApiEventHandler_Delete(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			e := NewRestApiEventHandler(tt.fields.client)
 			e.Delete(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got != tt.want {
-				t.Errorf("Delete() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, tt.args.q.Len())
 		})
 	}
 }
@@ -345,9 +340,7 @@ func Test_RestApiEventHandler_Generic(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			e := NewRestApiEventHandler(tt.fields.client)
 			e.Generic(tt.args.ctx, tt.args.evt, tt.args.q)
-			if got := tt.args.q.Len(); got != tt.want {
-				t.Errorf("Generic() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, tt.args.q.Len())
 		})
 	}
 }

--- a/internal/controller/slurmclient/utils/sort_test.go
+++ b/internal/controller/slurmclient/utils/sort_test.go
@@ -8,10 +8,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRestapisByCreationTimestamp(t *testing.T) {
@@ -62,9 +62,8 @@ func TestRestapisByCreationTimestamp(t *testing.T) {
 			for i := range tt.restapis {
 				got[i] = tt.restapis[i].Name
 			}
-			if diff := cmp.Diff(tt.want, got); diff != "" {
-				t.Errorf("RestapisByCreationTimestamp names (-want +got):\n%s", diff)
-			}
+
+			require.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/internal/controller/token/slurmjwt/token_test.go
+++ b/internal/controller/token/slurmjwt/token_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/SlinkyProject/slurm-operator/internal/utils/crypto"
+	"github.com/stretchr/testify/require"
 )
 
 func newSignedToken(signingKey []byte) string {
@@ -49,18 +50,18 @@ func TestToken_NewSignedToken(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tr := tt.fields.token
 			got, err := tr.NewSignedToken()
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Token.NewSignedToken() error = %v, wantErr %v", err, tt.wantErr)
-				return
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 			ok, err := VerifyToken(got, tr.signingKey)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("VerifyToken() = %v", err)
-				return
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
-			if ok != tt.wantOk {
-				t.Errorf("VerifyToken() ok = %v, wantOk %v", ok, tt.wantOk)
-			}
+			require.Equal(t, tt.wantOk, ok)
 		})
 	}
 }
@@ -95,9 +96,10 @@ func TestParseTokenClaims(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := ParseTokenClaims(tt.args.tokenString, tt.args.signingKey)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("ParseTokenClaims() error = %v, wantErr %v", err, tt.wantErr)
-				return
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 		})
 	}
@@ -143,13 +145,12 @@ func TestVerifyToken(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ok, err := VerifyToken(tt.args.tokenString, tt.args.signingKey)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("VerifyToken() error = %v, wantErr %v", err, tt.wantErr)
-				return
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
-			if ok != tt.wantOk {
-				t.Errorf("VerifyToken() ok = %v, wantOk %v", ok, tt.wantOk)
-			}
+			require.Equal(t, tt.wantOk, ok)
 		})
 	}
 }

--- a/internal/controller/token/token_sync_status_test.go
+++ b/internal/controller/token/token_sync_status_test.go
@@ -15,14 +15,13 @@ import (
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
 	"github.com/SlinkyProject/slurm-operator/internal/controller/token/slurmjwt"
 	"github.com/SlinkyProject/slurm-operator/internal/utils/crypto"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTokenReconciler_syncStatus(t *testing.T) {
 	signingKey := crypto.NewSigningKey()
 	signedToken, err := slurmjwt.NewToken(signingKey).NewSignedToken()
-	if err != nil {
-		t.Fatalf("failed to create signed token: %v", err)
-	}
+	require.NoError(t, err)
 
 	jwtKeySecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -137,8 +136,12 @@ func TestTokenReconciler_syncStatus(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := NewReconciler(tt.fields.Client)
-			if err := r.syncStatus(tt.args.ctx, tt.args.token); (err != nil) != tt.wantErr {
-				t.Errorf("TokenReconciler.syncStatus() error = %v, wantErr %v", err, tt.wantErr)
+			err := r.syncStatus(tt.args.ctx, tt.args.token)
+
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 		})
 	}
@@ -201,8 +204,12 @@ func TestTokenReconciler_updateStatus(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := NewReconciler(tt.fields.Client)
-			if err := r.updateStatus(tt.args.ctx, tt.args.token, tt.args.newStatus); (err != nil) != tt.wantErr {
-				t.Errorf("TokenReconciler.updateStatus() error = %v, wantErr %v", err, tt.wantErr)
+			err := r.updateStatus(tt.args.ctx, tt.args.token, tt.args.newStatus)
+
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 		})
 	}

--- a/internal/utils/historycontrol/historycontrol_test.go
+++ b/internal/utils/historycontrol/historycontrol_test.go
@@ -36,9 +36,8 @@ func Test_realHistory_ListControllerRevisions(t *testing.T) {
 		},
 	}
 	selector, err := metav1.LabelSelectorAsSelector(rs.Spec.Selector)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	revision := &appsv1.ControllerRevision{
 		TypeMeta:   rs.TypeMeta,
 		ObjectMeta: rs.ObjectMeta,

--- a/internal/utils/historycontrol/utils_test.go
+++ b/internal/utils/historycontrol/utils_test.go
@@ -51,10 +51,8 @@ func TestSetRevision(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			SetRevision(tt.args.labels, tt.args.revision)
+			require.Empty(t, cmp.Diff(tt.want, tt.args.labels), "unexpected encoded configuration")
 		})
-		if diff := cmp.Diff(tt.want, tt.args.labels); diff != "" {
-			t.Errorf("unexpected encoded configuration: (-want,+got)\n%s", diff)
-		}
 	}
 }
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->

<!--
Feature requests, code contributions, and bug reports are welcome!
GitHub issues and pull requests are handled on a best-effort basis.
The SchedMD official issue tracker is at <https://support.schedmd.com/>.
-->

## Summary

Refactoring `internal/controller` unit tests to use `testify/require` assertions.

Used `testify/require` in a few other unit tests across packages (seem to be a leftover between the part 1 merge and this PR).

This is a followup of https://github.com/SlinkyProject/slurm-operator/pull/209

## Checklist

- [x] I have read
  [CONTRIBUTING.md](https://github.com/SlinkyProject/slurm-operator/blob/main/CONTRIBUTING.md)
  and the
  [Code of Conduct](https://github.com/SlinkyProject/slurm-operator/blob/main/CODE_OF_CONDUCT.md).
- [ ] New or existing tests cover these changes (where applicable).
- [ ] Documentation is updated if user-visible behavior changes.

## Breaking Changes

<!--
Does this cause any breaking changes to users?
Explain why the breakage has to happen.
-->

## Testing Notes

```bash
make test
```

<img width="975" height="588" alt="Screenshot 2026-07-13 at 13 58 40" src="https://github.com/user-attachments/assets/e1e9d469-a791-4392-a2df-d904f07093ab" />

## Additional Context

<!--
Any other context for reviewers.
-->
