### PR TITLE
fix(controller): keep labeling the active controller when Slurm is unreachable

### DIFF
--- a/internal/controller/controller/controller_sync_status.go
+++ b/internal/controller/controller/controller_sync_status.go
@@ -103,9 +103,14 @@ func (r *ControllerReconciler) syncHAStatus(
 		return nil
 	}
 
+	errs := []error{}
+
 	pings, err := r.slurmControl.GetActiveHAController(ctx, controller)
 	if err != nil && !errors.Is(err, slurmcontrol.ErrNoSlurmClient) {
-		return err
+		// Do not bail out when Slurm cannot be asked which controller is active.
+		log.FromContext(ctx).V(1).Info("Failed to determine the active controller, defaulting to the primary",
+			"Controller", klog.KObj(controller), "error", err)
+		errs = append(errs, fmt.Errorf("failed to determine the active controller: %w", err))
 	}
 
 	activePodName := controller.PodName(0)
@@ -126,7 +131,6 @@ func (r *ControllerReconciler) syncHAStatus(
 	}
 	sort.Sort(objectutils.PodsByName(podList.Items))
 
-	errs := []error{}
 	for i := range podList.Items {
 		pod := &podList.Items[i]
 		mutateFn := func(pod *corev1.Pod) error {

--- a/internal/controller/controller/controller_sync_status_test.go
+++ b/internal/controller/controller/controller_sync_status_test.go
@@ -131,13 +131,22 @@ func TestControllerReconciler_syncHAStatus(t *testing.T) {
 			},
 		},
 		{
-			name:       "Slurm error is returned",
+			// Regression: a transport error used to abort before labeling, which
+			// left the Controller Service without endpoints. A Service without
+			// endpoints is what makes Slurm unreachable, so the next reconcile
+			// failed the same way and nothing ever relabeled a pod.
+			name:       "Slurm error defaults to primary",
 			controller: newController(false),
 			pods: []*corev1.Pod{
-				newPod(newController(false), 0, true),
+				newPod(newController(false), 0, false),
+				newPod(newController(false), 1, true),
 			},
 			pingErr: errors.New("internal error"),
 			wantErr: true,
+			wantActive: map[string]bool{
+				"slurm-controller-0": true,
+				"slurm-controller-1": false,
+			},
 		},
 	}
 	for _, tt := range tests {
@@ -158,9 +167,12 @@ func TestControllerReconciler_syncHAStatus(t *testing.T) {
 			err := r.syncHAStatus(t.Context(), tt.controller)
 			if tt.wantErr {
 				require.Error(t, err)
-				return
+			} else {
+				require.NoError(t, err)
 			}
-			require.NoError(t, err)
+
+			// Labels are reconciled either way: surfacing the Slurm failure
+			// must not cost the Service its endpoints.
 
 			got := make([]*corev1.Pod, 0, len(tt.pods))
 			for _, pod := range tt.pods {


### PR DESCRIPTION
Fixes #257.

`syncHAStatus` is the only place that sets `controller.slinky.slurm.net/active`, which chart 1.2.2 added to the `Controller` Service selector. It set the label only after `GetActiveHAController` succeeded, and that call goes through the very Service it is about to populate:

> no label → Service has no endpoints → Slurm unreachable → ping returns a transport error (not `ErrNoSlurmClient`) → `syncHAStatus` returns before labeling → no label

Once a Slurm client has been created it is kept for the lifetime of the operator (`slurmclient_sync.go` updates it in place), so `ErrNoSlurmClient` — the single error the code tolerated — stops being returned, and the cluster stays headless until someone labels a pod by hand. We hit this on a 1.2.1 → 1.2.2 chart upgrade: the controller pod was recreated without the label, and slurmd on every node, both login pods, slurmrestd and the operator's own Slurm access were down until we ran `kubectl label`.

This treats any ping failure the same way a missing client is already treated: fall through with no pings, label the primary, and let a later reconcile move the label once Slurm answers again. Labeling the primary is what the code already does for `ErrNoSlurmClient` and for the "nobody responded" case, so no new policy is introduced; the alternative — no endpoints at all — cannot recover on its own.

Testing:

- `go test ./internal/controller/controller/... -run TestControllerReconciler_syncHAStatus` — the existing case that asserted the error was propagated becomes a regression test asserting the primary gets labeled instead.
- Reproduced the deadlock on a 1.2.2 cluster (remove the label, watch the Service stay empty for minutes), then confirmed the patched behaviour restores the endpoint on the next reconcile.
