### PR TITLE
fix(token): keep refresh requeue positive so refresh never stops

### DIFF
--- a/internal/controller/token/token_requeue_test.go
+++ b/internal/controller/token/token_requeue_test.go
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: Copyright (C) SchedMD LLC.
+// SPDX-License-Identifier: Apache-2.0
+
+package token
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRefreshRequeueAfter(t *testing.T) {
+	tests := []struct {
+		name string
+		d    time.Duration
+		want time.Duration
+	}{
+		{
+			name: "negative is floored to the positive minimum",
+			d:    -1 * time.Minute,
+			want: tokenRefreshRequeueFloor,
+		},
+		{
+			name: "zero is floored to the positive minimum",
+			d:    0,
+			want: tokenRefreshRequeueFloor,
+		},
+		{
+			name: "positive below the floor is raised to the floor",
+			d:    500 * time.Millisecond,
+			want: tokenRefreshRequeueFloor,
+		},
+		{
+			name: "exactly the floor is kept",
+			d:    tokenRefreshRequeueFloor,
+			want: tokenRefreshRequeueFloor,
+		},
+		{
+			name: "positive above the floor is kept",
+			d:    12 * time.Minute,
+			want: 12 * time.Minute,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := refreshRequeueAfter(tt.d)
+			require.Equal(t, tt.want, got)
+			// The core invariant of #240: the refresh requeue is never <= 0,
+			// which controller-runtime would treat as "do not requeue".
+			require.Greater(t, got, time.Duration(0))
+		})
+	}
+}

--- a/internal/controller/token/token_sync.go
+++ b/internal/controller/token/token_sync.go
@@ -24,6 +24,21 @@ import (
 	jwt "github.com/golang-jwt/jwt/v5"
 )
 
+// tokenRefreshRequeueFloor bounds the token refresh requeue to a positive
+// value. controller-runtime treats a Result.RequeueAfter <= 0 as "do not
+// requeue", so an unbounded refreshTime.Sub(now) that reaches zero silently
+// stops the periodic refresh and lets the JWT expire (#240).
+const tokenRefreshRequeueFloor = 1 * time.Second
+
+// refreshRequeueAfter floors d to a positive minimum so the token controller
+// always re-enqueues itself for the next refresh.
+func refreshRequeueAfter(d time.Duration) time.Duration {
+	if d < tokenRefreshRequeueFloor {
+		return tokenRefreshRequeueFloor
+	}
+	return d
+}
+
 // Sync implements control logic for synchronizing a Token.
 func (r *TokenReconciler) Sync(ctx context.Context, req reconcile.Request) error {
 	logger := log.FromContext(ctx)
@@ -42,16 +57,11 @@ func (r *TokenReconciler) Sync(ctx context.Context, req reconcile.Request) error
 	if !token.DeletionTimestamp.IsZero() {
 		logger.Info("Token is being deleted, skipping sync", "request", req)
 		return nil
-	} else {
-		now := time.Now()
-		key := objectutils.KeyFunc(token)
-		expirationTime, err := r.getExpTime(ctx, token)
-		if err != nil {
-			durationStore.Push(key, 30*time.Second)
-		} else {
-			refreshTime := expirationTime.Add(-token.Lifetime() * 1 / 5)
-			durationStore.Push(key, refreshTime.Sub(now))
-		}
+	} else if _, err := r.getExpTime(ctx, token); err != nil {
+		// Could not read the current token expiration; retry shortly. The
+		// refresh requeue itself is armed by the "Refresh" sync step below so
+		// that it is computed from the freshly-minted token (#240).
+		durationStore.Push(objectutils.KeyFunc(token), 30*time.Second)
 	}
 
 	steps := []syncsteps.Step[*slinkyv1beta1.Token]{
@@ -85,14 +95,15 @@ func (r *TokenReconciler) Sync(ctx context.Context, req reconcile.Request) error
 					}
 				}
 
+				key := objectutils.KeyFunc(token)
 				refreshTime := now
 				if !expirationTime.IsZero() {
 					refreshTime = expirationTime.Add(-token.Lifetime() * 1 / 5)
-					key := objectutils.KeyFunc(token)
-					durationStore.Push(key, refreshTime.Sub(now))
 				}
 
 				if now.Before(refreshTime) {
+					// Not near expiration yet: re-enqueue at the refresh instant.
+					durationStore.Push(key, refreshRequeueAfter(refreshTime.Sub(now)))
 					logger.V(2).Info("token is not near expiration time yet, skipping...", "expirationTime", expirationTime)
 					return nil
 				}
@@ -104,6 +115,12 @@ func (r *TokenReconciler) Sync(ctx context.Context, req reconcile.Request) error
 				if err := objectutils.SyncObject(r.Client, ctx, r.eventRecorder, token, object, true); err != nil {
 					return fmt.Errorf("failed to sync object (%s): %w", klog.KObj(object), err)
 				}
+
+				// Arm the next refresh from the freshly-minted token rather than
+				// relying on the Owns(Secret) watch follow-up, which can be
+				// coalesced/dropped (#240). The new token expires at
+				// now+Lifetime, so the next refresh is due after Lifetime*4/5.
+				durationStore.Push(key, refreshRequeueAfter(token.Lifetime()-token.Lifetime()/5))
 
 				return nil
 			},


### PR DESCRIPTION
## Summary

The Token controller can silently stop refreshing. On the reconcile scheduled at the refresh instant, Sync() pushes RequeueAfter = refreshTime.Sub(now) where refreshTime = exp - Lifetime/5, so it is <= 0 at that moment. durationStore uses Less (keeps the minimum, no floor), so Pop returns <= 0 and controller-runtime treats that as "do not requeue". The loop then continues only via the Owns(&Secret{}) watch follow-up; when that event is coalesced or dropped, the Token is never re-enqueued, the JWT expires, and consumers get a Protocol authentication error until the ~10h cache resync.

This floors the refresh requeue to a positive minimum and arms the next refresh from the freshly-minted token instead of depending on the Secret watch.

closes #240

## Checklist

- [x] I have read the
  [CONTRIBUTING.md](https://github.com/SlinkyProject/slurm-operator/blob/main/CONTRIBUTING.md)
  and the
  [Code of Conduct](https://github.com/SlinkyProject/slurm-operator/blob/main/CODE_OF_CONDUCT.md).
- [x] New or existing tests cover these changes (where applicable).
- [ ] Documentation is updated if user-visible behavior changes.

## Breaking Changes

None.

## Testing Notes

- envtest suite for internal/controller/token/... passes with no regression.
- Added TestRefreshRequeueAfter covering the floor invariant (negative, zero, and below-floor inputs never yield <= 0).
- golangci-lint run ./internal/controller/token/ reports 0 issues.

## Additional Context

Introduced by f9d0a98 ("feat(token): ensure Token is refreshed timely", first shipped in v1.1.0), which added the durationStore.Push(refreshTime.Sub(now)) and switched the store from Greater to Less. v1.0.1 is unaffected.