### PR TITLE
fix(builder): keep explicitly-set false/0 values when merging CR templates

### DIFF
--- a/internal/utils/structutils/kube.go
+++ b/internal/utils/structutils/kube.go
@@ -7,8 +7,6 @@ import (
 	"encoding/json"
 
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
-
-	"github.com/SlinkyProject/slurm-operator/internal/utils/reflectutils"
 )
 
 // StrategicMergePatch merges two objects via kubernetes StrategicMergePatch
@@ -65,10 +63,11 @@ func cleanAndMarshal(obj any) ([]byte, error) {
 	return out, nil
 }
 
-// removeEmpty will recursively walk a map, deleting fields if its value is empty.
+// removeEmpty will recursively walk a map, deleting fields that carry no
+// information: nulls, empty strings and empty objects.
 func removeEmpty(m map[string]any) {
 	for k, v := range m {
-		if v == nil || reflectutils.IsEmpty(v) {
+		if v == nil || v == "" {
 			delete(m, k)
 		} else if subMap, ok := v.(map[string]any); ok {
 			removeEmpty(subMap)

--- a/internal/utils/structutils/kube_test.go
+++ b/internal/utils/structutils/kube_test.go
@@ -9,12 +9,78 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	"github.com/SlinkyProject/slurm-operator/internal/utils/structutils"
 )
 
 func Test_strategicMergePatch(t *testing.T) {
 	test_strategicMergePatch_pod(t)
+	test_strategicMergePatch_explicitZeroValues(t)
+}
+
+// Explicitly-set zero values are meaningful in the Kubernetes API and must
+// survive the merge: `allowPrivilegeEscalation: false` is required by the
+// restricted Pod Security Standard, `privileged: false` is the only way to
+// override a `true` in the base spec, and `runAsUser: 0` is an explicit
+// request for root.
+func test_strategicMergePatch_explicitZeroValues(t *testing.T) {
+	// The pod template path, as used by BuildPodTemplate.
+	base := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "app",
+					Image: "app",
+				},
+			},
+		},
+	}
+	patch := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			AutomountServiceAccountToken:  ptr.To(false),
+			TerminationGracePeriodSeconds: ptr.To(int64(0)),
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsUser: ptr.To(int64(0)),
+			},
+		},
+	}
+
+	got := structutils.StrategicMergePatch(base, patch)
+
+	require.Equal(t, ptr.To(false), got.Spec.AutomountServiceAccountToken)
+	require.Equal(t, ptr.To(int64(0)), got.Spec.TerminationGracePeriodSeconds)
+	require.NotNil(t, got.Spec.SecurityContext)
+	require.Equal(t, ptr.To(int64(0)), got.Spec.SecurityContext.RunAsUser)
+	// Fields only present in the base are untouched by the patch.
+	require.Len(t, got.Spec.Containers, 1)
+	require.Equal(t, "app", got.Spec.Containers[0].Image)
+
+	// The container path, as used by BuildContainer, where the container is
+	// the root of the merge.
+	baseContainer := &corev1.Container{
+		Name:  "login",
+		Image: "login",
+		SecurityContext: &corev1.SecurityContext{
+			Privileged:               ptr.To(true),
+			AllowPrivilegeEscalation: ptr.To(true),
+		},
+	}
+	patchContainer := &corev1.Container{
+		SecurityContext: &corev1.SecurityContext{
+			Privileged:               ptr.To(false),
+			AllowPrivilegeEscalation: ptr.To(false),
+			ReadOnlyRootFilesystem:   ptr.To(false),
+		},
+	}
+
+	gotContainer := structutils.StrategicMergePatch(baseContainer, patchContainer)
+
+	require.NotNil(t, gotContainer.SecurityContext)
+	require.Equal(t, ptr.To(false), gotContainer.SecurityContext.AllowPrivilegeEscalation)
+	require.Equal(t, ptr.To(false), gotContainer.SecurityContext.Privileged)
+	require.Equal(t, ptr.To(false), gotContainer.SecurityContext.ReadOnlyRootFilesystem)
+	require.Equal(t, "login", gotContainer.Image)
 }
 
 func test_strategicMergePatch_pod(t *testing.T) {


### PR DESCRIPTION
## Summary

`removeEmpty()` pruned every JSON value equal to the zero value of its Go type, so an explicitly-set `false` or `0` in a CR pod/container template was dropped from the strategic merge patch and never reached the built workload.

The fields at risk are `*bool`/`*int64` with `omitempty` in the Kubernetes API types: they are marshalled **only** when the user set them, so pruning them discarded configuration rather than noise. Nulls, empty strings and empty objects are still pruned, and lists are left exactly as `main` leaves them — an explicitly empty array is preserved — so nothing beyond booleans and numbers changes.

Concretely, `spec.login.securityContext.allowPrivilegeEscalation: false` on a `LoginSet` is stored in the CR but absent from the Deployment, so the login container runs with `NoNewPrivs: 0` and a `LoginSet` cannot satisfy the `restricted` Pod Security Standard. The chart's own default (`loginsetDefaults.login.securityContext.privileged: false`) is lost the same way, as are `readOnlyRootFilesystem: false`, `runAsUser: 0` and `terminationGracePeriodSeconds: 0`.

One clarification on the scope, since the helper is shared by `BuildContainer` and `BuildPodTemplate`: the loss happens at the **root of the merge** — the container itself for `BuildContainer`, and pod-level fields for `BuildPodTemplate`. `removeEmpty` never descended into lists, so a container sitting inside `spec.containers[]` already came through intact on `main`.

Closes #252.

## Checklist

- [x] I have read the
  [CONTRIBUTING.md](https://github.com/SlinkyProject/slurm-operator/blob/main/CONTRIBUTING.md)
  and the
  [Code of Conduct](https://github.com/SlinkyProject/slurm-operator/blob/main/CODE_OF_CONDUCT.md).
- [x] New or existing tests cover these changes (where applicable).
- [x] Documentation is updated if user-visible behavior changes. (No documentation change: the fix makes the builders honour values the CRD already documents.)

## Breaking Changes

No API or schema change, but the fix is **retroactive**, and that is worth stating plainly: a `false` or `0` already sitting in a CR or in chart values is inert today and becomes effective the moment the operator image is replaced. No CR is edited, no chart value changes, nothing shows up in a diff — the same configuration simply starts being honoured.

Mostly that is the point, and it hardens: `allowPrivilegeEscalation: false`, `privileged: false` and `hostUsers: false` start reaching the pod. Two directions deserve a look before upgrading:

* the base specs of Controller, Accounting and RestApi set `runAsNonRoot: true` with a non-root uid; an explicit `runAsNonRoot: false` or `runAsUser: 0` in a CR now overrides that, where before the operator silently won;
* `terminationGracePeriodSeconds: 0` now reaches the pod, which removes the window the slurmd `preStop` hook uses to drain the node.

A grep for zero-valued `securityContext` fields and for `terminationGracePeriodSeconds` across CRs and values is enough to see whether a given deployment is affected. A deployment that relied on an explicit `false` being silently ignored would change, but that would be the bug itself.

## Testing Notes

* `internal/utils/structutils/kube_test.go` gains a subtest that merges at both roots the builders use. A pod template carrying `automountServiceAccountToken: false`, `terminationGracePeriodSeconds: 0` and `securityContext.runAsUser: 0`, and a container — the root `BuildContainer` merges at — carrying `privileged: false`, `allowPrivilegeEscalation: false` and `readOnlyRootFilesystem: false` over a base that sets them `true`. Both halves fail on `main` and pass with this change. `make test` is green (50 packages) and `golangci-lint run ./internal/...` reports nothing from these files.
* List handling is deliberately untouched: `removeEmpty` has no list branch at all, so an explicitly empty array survives here exactly as it does on `main`.
* A known limit this does not change: non-pointer `bool` fields such as `hostNetwork`, `hostPID` and `hostIPC`, and non-pointer empty strings, are dropped by `omitempty` during `json.Marshal`, before `removeEmpty` ever sees them. No base spec sets those to `true` today, so there is nothing to override, but the class is not fully gone.
* Verified on a cluster (Kubernetes v1.35.8, charts `slurm-operator-1.2.1` / `slurm-1.2.1`, one `LoginSet` declaring all five fields; only the operator image swapped):

  Before (`ghcr.io/slinkyproject/slurm-operator:1.2.1`):

  ```
  container.securityContext: {"capabilities":{"add":[...],"drop":["ALL"]}}
  pod.terminationGracePeriodSeconds: 30
  pod.securityContext: {}
  ```

  After (this branch):

  ```
  container.securityContext: {"allowPrivilegeEscalation":false,"capabilities":{"add":[...],"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":false}
  pod.terminationGracePeriodSeconds: 0
  pod.securityContext: {"runAsUser":0}
  ```

  and in the login pod: `NoNewPrivs: 1`.

## Additional Context

Found while trying to run a `LoginSet` under the `restricted` Pod Security Standard.