### PR TITLE
fix(helm): bind webhook ClusterRoleBinding to the webhook ClusterRole

### DIFF
--- a/helm/slurm-operator/templates/_webhook.tpl
+++ b/helm/slurm-operator/templates/_webhook.tpl
@@ -11,6 +11,17 @@ Expand the name of the chart.
 {{- end }}
 
 {{/*
+Release-scoped webhook name, for cluster-scoped objects that would otherwise
+collide between two releases of this chart in different namespaces.
+The base is truncated to 55 chars (63 minus "-webhook") so that the suffix
+survives a long release name and still distinguishes the webhook's objects.
+*/}}
+{{- define "slurm-operator.webhook.fullname" -}}
+{{- $base := include "slurm-operator.fullname" . | trunc 55 | trimSuffix "-" -}}
+{{- printf "%s-webhook" $base -}}
+{{- end }}
+
+{{/*
 Common webhook labels
 */}}
 {{- define "slurm-operator.webhook.labels" -}}

--- a/helm/slurm-operator/templates/webhook/rbac.yaml
+++ b/helm/slurm-operator/templates/webhook/rbac.yaml
@@ -16,8 +16,7 @@ automountServiceAccountToken: true
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "slurm-operator.webhook.name" . }}
-  namespace: {{ include "slurm-operator.namespace" . }}
+  name: {{ include "slurm-operator.webhook.fullname" . }}
   labels:
     {{- include "slurm-operator.webhook.labels" . | nindent 4 }}
 {{- .Files.Get "files/webhook_rbac_rules.yaml" | nindent 0 }}
@@ -25,8 +24,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "slurm-operator.webhook.serviceAccountName" . }}
-  namespace: {{ include "slurm-operator.namespace" . }}
+  name: {{ include "slurm-operator.webhook.fullname" . }}
   labels:
     {{- include "slurm-operator.webhook.labels" . | nindent 4 }}
 subjects:
@@ -36,5 +34,5 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "slurm-operator.webhook.serviceAccountName" . }}
+  name: {{ include "slurm-operator.webhook.fullname" . }}
 {{- end }}{{- /* if and .Values.webhook.enabled .Values.webhook.serviceAccount.create */}}

--- a/helm/slurm-operator/tests/__snapshot__/webhook_rbac_test.yaml.snap
+++ b/helm/slurm-operator/tests/__snapshot__/webhook_rbac_test.yaml.snap
@@ -24,8 +24,7 @@ manifest should match snapshot:
         app.kubernetes.io/part-of: slurm-operator
         app.kubernetes.io/version: 1.2.3
         helm.sh/chart: slurm-operator-1.2.3
-      name: slurm-operator-webhook
-      namespace: test-namespace
+      name: test-release-slurm-operator-webhook
     rules:
       - apiGroups:
           - ""
@@ -104,12 +103,11 @@ manifest should match snapshot:
         app.kubernetes.io/part-of: slurm-operator
         app.kubernetes.io/version: 1.2.3
         helm.sh/chart: slurm-operator-1.2.3
-      name: slurm-operator-webhook
-      namespace: test-namespace
+      name: test-release-slurm-operator-webhook
     roleRef:
       apiGroup: rbac.authorization.k8s.io
       kind: ClusterRole
-      name: slurm-operator-webhook
+      name: test-release-slurm-operator-webhook
     subjects:
       - kind: ServiceAccount
         name: slurm-operator-webhook

--- a/helm/slurm-operator/tests/webhook_rbac_test.yaml
+++ b/helm/slurm-operator/tests/webhook_rbac_test.yaml
@@ -49,3 +49,39 @@ tests:
       - equal:
           path: metadata.name
           value: custom-service-account
+  - it: should scope cluster-scoped names to the release
+    set:
+      webhook:
+        serviceAccount:
+          name: custom-service-account
+    asserts:
+      - equal:
+          path: metadata.name
+          value: test-release-slurm-operator-webhook
+        documentSelector:
+          path: kind
+          value: ClusterRole
+      - equal:
+          path: metadata.name
+          value: test-release-slurm-operator-webhook
+        documentSelector:
+          path: kind
+          value: ClusterRoleBinding
+  - it: should bind to the webhook ClusterRole, not the serviceAccount name
+    documentSelector:
+      path: kind
+      value: ClusterRoleBinding
+    set:
+      webhook:
+        serviceAccount:
+          name: custom-service-account
+    asserts:
+      - equal:
+          path: roleRef.name
+          value: test-release-slurm-operator-webhook
+      - equal:
+          path: subjects[0].name
+          value: custom-service-account
+      - equal:
+          path: subjects[0].namespace
+          value: test-namespace


### PR DESCRIPTION
## Summary

The webhook `ClusterRoleBinding`'s `roleRef` named the ServiceAccount rather than the ClusterRole that holds the rules. Those two names coincide only while `webhook.serviceAccount.name` is unset, which is the default, so setting it leaves the binding dangling. The webhook then has no permissions, and because `webhook.validating.failurePolicy` defaults to `Fail`, every Slinky CR write is rejected. The same mistake let `roleRef` resolve to any ClusterRole named by that value, so `webhook.serviceAccount.name: cluster-admin` would bind the webhook to `cluster-admin`.

Both names now come from a single release-scoped helper, `slurm-operator.webhook.fullname`, and the ServiceAccount name appears only in `subjects`. Release-scoping the two cluster-scoped objects also stops two releases in different namespaces from fighting over one ClusterRole, which the operator chart already avoided.

## Checklist

- [x] I have read the
  [CONTRIBUTING.md](https://github.com/SlinkyProject/slurm-operator/blob/main/CONTRIBUTING.md)
  and the
  [Code of Conduct](https://github.com/SlinkyProject/slurm-operator/blob/main/CODE_OF_CONDUCT.md).
- [x] New or existing tests cover these changes (where applicable).
- [x] Documentation is updated if user-visible behavior changes.

## Breaking Changes

The webhook ClusterRole and ClusterRoleBinding are renamed from `slurm-operator-webhook` to `<release>-slurm-operator-webhook`. One unscoped name cannot serve two releases, so the rename is unavoidable. Helm creates the new objects before pruning the old ones, so the webhook is never left without permissions, but anything referencing the old names from outside the chart needs updating.

## Testing Notes

```bash
helm template rel-a ./helm/slurm-operator -n ns-a \
  --set webhook.serviceAccount.name=custom-webhook-sa \
  --show-only templates/webhook/rbac.yaml
```

The ClusterRole, the ClusterRoleBinding, and its `roleRef` should all read `rel-a-slurm-operator-webhook`, with `custom-webhook-sa` as the only subject. Before this change, `roleRef` pointed at `custom-webhook-sa` and no ClusterRole by that name existed.

## Additional Context

`webhook/rbac.yaml` is still gated entirely on `webhook.serviceAccount.create`, so `create: false` renders no ClusterRole or binding and fails closed in the same way. Closing that would add chart-owned RBAC for users who currently manage their own, so it is left as follow-up.

Also open on GitLab as nvidia/schedmd/slinky/slurm-operator!722; whichever forge maintainers prefer, the other can be closed.
