### PR TITLE
fix(nodeset): give DaemonSet-mode pods the standard daemon tolerations

### DIFF
--- a/internal/controller/nodeset/nodeset_sync.go
+++ b/internal/controller/nodeset/nodeset_sync.go
@@ -1300,6 +1300,10 @@ func (r *NodeSetReconciler) newNodeSetPodDaemon(
 	hostnameOverride := node.Annotations[slinkyv1beta1.AnnotationNodeHostnameOverride]
 
 	pod := nodesetutils.NewNodeSetDaemonSetPod(client, nodeset, controller, nodeName, hostnameOverride, revisionHash)
+	// Same tolerations the DaemonSet controller gives its own pods. Without
+	// them a NodeSet pod cannot be (re)created on a cordoned node, because
+	// cordon adds node.kubernetes.io/unschedulable:NoSchedule.
+	daemonutils.AddOrUpdateDaemonPodTolerations(&pod.Spec)
 	return pod, nil
 }
 
@@ -1325,6 +1329,10 @@ func newSimulatedDaemonPod(
 	}
 
 	pod := nodesetutils.NewNodeSetSimulatedPod(client, nodeset, controller, nodeName)
+	// The predicate must see the same tolerations the real pod gets,
+	// otherwise PodShouldRunOnNode reports "should not run" for nodes the
+	// pod would in fact tolerate.
+	daemonutils.AddOrUpdateDaemonPodTolerations(&pod.Spec)
 	return pod, nil
 }
 


### PR DESCRIPTION
## Summary

In `scalingMode: DaemonSet` a NodeSet pod cannot be created on a cordoned node. Cordon adds `node.kubernetes.io/unschedulable:NoSchedule`, the pod built by `newNodeSetPodDaemon` does not tolerate it, `PodShouldRunOnNode` returns `shouldRun=false`, and the node leaves `status.desired`.

Existing pods are unaffected — cordon does not evict — so nothing looks wrong until a pod has to come back. A rolling update after an image change is the ordinary way to get there, and from then on the node stays without a pod for as long as it is cordoned.

It is also inconsistent with the neighbouring code: `syncCordon` treats "pod on a cordoned node" as a legitimate state and drains the matching Slurm node for it, and `PodShouldRunOnNode` already returns `shouldContinueRunning=true` for it. Only the create path disagrees.

The fix applies `daemonutils.AddOrUpdateDaemonPodTolerations` — the same helper the upstream DaemonSet controller uses for its own pods — in two places:

* `newNodeSetPodDaemon`, the real DaemonSet-mode pod;
* `newSimulatedDaemonPod`, the pod used for predicate evaluation. This one matters too: the predicate has to see the same tolerations the real pod gets, otherwise it still reports "should not run" and the fix has no effect.

The package is already imported (`daemonutils "k8s.io/kubernetes/pkg/controller/daemon/util"`), so the change is two calls. `StatefulSet` scaling mode is untouched.

Closes #259.

## Checklist

- [x] I have read the
  [CONTRIBUTING.md](https://github.com/SlinkyProject/slurm-operator/blob/main/CONTRIBUTING.md)
  and the
  [Code of Conduct](https://github.com/SlinkyProject/slurm-operator/blob/main/CODE_OF_CONDUCT.md).
- [x] New or existing tests cover these changes (where applicable). (Existing `go test ./internal/controller/nodeset/...` passes; the behaviour was verified on a cluster, see below.)
- [x] Documentation is updated if user-visible behavior changes. (No documentation change: DaemonSet-mode pods now get the tolerations the Kubernetes DaemonSet controller documents for daemon pods.)

## Breaking Changes

None. Pods gain the standard daemon tolerations (`unschedulable`, `not-ready`, `unreachable`, `disk-pressure`, `memory-pressure`, `pid-pressure`, `network-unavailable`), exactly as pods of a Kubernetes `DaemonSet` do. A cordoned node keeps its slurmd pod, which is what `syncCordon` already assumes.

## Testing Notes

Reproduced and verified on operator + chart 1.2.2, single-node cluster:

| step | before | after |
|---|---|---|
| DaemonSet mode, node uncordoned | desired=1, pod Running | same |
| cordon the node | pod survives | same |
| delete the pod | **desired=0, no pod, never recovers** | desired=1, pod Running on the cordoned node |

`go build ./...` clean, `gofmt` clean, `go test ./internal/controller/nodeset/...` passes.

## Additional Context

Found on a cluster that cordons nodes before powering them down: a slurmd image bump rolled the NodeSet, and the cordoned nodes never got their pods back — the NodeSet simply had nothing to place on them for as long as they stayed cordoned.