### PR TITLE
fix(worker): omit empty topology config

### DIFF
--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -133,9 +133,8 @@ pre-defining the node in slurm.conf.
 ##### Dynamic Topology
 
 The operator ensures that each slurmd pod registers with the topology that
-matches the Kubernetes node it is scheduled on. It injects topology into the pod
-(e.g. via `POD_TOPOLOGY`) and, after registration, updates the Slurm node’s
-topology through the Slurm API. As a result, the Slurm
+matches the Kubernetes node it is scheduled on. After registration, it updates
+the Slurm node’s topology through the Slurm API. As a result, the Slurm
 [topology configuration][topology.yaml] does not need to enumerate every node in
 advance for topology-aware scheduling to work on Kubernetes.
 

--- a/internal/builder/workerbuilder/worker_app.go
+++ b/internal/builder/workerbuilder/worker_app.go
@@ -201,14 +201,6 @@ func (b *WorkerBuilder) slurmdContainer(nodeset *slinkyv1beta1.NodeSet, controll
 			Args: slurmdArgs(nodeset, controller),
 			Env: []corev1.EnvVar{
 				{
-					Name: "SLINKY_TOPOLOGY",
-					ValueFrom: &corev1.EnvVarSource{
-						FieldRef: &corev1.ObjectFieldSelector{
-							FieldPath: fmt.Sprintf("metadata.annotations['%s']", slinkyv1beta1.AnnotationNodeTopologySpec),
-						},
-					},
-				},
-				{
 					Name:  "POD_CPUS",
 					Value: strconv.FormatInt(cpus, 10),
 				},
@@ -308,7 +300,6 @@ func ParseExtraConf(extraConf string) (map[string][]string, error) {
 func slurmdConfArgs(nodeset *slinkyv1beta1.NodeSet) []string {
 	confMap := map[string]string{
 		"Features": strings.Join(baselineFeatures(nodeset), ","),
-		"Topology": `'"$SLINKY_TOPOLOGY"'`,
 	}
 
 	// The NodeSet webhook validates ExtraConf at admission, but it is a separate,

--- a/internal/builder/workerbuilder/worker_app_test.go
+++ b/internal/builder/workerbuilder/worker_app_test.go
@@ -458,9 +458,9 @@ func TestSlurmdConfArgs(t *testing.T) {
 		want    []string
 	}{
 		{
-			name:    "name only",
+			name:    "name only omits empty topology so image resource configuration is valid",
 			nodeset: &slinkyv1beta1.NodeSet{ObjectMeta: metav1.ObjectMeta{Name: "gpu"}},
-			want:    []string{"--conf", `'Features=gpu Topology='"$SLINKY_TOPOLOGY"''`},
+			want:    []string{"--conf", `'Features=gpu'`},
 		},
 		{
 			name: "feature and non-feature keys",
@@ -468,10 +468,10 @@ func TestSlurmdConfArgs(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "gpu"},
 				Spec:       slinkyv1beta1.NodeSetSpec{ExtraConf: "Weight=10 feature=a"},
 			},
-			want: []string{"--conf", `'Features=a,gpu Topology='"$SLINKY_TOPOLOGY"' Weight=10'`},
+			want: []string{"--conf", `'Features=a,gpu Weight=10'`},
 		},
 		{
-			name: "clobber topology key",
+			name: "preserves explicit topology key",
 			nodeset: &slinkyv1beta1.NodeSet{
 				ObjectMeta: metav1.ObjectMeta{Name: "gpu"},
 				Spec:       slinkyv1beta1.NodeSetSpec{ExtraConf: "Topology=switch-topo:s1"},
@@ -484,7 +484,7 @@ func TestSlurmdConfArgs(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "gpu"},
 				Spec:       slinkyv1beta1.NodeSetSpec{ExtraConf: "Features=z,a"},
 			},
-			want: []string{"--conf", `'Features=a,gpu,z Topology='"$SLINKY_TOPOLOGY"''`},
+			want: []string{"--conf", `'Features=a,gpu,z'`},
 		},
 		{
 			name: "hostname override is the feature name",
@@ -498,7 +498,7 @@ func TestSlurmdConfArgs(t *testing.T) {
 					},
 				},
 			},
-			want: []string{"--conf", `'Features=foo Topology='"$SLINKY_TOPOLOGY"''`},
+			want: []string{"--conf", `'Features=foo'`},
 		},
 		{
 			name: "malformed ExtraConf degrades to baseline instead of panicking",
@@ -506,7 +506,7 @@ func TestSlurmdConfArgs(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "gpu"},
 				Spec:       slinkyv1beta1.NodeSetSpec{ExtraConf: "Weight10 Feature=a"},
 			},
-			want: []string{"--conf", `'Features=gpu Topology='"$SLINKY_TOPOLOGY"''`},
+			want: []string{"--conf", `'Features=gpu'`},
 		},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary

Fixes Worker registration failures when no Slurm topology is configured.

The operator previously emitted an empty `Topology=` entry in `slurmd --conf`.
When the container entrypoint appended `CoreSpecCount` and `MemSpecLimit`, Slurm
parsed `CoreSpecCount` as the topology value and marked the node as
`INVALID_REG`.

## Changes

- Do not emit `Topology=` unless topology is explicitly configured through
  `NodeSet.spec.extraConf`.
- Remove the unused `SLINKY_TOPOLOGY` environment variable.
- Preserve explicit `Topology=<value>` configuration through `extraConf`.
- Keep topology synchronization through the Slurm API after node registration.
- Add regression coverage for the default `--conf` output.
- Update the architecture documentation.

## Result

Workers without topology now register with resource configuration similar to:

```text
--conf Features=slinky CoreSpecCount=36 MemSpecLimit=175607
This allows Slurm to correctly report the configured effective CPU and memory
resources.
Testing
go test -mod=mod ./internal/builder/...
go test -mod=mod ./internal/builder/workerbuilder
```

Fixes SlinkyProject/containers#20