### PR TITLE
fix: own the auth-token Secret by the Token, not the JWT key

### DIFF
--- a/internal/builder/common/token_secret.go
+++ b/internal/builder/common/token_secret.go
@@ -44,12 +44,7 @@ func (b *CommonBuilder) BuildTokenSecret(token *slinkyv1beta1.Token) (*corev1.Se
 		Immutable: !ptr.Deref(token.Spec.Refresh, defaults.DefaultTokenRefresh),
 	}
 
-	jwtSecret := &corev1.Secret{}
-	if err := b.client.Get(ctx, token.JwtKey(), jwtSecret); err != nil {
-		return nil, err
-	}
-
-	o, err := b.BuildSecret(opts, jwtSecret)
+	o, err := b.BuildSecret(opts, token)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build token secret: %w", err)
 	}

--- a/internal/builder/common/token_secret_test.go
+++ b/internal/builder/common/token_secret_test.go
@@ -100,6 +100,11 @@ func TestBuilder_BuildTokenSecret(t *testing.T) {
 			require.NoError(t, err)
 			refresh := ptr.Deref(tt.args.token.Spec.Refresh, defaults.DefaultTokenRefresh)
 			require.Equal(t, !refresh, ptr.Deref(got.Immutable, false))
+
+			owner := metav1.GetControllerOf(got)
+			require.NotNil(t, owner)
+			require.Equal(t, slinkyv1beta1.TokenKind, owner.Kind)
+			require.Equal(t, tt.args.token.Name, owner.Name)
 		})
 	}
 }

--- a/internal/controller/token/suite_test.go
+++ b/internal/controller/token/suite_test.go
@@ -13,10 +13,12 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
 	"github.com/SlinkyProject/slurm-operator/internal/utils/testutils"
@@ -71,6 +73,20 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
+	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:  scheme.Scheme,
+		Metrics: server.Options{BindAddress: "0"},
+	})
+	Expect(err).ToNot(HaveOccurred())
+
+	err = NewReconciler(k8sManager.GetClient()).SetupWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred())
+
+	go func() {
+		defer GinkgoRecover()
+		err = k8sManager.Start(ctx)
+		Expect(err).ToNot(HaveOccurred(), "failed to run manager")
+	}()
 })
 
 var _ = AfterSuite(func() {

--- a/internal/controller/token/token_controller_test.go
+++ b/internal/controller/token/token_controller_test.go
@@ -4,13 +4,19 @@
 package token
 
 import (
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	"github.com/SlinkyProject/slurm-operator/internal/utils/objectutils"
+	"github.com/SlinkyProject/slurm-operator/internal/utils/structutils"
 	"github.com/SlinkyProject/slurm-operator/internal/utils/testutils"
 )
 
@@ -77,7 +83,7 @@ var _ = Describe("Token Controller", func() {
 			}).Should(Succeed())
 
 			By("Waiting for Token child to be created")
-			secretKey := token.JwtKey()
+			secretKey := token.SecretKey()
 			secret := &corev1.Secret{}
 			Eventually(func(g Gomega) {
 				g.Expect(k8sClient.Get(ctx, secretKey, secret)).To(Succeed())
@@ -102,4 +108,169 @@ var _ = Describe("Token Controller", func() {
 		})
 
 	})
+
+	Context("When owning the generated auth-token Secret", func() {
+		var token *slinkyv1beta1.Token
+		var jwtKeySecret *corev1.Secret
+
+		BeforeEach(func() {
+			name := testutils.GenerateResourceName(5)
+			jwtKeyRef := testutils.NewJwtKeyRef(name)
+			jwtKeySecret = testutils.NewJwtKeySecret(jwtKeyRef)
+			token = testutils.NewToken(name, jwtKeySecret)
+			Expect(k8sClient.Create(ctx, jwtKeySecret.DeepCopy())).To(Succeed())
+			Expect(k8sClient.Create(ctx, token.DeepCopy())).To(Succeed())
+		})
+
+		AfterEach(func() {
+			_ = k8sClient.Delete(ctx, jwtKeySecret)
+			_ = k8sClient.Delete(ctx, token)
+		})
+
+		It("Should set the Token CR as the controller owner", func(ctx SpecContext) {
+			By("Waiting for the auth-token Secret to be created")
+			// SecretKey() is the generated credential, distinct from JwtKey() (the signing key).
+			authSecret := waitForSecret(ctx, token.SecretKey())
+
+			By("Verifying the controller owner is the Token, not the JWT signing key Secret")
+			owner := metav1.GetControllerOf(authSecret)
+			Expect(owner).NotTo(BeNil())
+			Expect(owner.Kind).To(Equal(slinkyv1beta1.TokenKind))
+			Expect(owner.Name).To(Equal(token.Name))
+		}, SpecTimeout(testutils.Timeout))
+
+		It("Should recreate the auth-token Secret when it is deleted out-of-band", func(ctx SpecContext) {
+			By("Waiting for the auth-token Secret to be created")
+			authSecret := waitForSecret(ctx, token.SecretKey())
+			originalUID := authSecret.UID
+
+			By("Deleting the auth-token Secret out-of-band")
+			Expect(k8sClient.Delete(ctx, authSecret)).To(Succeed())
+
+			By("Verifying the Secret watch drives a reconcile that recreates it")
+			Eventually(func(g Gomega) {
+				recreated := &corev1.Secret{}
+				g.Expect(k8sClient.Get(ctx, token.SecretKey(), recreated)).To(Succeed())
+				g.Expect(recreated.UID).NotTo(Equal(originalUID))
+			}, testutils.Timeout, testutils.Interval).Should(Succeed())
+		}, SpecTimeout(testutils.Timeout))
+	})
+
+	Context("When adopting an auth-token Secret owned by the JWT signing key", func() {
+		var token *slinkyv1beta1.Token
+		var jwtKeySecret *corev1.Secret
+
+		// Refresh is disabled so the Secret is created immutable, which is the
+		// case the normal sync path skips entirely.
+		BeforeEach(func() {
+			name := testutils.GenerateResourceName(5)
+			jwtKeyRef := testutils.NewJwtKeyRef(name)
+			jwtKeySecret = testutils.NewJwtKeySecret(jwtKeyRef)
+			token = testutils.NewToken(name, jwtKeySecret)
+			token.Spec.Refresh = ptr.To(false)
+			Expect(k8sClient.Create(ctx, jwtKeySecret.DeepCopy())).To(Succeed())
+			Expect(k8sClient.Create(ctx, token.DeepCopy())).To(Succeed())
+		})
+
+		AfterEach(func() {
+			_ = k8sClient.Delete(ctx, jwtKeySecret)
+			_ = k8sClient.Delete(ctx, token)
+		})
+
+		It("Should repoint the controller owner at the Token", func(ctx SpecContext) {
+			By("Waiting for the immutable auth-token Secret to be created")
+			authSecret := waitForSecret(ctx, token.SecretKey())
+			Expect(ptr.Deref(authSecret.Immutable, false)).To(BeTrue())
+
+			By("Rewriting the owner to the JWT signing key, as older operators did")
+			staleOwner := &corev1.Secret{}
+			Expect(k8sClient.Get(ctx, token.JwtKey(), staleOwner)).To(Succeed())
+			Expect(objectutils.PatchObject(k8sClient, ctx, authSecret, func(o *corev1.Secret) error {
+				o.OwnerReferences = []metav1.OwnerReference{
+					*metav1.NewControllerRef(staleOwner, corev1.SchemeGroupVersion.WithKind("Secret")),
+				}
+				return nil
+			})).To(Succeed())
+
+			By("Triggering a reconcile, as an operator restart would")
+			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(token), token)).To(Succeed())
+			token.Annotations = structutils.MergeMaps(token.Annotations, map[string]string{
+				"test.slinky.slurm.net/trigger": "adopt",
+			})
+			Expect(k8sClient.Update(ctx, token)).To(Succeed())
+
+			By("Verifying the Secret is adopted by the Token")
+			Eventually(func(g Gomega) {
+				adopted := &corev1.Secret{}
+				g.Expect(k8sClient.Get(ctx, token.SecretKey(), adopted)).To(Succeed())
+				owner := metav1.GetControllerOf(adopted)
+				g.Expect(owner).NotTo(BeNil())
+				g.Expect(owner.Kind).To(Equal(slinkyv1beta1.TokenKind))
+				g.Expect(owner.UID).To(Equal(token.UID))
+			}, testutils.Timeout, testutils.Interval).Should(Succeed())
+		}, SpecTimeout(testutils.Timeout))
+
+	})
+
+	Context("When the target Secret is owned by an unrelated resource", func() {
+		var token *slinkyv1beta1.Token
+		var jwtKeySecret *corev1.Secret
+		var unrelated *corev1.Secret
+
+		AfterEach(func() {
+			_ = k8sClient.Delete(ctx, token)
+			_ = k8sClient.Delete(ctx, jwtKeySecret)
+			_ = k8sClient.Delete(ctx, unrelated)
+		})
+
+		It("Should not take ownership of it", func(ctx SpecContext) {
+			name := testutils.GenerateResourceName(5)
+			jwtKeyRef := testutils.NewJwtKeyRef(name)
+			jwtKeySecret = testutils.NewJwtKeySecret(jwtKeyRef)
+			token = testutils.NewToken(name, jwtKeySecret)
+			Expect(k8sClient.Create(ctx, jwtKeySecret.DeepCopy())).To(Succeed())
+
+			By("Pre-creating the target Secret owned by an unrelated Secret")
+			unrelated = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name + "-unrelated",
+					Namespace: token.Namespace,
+				},
+			}
+			Expect(k8sClient.Create(ctx, unrelated)).To(Succeed())
+
+			squatter := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      token.SecretKey().Name,
+					Namespace: token.SecretKey().Namespace,
+					OwnerReferences: []metav1.OwnerReference{
+						*metav1.NewControllerRef(unrelated, corev1.SchemeGroupVersion.WithKind("Secret")),
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, squatter)).To(Succeed())
+
+			By("Creating the Token that targets it")
+			Expect(k8sClient.Create(ctx, token.DeepCopy())).To(Succeed())
+			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(token), token)).To(Succeed())
+
+			By("Verifying the owner is never rewritten")
+			Consistently(func(g Gomega) {
+				current := &corev1.Secret{}
+				g.Expect(k8sClient.Get(ctx, token.SecretKey(), current)).To(Succeed())
+				owner := metav1.GetControllerOf(current)
+				g.Expect(owner).NotTo(BeNil())
+				g.Expect(owner.UID).To(Equal(unrelated.UID))
+			}, 5*time.Second, testutils.Interval).Should(Succeed())
+		}, SpecTimeout(testutils.Timeout))
+	})
 })
+
+func waitForSecret(ctx SpecContext, key types.NamespacedName) *corev1.Secret {
+	GinkgoHelper()
+	secret := &corev1.Secret{}
+	Eventually(func(g Gomega) {
+		g.Expect(k8sClient.Get(ctx, key, secret)).To(Succeed())
+	}, testutils.Timeout, testutils.Interval).Should(Succeed())
+	return secret
+}

--- a/internal/controller/token/token_sync.go
+++ b/internal/controller/token/token_sync.go
@@ -10,10 +10,13 @@ import (
 	"time"
 
 	jwt "github.com/golang-jwt/jwt/v5"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -56,6 +59,9 @@ func (r *TokenReconciler) Sync(ctx context.Context, req reconcile.Request) error
 				}
 				if err := objectutils.SyncObject(r.Client, ctx, r.eventRecorder, token, object, false); err != nil {
 					return fmt.Errorf("failed to sync object (%s): %w", klog.KObj(object), err)
+				}
+				if err := r.adoptSecret(ctx, token, object); err != nil {
+					return fmt.Errorf("failed to adopt object (%s): %w", klog.KObj(object), err)
 				}
 				return nil
 			},
@@ -117,6 +123,46 @@ func (r *TokenReconciler) Sync(ctx context.Context, req reconcile.Request) error
 	}
 
 	return r.syncStatus(ctx, token)
+}
+
+// adoptSecret repoints the auth-token Secret's controller owner at the Token.
+//
+// Operator versions before this fix set the JWT signing key Secret as the owner,
+// which orphaned the credential when the Token was deleted and made the Secret
+// watch in SetupWithManager unresolvable. Those Secrets cannot be repaired by
+// the normal sync: SyncObject is called create-only here, and skips immutable
+// Secrets entirely. Owner references are metadata, so they remain patchable even
+// when the Secret's contents are immutable.
+//
+// Only Secrets owned by this Token's signing key are adopted. spec.secretRef can
+// name any Secret, so anything else is left alone rather than taking ownership of
+// a resource this controller did not create.
+func (r *TokenReconciler) adoptSecret(ctx context.Context, token *slinkyv1beta1.Token, desired *corev1.Secret) error {
+	logger := log.FromContext(ctx)
+
+	secret := &corev1.Secret{}
+	if err := r.Get(ctx, token.SecretKey(), secret); err != nil {
+		return client.IgnoreNotFound(err)
+	}
+	if !secret.DeletionTimestamp.IsZero() {
+		return nil
+	}
+
+	owner := metav1.GetControllerOf(secret)
+	if owner == nil || owner.UID == token.UID {
+		return nil
+	}
+	if owner.Kind != "Secret" || owner.Name != token.JwtRef().Name {
+		logger.V(1).Info("Auth-token Secret is owned by another resource, skipping adoption",
+			"secret", klog.KObj(secret), "owner", owner)
+		return nil
+	}
+
+	logger.Info("Adopting auth-token Secret", "secret", klog.KObj(secret))
+	return objectutils.PatchObject(r.Client, ctx, secret, func(o *corev1.Secret) error {
+		o.OwnerReferences = desired.OwnerReferences
+		return nil
+	})
 }
 
 func (r *TokenReconciler) getExpTime(ctx context.Context, token *slinkyv1beta1.Token) (time.Time, error) {


### PR DESCRIPTION
## Summary

`BuildTokenSecret` passes the JWT signing key Secret to `BuildSecret` as the owner, so the generated credential's controller `ownerReference` points at another Secret rather than the `Token` that requested it.

```go
jwtSecret := &corev1.Secret{}
if err := b.client.Get(ctx, token.JwtKey(), jwtSecret); err != nil {
	return nil, err
}

o, err := b.BuildSecret(opts, jwtSecret)
```

This cuts both ways:

- Deleting a `Token` leaves a live, valid Slurm JWT behind with no owning resource, invisible to anyone auditing `Token` objects.
- Deleting or rotating the JWT signing key garbage-collects every credential derived from it.

It also makes `Owns(&corev1.Secret{})` in `SetupWithManager` dead code, because the owner lookup can never resolve back to a `Token`. An out-of-band Secret deletion therefore goes unnoticed until the refresh requeue at 80% of the token lifetime — or forever when `spec.refresh` is `false`, since that path schedules no requeue at all.

The fix passes the `Token` as the owner. That also removes the `client.Get` above, which existed only to supply that owner; the signing key material is already resolved through `refResolver.GetSecretKeyRef`.

### Adopting existing Secrets

Secrets written by earlier versions cannot be repaired by the normal sync path. `SyncObject` is called create-only from the `Token` Secret step, so it returns before the patch block, and even with `shouldUpdate=true` it skips `Immutable` Secrets — which is exactly what `spec.refresh: false` produces. Those credentials would stay mis-owned indefinitely.

`adoptSecret` repairs them by patching only the owner references, which remains legal on an immutable Secret because immutability covers `data`, not metadata.

Adoption is deliberately narrow: it only touches Secrets whose controller owner is *this* `Token`'s signing key. `spec.secretRef` can name any Secret, so a name collision with an unrelated pre-existing Secret must not cause the operator to seize it and later garbage-collect it.

## Checklist

- [x] I have read the
  [CONTRIBUTING.md](https://github.com/SlinkyProject/slurm-operator/blob/main/CONTRIBUTING.md)
  and the
  [Code of Conduct](https://github.com/SlinkyProject/slurm-operator/blob/main/CODE_OF_CONDUCT.md).
- [x] New or existing tests cover these changes (where applicable).
- [x] Documentation is updated if user-visible behavior changes.

## Breaking Changes

None for users. On upgrade, existing auth-token Secrets are re-pointed from the signing key Secret to their `Token`. This changes their garbage-collection behavior to the intended one: they are removed when the `Token` is deleted, and they survive deletion of the signing key.

## Testing Notes

`internal/controller/token/suite_test.go` never started a manager, so its specs passed without a controller running. The spec that looked like it covered this behavior used `token.JwtKey()` (the signing key) where it meant `token.SecretKey()` (the generated credential), so it never touched the generated Secret at all. This PR starts a manager and corrects that key, then adds specs for ownership, recreation after out-of-band deletion, adoption of an immutable mis-owned Secret, and the no-hijack guard. Each new spec was confirmed to fail when its corresponding fix is reverted.

Also verified end to end on a kind cluster, comparing an unpatched build against the patched one using identical manifests. A `Token` Secret created by the unpatched build was adopted at operator startup, and a `refresh: false` Token behaved as follows:

| Scenario | Unpatched | Patched |
|---|---|---|
| Owner on create | `Secret/<jwt-key>` | `Token/<name>`, uid matches CR |
| Pre-existing mis-owned Secret | never repaired | adopted at startup |
| Credential deleted out-of-band | absent >90s, 0 reconciles | recreated in ~3s |
| Signing key deleted | credential destroyed | credential survives |
| `Token` deleted | live JWT orphaned | collected in ~3s |

Token reconcile counts stayed flat over an idle period afterwards and adoption logged once per affected Secret, so the adoption patch is idempotent and does not hot-loop.

## Additional Context

Fixing the owner also revives the `Owns(&corev1.Secret{})` watch as a side effect. The early return on `DeletionTimestamp` in `token_sync.go` is left as-is, since owner-reference garbage collection now covers cleanup and no finalizer is needed.