### PR TITLE
fix(nodeset): tolerate NotFound on cordon/uncordon of vanished pods (fixes rolling-update wedge)

### DIFF
--- a/internal/controller/nodeset/nodeset_sync.go
+++ b/internal/controller/nodeset/nodeset_sync.go
@@ -1196,6 +1196,12 @@ func (r *NodeSetReconciler) doPodScale(
 		return r.syncPodUncordon(ctx, nodeset, pod)
 	}
 	if _, err := utils.SlowStartBatch(len(podsToKeep), utils.SlowStartInitialBatchSize, uncordonFn); err != nil {
+		// No creates will be attempted this sync; release the creation
+		// expectations raised above, otherwise subsequent reconciles wait
+		// for creations that were never issued (see issue #249).
+		for range numCreate {
+			r.expectations.CreationObserved(logger, key)
+		}
 		return err
 	}
 
@@ -1529,6 +1535,12 @@ func (r *NodeSetReconciler) makePodCordon(
 		return nil
 	}
 	if err := objectutils.PatchObject(r.Client, ctx, pod, mutateFn); err != nil {
+		// The pod may already be gone (e.g. deleted by this controller in a
+		// previous reconcile and still present in the informer cache).
+		// There is nothing left to cordon in that case.
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
 		return err
 	}
 
@@ -1568,6 +1580,13 @@ func (r *NodeSetReconciler) makePodUncordon(ctx context.Context, pod *corev1.Pod
 		return nil
 	}
 	if err := objectutils.PatchObject(r.Client, ctx, pod, mutateFn); err != nil {
+		// The pod may already be gone (e.g. deleted by a rolling update in a
+		// previous reconcile and still present in the informer cache).
+		// Failing here would abort the whole NodeSetPods step before any
+		// replacement pods are created (see issue #249).
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
 		return err
 	}
 

--- a/internal/controller/nodeset/nodeset_sync_test.go
+++ b/internal/controller/nodeset/nodeset_sync_test.go
@@ -2490,7 +2490,7 @@ func TestNodeSetReconciler_makePodCordon(t *testing.T) {
 				ctx: context.TODO(),
 				pod: pod1.DeepCopy(),
 			},
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name: "cordoned",
@@ -2731,7 +2731,7 @@ func TestNodeSetReconciler_makePodUncordon(t *testing.T) {
 				ctx: context.TODO(),
 				pod: pod1.DeepCopy(),
 			},
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name: "cordoned",


### PR DESCRIPTION
## Summary

Fixes #249 — NodeSet rolling update wedges: the node is left drained
(`slurm-operator: Pod is terminating`) and the replacement pod is never
created until a manual `scontrol undrain`.

## Root cause

On the reconcile right after the rolling update deletes the old pod, the
stale informer cache can still list that pod. In `doPodScale`:

1. creation expectations are raised (`RaiseExpectations`) **before** the
   uncordon batch;
2. `syncPodUncordon` → `makePodUncordon` patches the cached, already
   deleted pod and fails with `NotFound`
   (`failed to patch <ns>/<pod>: pods "<pod>" not found`), aborting the
   step **before any create is attempted**;
3. the raised creation expectations are never released (the existing
   `skippedPods` compensation only runs when the create batch itself
   runs), so subsequent reconciles wait for creations that were never
   issued — the NodeSet wedges, and the operator-owned drain outlives
   the pod it was placed for.

Reproduced on 3 out of 3 rolling updates (daemonset scaling mode, Slurm
26.05, operator 1.2.1); details, events and logs in #249.

## Changes

- `makePodCordon` / `makePodUncordon`: treat `NotFound` as a no-op — the
  pod is gone, there is nothing to (un)cordon. This mirrors the existing
  handling in the deadline and topology pod patches in the same file.
- `doPodScale`: when the uncordon batch fails, release the creation
  expectations raised earlier in the same sync, so an aborted step can
  no longer block future creations.
- Tests: the two `NotFound` subtests of `makePodCordon`/`makePodUncordon`
  now expect success.

## Testing

- `go build ./...`, `gofmt`, `go vet` clean.
- `go test ./internal/controller/nodeset/...` green (envtest suite
  included, k8s 1.37 assets).
- The failure mode itself was exercised live on a test cluster (three
  wedged rollouts in one day before the fix; with NotFound tolerated the
  aborting patch disappears from the chain).

