### PR TITLE
feat: add vendor changes to slurm helm chart for A3 Ultra machines

### DIFF
--- a/helm/slurm/_vendor/google/a3ultra/example-values.yaml
+++ b/helm/slurm/_vendor/google/a3ultra/example-values.yaml
@@ -1,25 +1,25 @@
 ---
-# Example configuration for Google Cloud GKE A3 Mega node topology
+# Example configuration for Google Cloud GKE A3 Ultra node topology
 
 vendor:
   google:
-    a3mega:
-      - targetNodeSet: a3-mega-nodes
-        nodePool: "a3-mega-nodepool"
+    a3ultra:
+      - targetNodeSet: a3-ultra-nodes
+        nodePool: "a3-ultra-nodepool"
         networks:
           - default
-          - vpc1
-          - vpc2
-          - vpc3
-          - vpc4
-          - vpc5
-          - vpc6
-          - vpc7
-          - vpc8
+          - rdma-0
+          - rdma-1
+          - rdma-2
+          - rdma-3
+          - rdma-4
+          - rdma-5
+          - rdma-6
+          - rdma-7
 
 # The GPU nodeset that matches targetNodeSet
 nodesets:
-  a3-mega-nodes:
+  a3-ultra-nodes:
     enabled: true
     replicas: 1
     image:

--- a/helm/slurm/_vendor/google/a3ultra/snippets/nodeset.yaml
+++ b/helm/slurm/_vendor/google/a3ultra/snippets/nodeset.yaml
@@ -1,0 +1,49 @@
+---
+slurmd:
+  env:
+    - name: LD_LIBRARY_PATH
+      value: /usr/local/nvidia/lib64
+    - name: PATH
+      value: /usr/local/nvidia/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+  volumeMounts:
+    - name: library-dir-host
+      mountPath: /usr/local/nvidia
+    - name: gib
+      mountPath: /usr/local/gib
+  resources:
+    requests:
+      nvidia.com/gpu: 8
+    limits:
+      nvidia.com/gpu: 8
+extraConfMap:
+  gres: "gpu:nvidia_h200:8"
+metadata:
+  annotations:
+    networking.gke.io/default-interface: 'eth0'
+    networking.gke.io/interfaces: |
+      [
+      {{- $networkCount := len .a3ultraConfig.networks -}}
+      {{- range $index, $network := .a3ultraConfig.networks }}
+        {{- $ifName := printf "eth%d" $index -}}
+        {{- if gt $index 0 -}}
+          {{- $ifName = printf "eth%d" (add $index 1) -}}
+        {{- end }}
+        {"interfaceName":{{ $ifName | quote }},"network":{{ $network | quote }}}{{ if ne (add $index 1) $networkCount }},{{ end }}
+      {{- end }}
+      ]
+podSpec:
+  nodeSelector:
+    cloud.google.com/gke-nodepool: '{{ .a3ultraConfig.nodePool }}'
+  volumes:
+    - name: library-dir-host
+      hostPath:
+        path: /home/kubernetes/bin/nvidia
+    - name: gib
+      hostPath:
+        path: /home/kubernetes/bin/gib
+    - name: sys
+      hostPath:
+        path: /sys
+    - name: proc-sys
+      hostPath:
+        path: /proc/sys

--- a/helm/slurm/templates/_vendor.tpl
+++ b/helm/slurm/templates/_vendor.tpl
@@ -164,5 +164,8 @@ Vendor contract:
 {{/* Google A3 Mega */}}
 {{- $nodeset = include "slurm.nodeset.applyPatch" (dict "nodeset" $nodeset "patchYaml" (include "slurm.vendor.google.a3mega.nodesetPatch" $ctx)) | fromYaml -}}
 
+{{/* Google A3 Ultra */}}
+{{- $nodeset = include "slurm.nodeset.applyPatch" (dict "nodeset" $nodeset "patchYaml" (include "slurm.vendor.google.a3ultra.nodesetPatch" $ctx)) | fromYaml -}}
+
 {{- $nodeset | toYaml -}}
 {{- end -}}

--- a/helm/slurm/templates/controller/controller-cr.yaml
+++ b/helm/slurm/templates/controller/controller-cr.yaml
@@ -60,6 +60,9 @@ spec:
     {{- if and (include "slurm.vendor.google.a3mega.enabled" .) (not $hasGresConf) }}
     - name: {{ include "slurm.vendor.google.a3mega.configName" . }}
     {{- end }}{{- /* and (include "slurm.vendor.google.a3mega.enabled" .) (not $hasGresConf) */}}
+    {{- if and (include "slurm.vendor.google.a3ultra.enabled" .) (not $hasGresConf) }}
+    - name: {{ include "slurm.vendor.google.a3ultra.configName" . }}
+    {{- end }}{{- /* and (include "slurm.vendor.google.a3ultra.enabled" .) (not $hasGresConf) */}}
   prologScriptRefs:
     {{- if .Values.prologScripts }}
     - name: {{ include "slurm.controller.prologName" . }}

--- a/helm/slurm/templates/vendor/google/a3ultra/_helpers.tpl
+++ b/helm/slurm/templates/vendor/google/a3ultra/_helpers.tpl
@@ -1,0 +1,42 @@
+{{/*
+SPDX-FileCopyrightText: Copyright (C) SchedMD LLC.
+SPDX-License-Identifier: Apache-2.0
+*/}}
+
+{{/*
+Cluster config files.
+*/}}
+{{- define "slurm.vendor.google.a3ultra.enabled" -}}
+{{- if gt (len (.Values.vendor.google | dig "a3ultra" list)) 0 -}}
+  {{- print "true" -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Cluster config files.
+*/}}
+{{- define "slurm.vendor.google.a3ultra.configName" -}}
+{{- printf "%s-config-a3ultra" (include "slurm.fullname" .) -}}
+{{- end }}
+
+{{/*
+Return a nodeset values patch for A3 Ultra, or empty when not applicable.
+*/}}
+{{- define "slurm.vendor.google.a3ultra.nodesetPatch" -}}
+{{- $root := .root -}}
+{{- $key := .key -}}
+{{- $a3ultraConfig := dict -}}
+{{- range $config := ($root.Values.vendor.google | dig "a3ultra" list) -}}
+  {{- if eq (get $config "targetNodeSet" | default "") $key -}}
+    {{- $a3ultraConfig = $config -}}
+  {{- end -}}
+{{- end -}}
+{{- if $a3ultraConfig -}}
+  {{- $networks := get $a3ultraConfig "networks" | default list -}}
+  {{- if ne (len $networks) 9 -}}
+    {{- fail (printf "Google Cloud GKE A3 Ultra requires exactly 9 networks, but %d were specified." (len $networks)) -}}
+  {{- end -}}
+  {{- $_ := set $root "a3ultraConfig" $a3ultraConfig -}}
+  {{- tpl ($root.Files.Get "_vendor/google/a3ultra/snippets/nodeset.yaml") $root -}}
+{{- end -}}
+{{- end }}

--- a/helm/slurm/templates/vendor/google/a3ultra/config-configmap.yaml
+++ b/helm/slurm/templates/vendor/google/a3ultra/config-configmap.yaml
@@ -1,0 +1,18 @@
+{{- /*
+SPDX-FileCopyrightText: Copyright (C) SchedMD LLC.
+SPDX-License-Identifier: Apache-2.0
+*/}}
+
+{{- $hasGresConf := hasKey (.Values.configFiles | default dict) "gres.conf" -}}
+{{- if and (include "slurm.vendor.google.a3ultra.enabled" .) (not $hasGresConf) -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "slurm.vendor.google.a3ultra.configName" . }}
+  namespace: {{ include "slurm.namespace" . }}
+  labels:
+    {{- include "slurm.labels" . | nindent 4 }}
+data:
+  gres.conf: |
+    AutoDetect=nvidia
+{{- end }}{{- /* if and (include "slurm.vendor.google.a3ultra.enabled" .) (not $hasGresConf) */}}

--- a/helm/slurm/tests/vendor_google_a3ultra_test.yaml
+++ b/helm/slurm/tests/vendor_google_a3ultra_test.yaml
@@ -1,0 +1,242 @@
+---
+suite: test vendor google gke a3ultra
+templates:
+  - nodeset/nodeset-cr.yaml
+  - controller/controller-cr.yaml
+  - vendor/google/a3ultra/config-configmap.yaml
+release:
+  name: test-release
+  namespace: test-namespace
+chart:
+  version: 1.2.3
+  appVersion: 1.2.3
+tests:
+  - it: should not inject A3 Ultra configuration when disabled
+    template: nodeset/nodeset-cr.yaml
+    set:
+      vendor:
+        google:
+          a3ultra: []
+      nodesets:
+        slinky:
+          enabled: true
+          slurmd:
+            image:
+              tag: v1.2.3
+    asserts:
+      - notExists:
+          path: spec.template.metadata.annotations
+      - notExists:
+          path: spec.template.spec.containers
+      - equal:
+          path: spec.template.spec.initContainers
+          value: []
+      - equal:
+          path: spec.template.spec.volumes
+          value: []
+
+  - it: should inject A3 Ultra configuration when enabled and targeting nodeset
+    template: nodeset/nodeset-cr.yaml
+    set:
+      vendor:
+        google:
+          a3ultra:
+            - targetNodeSet: "slinky"
+              nodePool: "a3-ultra-nodepool"
+              networks: ["default", "rdma-0", "rdma-1", "rdma-2", "rdma-3", "rdma-4", "rdma-5", "rdma-6", "rdma-7"]
+      nodesets:
+        slinky:
+          enabled: true
+          slurmd:
+            image:
+              tag: v1.2.3
+    asserts:
+      # Node Pool Selector
+      - equal:
+          path: spec.template.spec.nodeSelector["cloud.google.com/gke-nodepool"]
+          value: "a3-ultra-nodepool"
+      # Automatic GPU limits/requests injection
+      - equal:
+          path: spec.slurmd.resources.limits["nvidia.com/gpu"]
+          value: 8
+      - equal:
+          path: spec.slurmd.resources.requests["nvidia.com/gpu"]
+          value: 8
+      # Annotations
+      - equal:
+          path: spec.template.metadata.annotations["networking.gke.io/default-interface"]
+          value: "eth0"
+      - equal:
+          path: spec.template.metadata.annotations["networking.gke.io/interfaces"]
+          value: |
+            [
+              {"interfaceName":"eth0","network":"default"},
+              {"interfaceName":"eth2","network":"rdma-0"},
+              {"interfaceName":"eth3","network":"rdma-1"},
+              {"interfaceName":"eth4","network":"rdma-2"},
+              {"interfaceName":"eth5","network":"rdma-3"},
+              {"interfaceName":"eth6","network":"rdma-4"},
+              {"interfaceName":"eth7","network":"rdma-5"},
+              {"interfaceName":"eth8","network":"rdma-6"},
+              {"interfaceName":"eth9","network":"rdma-7"}
+            ]
+      # Volumes
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: library-dir-host
+            hostPath:
+              path: /home/kubernetes/bin/nvidia
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: gib
+            hostPath:
+              path: /home/kubernetes/bin/gib
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: sys
+            hostPath:
+              path: /sys
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: proc-sys
+            hostPath:
+              path: /proc/sys
+      # slurmd container volume mounts
+      - contains:
+          path: spec.slurmd.volumeMounts
+          content:
+            name: library-dir-host
+            mountPath: /usr/local/nvidia
+      - contains:
+          path: spec.slurmd.volumeMounts
+          content:
+            name: gib
+            mountPath: /usr/local/gib
+      # slurmd container environment variables
+      - contains:
+          path: spec.slurmd.env
+          content:
+            name: LD_LIBRARY_PATH
+            value: /usr/local/nvidia/lib64
+      - contains:
+          path: spec.slurmd.env
+          content:
+            name: PATH
+            value: /usr/local/nvidia/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      # Automatic extraConfMap Gres injection
+      - equal:
+          path: spec.extraConf
+          value: "gres=gpu:nvidia_h200:8"
+
+  - it: should inject AutoDetect=nvidia in gres.conf when A3 Ultra is enabled
+    template: vendor/google/a3ultra/config-configmap.yaml
+    set:
+      vendor:
+        google:
+          a3ultra:
+            - targetNodeSet: "slinky"
+              nodePool: "a3-ultra-nodepool"
+              networks: ["default", "rdma-0", "rdma-1", "rdma-2", "rdma-3", "rdma-4", "rdma-5", "rdma-6", "rdma-7"]
+      nodesets:
+        slinky:
+          enabled: true
+          slurmd:
+            image:
+              tag: v1.2.3
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: kind
+          value: ConfigMap
+      - equal:
+          path: metadata.name
+          value: test-release-slurm-config-a3ultra
+      - equal:
+          path: data["gres.conf"]
+          value: "AutoDetect=nvidia\n"
+
+  - it: should not override gres.conf if already provided in configFiles when A3 Ultra is enabled
+    template: vendor/google/a3ultra/config-configmap.yaml
+    set:
+      configFiles:
+        gres.conf: |
+          AutoDetect=off
+      vendor:
+        google:
+          a3ultra:
+            - targetNodeSet: "slinky"
+              nodePool: "a3-ultra-nodepool"
+              networks: ["default", "rdma-0", "rdma-1", "rdma-2", "rdma-3", "rdma-4", "rdma-5", "rdma-6", "rdma-7"]
+      nodesets:
+        slinky:
+          enabled: true
+          slurmd:
+            image:
+              tag: v1.2.3
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should include configFileRefs in controller spec when A3 Ultra is enabled
+    template: controller/controller-cr.yaml
+    set:
+      vendor:
+        google:
+          a3ultra:
+            - targetNodeSet: "slinky"
+              nodePool: "a3-ultra-nodepool"
+              networks: ["default", "rdma-0", "rdma-1", "rdma-2", "rdma-3", "rdma-4", "rdma-5", "rdma-6", "rdma-7"]
+      nodesets:
+        slinky:
+          enabled: true
+          slurmd:
+            image:
+              tag: v1.2.3
+    asserts:
+      - contains:
+          path: spec.configFileRefs
+          any: true
+          content:
+            name: test-release-slurm-config-a3ultra
+
+  - it: should fail if exactly 9 networks are not specified
+    template: nodeset/nodeset-cr.yaml
+    set:
+      vendor:
+        google:
+          a3ultra:
+            - targetNodeSet: "slinky"
+              nodePool: "a3-ultra-nodepool"
+              networks: ["default", "rdma-0"]
+      nodesets:
+        slinky:
+          enabled: true
+          slurmd:
+            image:
+              tag: v1.2.3
+    asserts:
+      - failedTemplate:
+          errorMessage: Google Cloud GKE A3 Ultra requires exactly 9 networks, but 2 were specified.
+
+  - it: should fail if networks are completely missing
+    template: nodeset/nodeset-cr.yaml
+    set:
+      vendor:
+        google:
+          a3ultra:
+            - targetNodeSet: "slinky"
+              nodePool: "a3-ultra-nodepool"
+      nodesets:
+        slinky:
+          enabled: true
+          slurmd:
+            image:
+              tag: v1.2.3
+    asserts:
+      - failedTemplate:
+          errorMessage: Google Cloud GKE A3 Ultra requires exactly 9 networks, but 0 were specified.

--- a/helm/slurm/values.yaml
+++ b/helm/slurm/values.yaml
@@ -916,6 +916,20 @@ vendor:
     #     - vpc6
     #     - vpc7
     #     - vpc8
+    # -- A3 Ultra configurations. List of objects corresponding to nodesets.
+    a3ultra: []
+    # - targetNodeSet: a3-ultra-compute
+    #   nodePool: "a3-ultra-compute-nodepool"
+    #   networks:
+    #     - default
+    #     - rdma-0
+    #     - rdma-1
+    #     - rdma-2
+    #     - rdma-3
+    #     - rdma-4
+    #     - rdma-5
+    #     - rdma-6
+    #     - rdma-7
 
 # -- Extra Kubernetes objects to deploy alongside the chart.
 # Each entry is rendered as a standalone Kubernetes object.


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->

<!--
Feature requests, code contributions, and bug reports are welcome!
GitHub issues and pull requests are handled on a best-effort basis.
The SchedMD official issue tracker is at <https://support.schedmd.com/>.
-->

## Summary

This PR introduces native support for Google Cloud GKE A3 Ultra node topologies (H200 GPUs with GPUDirect RDMA) within the Slurm Operator Helm chart.

It helps reduce significant Kubernetes boilerplate (e.g. injecting 9 secondary multi-network VPC NICs, mounting GKE-specific RDMA drivers, and configuring dynamic GRES). 

It takes advantage of the latest official Slinky vendor changes under `vendor.google.a3ultra`.

It dynamically injects:
- GKE Multi-Networking Interface Mapping - maps the default network to `eth0` and the 8 dedicated RDMA networks (e.g., `rdma-0` through `rdma-7`) to interfaces `eth2`–`eth9`(skipping `eth1`).
- Volume Mounts - required HostPaths (/home/kubernetes/bin/nvidia, /home/kubernetes/bin/gib, /sys, and /proc/sys) properly routed to the slurmd pod to expose the required GPU driver libraries, GKE's RDMA interface driver (gIB), and kernel system directories needed for GPUDirect RDMA.
- Slurm Auto-Configuration - automatically sets nvidia.com/gpu: 8 resource limits/requests, sets gres: "gpu:nvidia_h200:8" node configuration, and dynamically provisions a gres.conf with AutoDetect=nvidia for GPU discovery.

## Checklist

- [x] I have read
  [CONTRIBUTING.md](https://github.com/SlinkyProject/slurm-operator/blob/main/CONTRIBUTING.md)
  and the
  [Code of Conduct](https://github.com/SlinkyProject/slurm-operator/blob/main/CODE_OF_CONDUCT.md).
- [x] New or existing tests cover these changes (where applicable).
- [x] Documentation is updated if user-visible behavior changes.

## Breaking Changes

<!--
Does this cause any breaking changes to users?
Explain why the breakage has to happen.
-->

## Testing Notes

<!--
How to test this change.
-->

## Additional Context

<!--
Any other context for reviewers.
-->
